### PR TITLE
perf: fix N+1 query in Evolution provider breakdown

### DIFF
--- a/lib/aludel/prompts/evolution.ex
+++ b/lib/aludel/prompts/evolution.ex
@@ -132,10 +132,21 @@ defmodule Aludel.Prompts.Evolution do
   defp build_provider_breakdown([]), do: []
 
   defp build_provider_breakdown(suite_runs) do
+    provider_ids =
+      suite_runs
+      |> Enum.map(& &1.provider_id)
+      |> Enum.uniq()
+
+    providers =
+      Provider
+      |> where([p], p.id in ^provider_ids)
+      |> repo().all()
+      |> Map.new(&{&1.id, &1})
+
     suite_runs
     |> Enum.group_by(& &1.provider_id)
     |> Enum.map(fn {provider_id, runs} ->
-      provider = repo().get!(Provider, provider_id)
+      provider = Map.fetch!(providers, provider_id)
 
       total_tests = Enum.reduce(runs, 0, fn sr, acc -> acc + sr.passed + sr.failed end)
       total_passed = Enum.reduce(runs, 0, fn sr, acc -> acc + sr.passed end)


### PR DESCRIPTION
## Motivation

The `build_provider_breakdown/1` function was fetching provider records inside a loop, causing N+1 queries. For each unique provider in the run list, a separate database query was executed, causing noticeable slowdown with many providers or versions.

## Changes

Refactored `build_provider_breakdown/1` to batch-fetch providers:

1. Extract unique provider IDs from suite runs
2. Fetch all providers at once using `WHERE id IN (...)` query
3. Build a map with provider ID as key for O(1) lookup
4. Use `Map.fetch!` to retrieve providers when building metrics

## Test Plan

All 350 tests pass, including 18 Evolution-specific tests that verify:
- Provider breakdown calculations remain correct
- Provider names are properly sorted
- Cost and latency metrics are accurate
- Multiple providers are handled correctly

The optimization is transparent - behavior is unchanged, only performance improves by reducing database queries from N to 1.

Closes #48