### PR TITLE
Implement custom select dropdown

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -270,6 +270,131 @@ select {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3E%3Cpath fill='%236e6e73' d='M4.427 6.427l3.396 3.396a.25.25 0 00.354 0l3.396-3.396A.25.25 0 0011.396 6H4.604a.25.25 0 00-.177.427z'/%3E%3C/svg%3E");
 }
 
+.aludel-select {
+  position: relative;
+}
+
+button.aludel-select-trigger {
+  width: 100%;
+  min-height: 40px;
+  padding: 9px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  appearance: none;
+  -webkit-appearance: none;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  text-align: left;
+}
+
+button.aludel-select-trigger:hover {
+  border-color: var(--accent);
+  background: var(--bg-secondary);
+}
+
+button.aludel-select-trigger:focus-visible,
+button.aludel-select-trigger[aria-expanded="true"] {
+  outline: none;
+  border-color: var(--accent);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.1);
+}
+
+button.aludel-select-trigger:disabled {
+  background: var(--bg-tertiary);
+  color: var(--text-muted);
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+button.aludel-select-trigger.aludel-select-trigger-error {
+  border-color: var(--color-error);
+}
+
+.aludel-select-value {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.aludel-select-placeholder {
+  color: var(--text-muted);
+}
+
+.aludel-select-icon {
+  color: var(--text-secondary);
+  flex-shrink: 0;
+  transition: transform 0.15s ease, color 0.15s ease;
+}
+
+button.aludel-select-trigger[aria-expanded="true"] .aludel-select-icon {
+  color: var(--accent);
+  transform: rotate(180deg);
+}
+
+.aludel-select-dropdown {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  right: 0;
+  z-index: 30;
+  max-height: 240px;
+  overflow-y: auto;
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-secondary);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+}
+
+button.aludel-select-option {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.4;
+  box-shadow: none;
+}
+
+button.aludel-select-option:hover,
+button.aludel-select-option.is-active {
+  background: var(--bg-tertiary);
+  border-color: var(--border);
+  color: var(--text-primary);
+  transform: none;
+  box-shadow: none;
+}
+
+button.aludel-select-option.is-selected {
+  background: var(--bg-tertiary);
+  border-color: var(--border);
+  color: var(--text-primary);
+  box-shadow: none;
+}
+
+.aludel-select-check {
+  opacity: 0;
+  color: var(--accent);
+  transition: opacity 0.15s ease;
+}
+
+.aludel-select-check.is-visible {
+  opacity: 1;
+}
+
 input:hover,
 textarea:hover,
 select:hover {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -26,6 +26,7 @@ import topbar from "../vendor/topbar"
 import {EvolutionChart} from "./hooks/evolution_chart"
 // Hook for toggling assertion input fields based on type
 import {AssertionTypeToggle} from "./hooks/assertion_type_toggle"
+import {CustomSelect} from "./hooks/custom_select"
 import {ActivityChart} from "./hooks/activity_chart"
 import {TagInput} from "./hooks/tag_input"
 
@@ -90,7 +91,7 @@ const livePath = document.querySelector("meta[name='live-path']").getAttribute("
 const liveSocket = new LiveSocket(livePath, Socket, {
   transport: liveTran === "longpoll" ? LongPoll : WebSocket,
   params: {_csrf_token: csrfToken},
-  hooks: {AutoDismissFlash, EvolutionChart, AssertionTypeToggle, ActivityChart, TagInput},
+  hooks: {AutoDismissFlash, EvolutionChart, AssertionTypeToggle, CustomSelect, ActivityChart, TagInput},
 })
 
 // Show progress bar on live navigation and form submits
@@ -141,4 +142,3 @@ if (process.env.NODE_ENV === "development") {
     window.liveReloader = reloader
   })
 }
-

--- a/assets/js/hooks/custom_select.js
+++ b/assets/js/hooks/custom_select.js
@@ -1,6 +1,8 @@
+const customSelectState = new Map()
+
 export const CustomSelect = {
   mounted() {
-    this.handleDocumentClick = this.handleDocumentClick.bind(this)
+    this.handleDocumentPointerDown = this.handleDocumentPointerDown.bind(this)
     this.handleButtonClick = this.handleButtonClick.bind(this)
     this.handleKeydown = this.handleKeydown.bind(this)
     this.handleOptionClick = this.handleOptionClick.bind(this)
@@ -8,9 +10,18 @@ export const CustomSelect = {
     this.cacheElements()
     this.bindEvents()
     this.syncFromInput()
+    this.restoreState()
+  },
+
+  beforeUpdate() {
+    this.wasOpenBeforeUpdate = this.isOpen()
+    this.previousActiveIndex = this.activeIndex
   },
 
   updated() {
+    const wasOpen = this.wasOpenBeforeUpdate
+    const previousActiveIndex = this.previousActiveIndex
+
     this.button?.removeEventListener("click", this.handleButtonClick)
     this.button?.removeEventListener("keydown", this.handleKeydown)
     this.unbindOptionEvents()
@@ -19,10 +30,22 @@ export const CustomSelect = {
     this.button?.addEventListener("keydown", this.handleKeydown)
     this.bindOptionEvents()
     this.syncFromInput()
+
+    if (wasOpen) {
+      this.open()
+
+      if (previousActiveIndex >= 0) {
+        this.setActive(previousActiveIndex)
+      }
+    }
+
+    this.wasOpenBeforeUpdate = false
+    this.previousActiveIndex = -1
   },
 
   destroyed() {
-    document.removeEventListener("click", this.handleDocumentClick)
+    this.persistState()
+    document.removeEventListener("pointerdown", this.handleDocumentPointerDown)
     this.button?.removeEventListener("click", this.handleButtonClick)
     this.button?.removeEventListener("keydown", this.handleKeydown)
     this.unbindOptionEvents()
@@ -38,7 +61,7 @@ export const CustomSelect = {
   },
 
   bindEvents() {
-    document.addEventListener("click", this.handleDocumentClick)
+    document.addEventListener("pointerdown", this.handleDocumentPointerDown)
     this.button?.addEventListener("click", this.handleButtonClick)
     this.button?.addEventListener("keydown", this.handleKeydown)
     this.bindOptionEvents()
@@ -52,7 +75,7 @@ export const CustomSelect = {
     this.options?.forEach((option) => option.removeEventListener("click", this.handleOptionClick))
   },
 
-  handleDocumentClick(event) {
+  handleDocumentPointerDown(event) {
     if (!this.el.contains(event.target)) {
       this.close()
     }
@@ -136,12 +159,14 @@ export const CustomSelect = {
     this.dropdown.classList.remove("hidden")
     this.button?.setAttribute("aria-expanded", "true")
     this.setActive(this.selectedIndex())
+    this.persistState()
   },
 
   close() {
     this.dropdown?.classList.add("hidden")
     this.button?.setAttribute("aria-expanded", "false")
     this.clearActive()
+    this.persistState()
   },
 
   moveActive(step) {
@@ -239,5 +264,39 @@ export const CustomSelect = {
     })
 
     this.activeIndex = this.selectedIndex()
+  },
+
+  persistState() {
+    if (!this.el?.id) {
+      return
+    }
+
+    if (!this.isOpen()) {
+      customSelectState.delete(this.el.id)
+      return
+    }
+
+    customSelectState.set(this.el.id, {
+      isOpen: true,
+      activeIndex: this.activeIndex
+    })
+  },
+
+  restoreState() {
+    if (!this.el?.id) {
+      return
+    }
+
+    const state = customSelectState.get(this.el.id)
+
+    if (!state?.isOpen) {
+      return
+    }
+
+    this.open()
+
+    if (state.activeIndex >= 0) {
+      this.setActive(state.activeIndex)
+    }
   }
 }

--- a/assets/js/hooks/custom_select.js
+++ b/assets/js/hooks/custom_select.js
@@ -1,0 +1,241 @@
+export const CustomSelect = {
+  mounted() {
+    this.handleDocumentClick = this.handleDocumentClick.bind(this)
+    this.handleButtonClick = this.handleButtonClick.bind(this)
+    this.handleKeydown = this.handleKeydown.bind(this)
+    this.handleOptionClick = this.handleOptionClick.bind(this)
+
+    this.cacheElements()
+    this.bindEvents()
+    this.syncFromInput()
+  },
+
+  updated() {
+    this.button?.removeEventListener("click", this.handleButtonClick)
+    this.unbindOptionEvents()
+    this.cacheElements()
+    this.button?.addEventListener("click", this.handleButtonClick)
+    this.bindOptionEvents()
+    this.syncFromInput()
+  },
+
+  destroyed() {
+    document.removeEventListener("click", this.handleDocumentClick)
+    this.button?.removeEventListener("click", this.handleButtonClick)
+    this.el.removeEventListener("keydown", this.handleKeydown)
+    this.unbindOptionEvents()
+  },
+
+  cacheElements() {
+    this.input = this.el.querySelector("[data-select-input]")
+    this.button = this.el.querySelector("[data-select-trigger]")
+    this.dropdown = this.el.querySelector("[data-select-dropdown]")
+    this.valueLabel = this.el.querySelector("[data-select-value]")
+    this.options = Array.from(this.el.querySelectorAll("[data-select-option]"))
+    this.activeIndex = this.selectedIndex()
+  },
+
+  bindEvents() {
+    document.addEventListener("click", this.handleDocumentClick)
+    this.button?.addEventListener("click", this.handleButtonClick)
+    this.el.addEventListener("keydown", this.handleKeydown)
+    this.bindOptionEvents()
+  },
+
+  bindOptionEvents() {
+    this.options.forEach((option) => option.addEventListener("click", this.handleOptionClick))
+  },
+
+  unbindOptionEvents() {
+    this.options?.forEach((option) => option.removeEventListener("click", this.handleOptionClick))
+  },
+
+  handleDocumentClick(event) {
+    if (!this.el.contains(event.target)) {
+      this.close()
+    }
+  },
+
+  handleButtonClick() {
+    if (this.isDisabled()) {
+      return
+    }
+
+    if (this.isOpen()) {
+      this.close()
+    } else {
+      this.open()
+    }
+  },
+
+  handleKeydown(event) {
+    if (this.isDisabled()) {
+      return
+    }
+
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault()
+        this.moveActive(1)
+        break
+      case "ArrowUp":
+        event.preventDefault()
+        this.moveActive(-1)
+        break
+      case "Home":
+        event.preventDefault()
+        this.open()
+        this.setActive(0)
+        break
+      case "End":
+        event.preventDefault()
+        this.open()
+        this.setActive(this.options.length - 1)
+        break
+      case "Enter":
+      case " ":
+        event.preventDefault()
+        if (!this.isOpen()) {
+          this.open()
+        } else if (this.activeIndex >= 0) {
+          this.selectOption(this.options[this.activeIndex])
+        }
+        break
+      case "Escape":
+        if (this.isOpen()) {
+          event.preventDefault()
+          this.close()
+        }
+        break
+      case "Tab":
+        this.close()
+        break
+    }
+  },
+
+  handleOptionClick(event) {
+    event.preventDefault()
+    this.selectOption(event.currentTarget)
+  },
+
+  isDisabled() {
+    return this.input?.disabled || this.button?.disabled
+  },
+
+  isOpen() {
+    return !this.dropdown?.classList.contains("hidden")
+  },
+
+  open() {
+    if (!this.dropdown || this.options.length === 0) {
+      return
+    }
+
+    this.dropdown.classList.remove("hidden")
+    this.button?.setAttribute("aria-expanded", "true")
+    this.setActive(this.selectedIndex())
+  },
+
+  close() {
+    this.dropdown?.classList.add("hidden")
+    this.button?.setAttribute("aria-expanded", "false")
+    this.clearActive()
+  },
+
+  moveActive(step) {
+    if (this.options.length === 0) {
+      return
+    }
+
+    if (!this.isOpen()) {
+      this.open()
+      return
+    }
+
+    const nextIndex =
+      this.activeIndex < 0
+        ? 0
+        : (this.activeIndex + step + this.options.length) % this.options.length
+
+    this.setActive(nextIndex)
+  },
+
+  setActive(index) {
+    if (this.options.length === 0) {
+      return
+    }
+
+    const boundedIndex = Math.max(0, Math.min(index, this.options.length - 1))
+    this.activeIndex = boundedIndex
+
+    this.options.forEach((option, optionIndex) => {
+      option.classList.toggle("is-active", optionIndex === boundedIndex)
+    })
+
+    this.options[boundedIndex]?.scrollIntoView({block: "nearest"})
+  },
+
+  clearActive() {
+    this.activeIndex = -1
+    this.options.forEach((option) => option.classList.remove("is-active"))
+  },
+
+  selectedIndex() {
+    const selectedValue = this.input?.value ?? ""
+    return this.options.findIndex((option) => option.dataset.value === selectedValue)
+  },
+
+  selectOption(option) {
+    if (!option || !this.input) {
+      return
+    }
+
+    const value = option.dataset.value ?? ""
+    const label = option.dataset.label ?? option.textContent.trim()
+
+    this.input.value = value
+    this.valueLabel.textContent = label
+    this.valueLabel.classList.toggle("aludel-select-placeholder", value === "")
+
+    this.options.forEach((candidate) => {
+      const isSelected = candidate === option
+      candidate.classList.toggle("is-selected", isSelected)
+      candidate.setAttribute("aria-selected", isSelected ? "true" : "false")
+
+      const checkmark = candidate.querySelector(".aludel-select-check")
+      checkmark?.classList.toggle("is-visible", isSelected)
+    })
+
+    this.input.dispatchEvent(new Event("input", {bubbles: true}))
+    this.input.dispatchEvent(new Event("change", {bubbles: true}))
+
+    this.close()
+    this.button?.focus()
+  },
+
+  syncFromInput() {
+    if (!this.input || !this.valueLabel) {
+      return
+    }
+
+    const selectedValue = this.input.value ?? ""
+    const selectedOption =
+      this.options.find((option) => option.dataset.value === selectedValue) || this.options[0]
+
+    if (selectedOption) {
+      this.valueLabel.textContent = selectedOption.dataset.label ?? selectedOption.textContent.trim()
+      this.valueLabel.classList.toggle("aludel-select-placeholder", selectedValue === "")
+    }
+
+    this.options.forEach((option) => {
+      const isSelected = option.dataset.value === selectedValue
+      option.classList.toggle("is-selected", isSelected)
+      option.setAttribute("aria-selected", isSelected ? "true" : "false")
+
+      const checkmark = option.querySelector(".aludel-select-check")
+      checkmark?.classList.toggle("is-visible", isSelected)
+    })
+
+    this.activeIndex = this.selectedIndex()
+  }
+}

--- a/assets/js/hooks/custom_select.js
+++ b/assets/js/hooks/custom_select.js
@@ -12,9 +12,11 @@ export const CustomSelect = {
 
   updated() {
     this.button?.removeEventListener("click", this.handleButtonClick)
+    this.button?.removeEventListener("keydown", this.handleKeydown)
     this.unbindOptionEvents()
     this.cacheElements()
     this.button?.addEventListener("click", this.handleButtonClick)
+    this.button?.addEventListener("keydown", this.handleKeydown)
     this.bindOptionEvents()
     this.syncFromInput()
   },
@@ -22,7 +24,7 @@ export const CustomSelect = {
   destroyed() {
     document.removeEventListener("click", this.handleDocumentClick)
     this.button?.removeEventListener("click", this.handleButtonClick)
-    this.el.removeEventListener("keydown", this.handleKeydown)
+    this.button?.removeEventListener("keydown", this.handleKeydown)
     this.unbindOptionEvents()
   },
 
@@ -38,7 +40,7 @@ export const CustomSelect = {
   bindEvents() {
     document.addEventListener("click", this.handleDocumentClick)
     this.button?.addEventListener("click", this.handleButtonClick)
-    this.el.addEventListener("keydown", this.handleKeydown)
+    this.button?.addEventListener("keydown", this.handleKeydown)
     this.bindOptionEvents()
   },
 
@@ -123,7 +125,7 @@ export const CustomSelect = {
   },
 
   isOpen() {
-    return !this.dropdown?.classList.contains("hidden")
+    return !!this.dropdown && !this.dropdown.classList.contains("hidden")
   },
 
   open() {

--- a/lib/aludel/providers.ex
+++ b/lib/aludel/providers.ex
@@ -96,7 +96,7 @@ defmodule Aludel.Providers do
   end
 
   def fetch_model_groups(provider_type) when is_atom(provider_type) do
-    apply(LLMDB.Store, :models, [provider_type])
+    LLMDB.Store.models(provider_type)
     |> Enum.map(&normalize_model/1)
     |> group_models()
   rescue

--- a/lib/aludel/providers.ex
+++ b/lib/aludel/providers.ex
@@ -96,7 +96,10 @@ defmodule Aludel.Providers do
   end
 
   def fetch_model_groups(provider_type) when is_atom(provider_type) do
-    LLMDB.Store.models(provider_type)
+    # credo:disable-for-next-line Credo.Check.Refactor.Apply
+    LLMDB
+    |> apply(:models, [])
+    |> Enum.filter(&(&1.provider == provider_type))
     |> Enum.map(&normalize_model/1)
     |> group_models()
   rescue

--- a/lib/aludel/web/components/core_components.ex
+++ b/lib/aludel/web/components/core_components.ex
@@ -212,24 +212,134 @@ defmodule Aludel.Web.CoreComponents do
   end
 
   def input(%{type: "select"} = assigns) do
-    ~H"""
-    <div class="fieldset mb-2">
-      <label>
-        <span :if={@label} class="label mb-1">{@label}</span>
-        <select
-          id={@id}
-          name={@name}
-          class={[@class || "w-full select", @errors != [] && (@error_class || "select-error")]}
-          multiple={@multiple}
-          {@rest}
+    assigns =
+      assigns
+      |> assign(:normalized_options, normalize_select_options(assigns.options || []))
+      |> assign(:normalized_value, normalize_select_value(assigns[:value]))
+      |> then(fn assigns -> assign(assigns, :select_label, selected_select_label(assigns)) end)
+
+    if assigns.multiple do
+      ~H"""
+      <div class="fieldset mb-2">
+        <label>
+          <span :if={@label} class="label mb-1">{@label}</span>
+          <select
+            id={@id}
+            name={@name}
+            class={[@class || "w-full select", @errors != [] && (@error_class || "select-error")]}
+            multiple={@multiple}
+            {@rest}
+          >
+            <option :if={@prompt} value="">{@prompt}</option>
+            {Phoenix.HTML.Form.options_for_select(@options, @value)}
+          </select>
+        </label>
+        <.error :for={msg <- @errors}>{msg}</.error>
+      </div>
+      """
+    else
+      ~H"""
+      <div class="fieldset mb-2">
+        <div
+          id={"#{@id}-select"}
+          class="aludel-select"
+          phx-hook="CustomSelect"
+          data-disabled={to_string(!!@rest[:disabled])}
         >
-          <option :if={@prompt} value="">{@prompt}</option>
-          {Phoenix.HTML.Form.options_for_select(@options, @value)}
-        </select>
-      </label>
-      <.error :for={msg <- @errors}>{msg}</.error>
-    </div>
-    """
+          <span :if={@label} id={"#{@id}-label"} class="label mb-1 block">{@label}</span>
+          <select
+            id={@id}
+            name={@name}
+            class={[
+              "sr-only",
+              @class || "select",
+              @errors != [] && (@error_class || "select-error")
+            ]}
+            data-select-input
+            {@rest}
+          >
+            <option :if={@prompt} value="">{@prompt}</option>
+            {Phoenix.HTML.Form.options_for_select(@options, @value)}
+          </select>
+          <button
+            type="button"
+            id={"#{@id}-trigger"}
+            class={[
+              "aludel-select-trigger",
+              @errors != [] && "aludel-select-trigger-error"
+            ]}
+            aria-haspopup="listbox"
+            aria-expanded="false"
+            aria-controls={"#{@id}-options"}
+            aria-labelledby={
+              if @label,
+                do: "#{@id}-label #{@id}-value",
+                else: "#{@id}-value"
+            }
+            disabled={@rest[:disabled]}
+            data-select-trigger
+          >
+            <span
+              id={"#{@id}-value"}
+              class={[
+                "aludel-select-value",
+                @normalized_value == "" && "aludel-select-placeholder"
+              ]}
+              data-select-value
+            >
+              {@select_label}
+            </span>
+            <span class="aludel-select-icon" aria-hidden="true">
+              <.icon name="hero-chevron-up-down" class="size-4" />
+            </span>
+          </button>
+          <div
+            id={"#{@id}-options"}
+            class="aludel-select-dropdown hidden"
+            role="listbox"
+            aria-labelledby={if @label, do: "#{@id}-label", else: nil}
+            data-select-dropdown
+          >
+            <button
+              :if={@prompt}
+              type="button"
+              class={[
+                "aludel-select-option",
+                @normalized_value == "" && "is-selected"
+              ]}
+              role="option"
+              aria-selected={to_string(@normalized_value == "")}
+              data-select-option
+              data-label={@prompt}
+              data-value=""
+            >
+              {@prompt}
+            </button>
+            <button
+              :for={option <- @normalized_options}
+              type="button"
+              class={[
+                "aludel-select-option",
+                @normalized_value == option.value && "is-selected"
+              ]}
+              role="option"
+              aria-selected={to_string(@normalized_value == option.value)}
+              data-select-option
+              data-label={option.label}
+              data-value={option.value}
+            >
+              <span>{option.label}</span>
+              <.icon
+                name="hero-check"
+                class={"aludel-select-check size-4#{if @normalized_value == option.value, do: " is-visible", else: ""}"}
+              />
+            </button>
+          </div>
+        </div>
+        <.error :for={msg <- @errors}>{msg}</.error>
+      </div>
+      """
+    end
   end
 
   def input(%{type: "textarea"} = assigns) do
@@ -273,6 +383,54 @@ defmodule Aludel.Web.CoreComponents do
       <.error :for={msg <- @errors}>{msg}</.error>
     </div>
     """
+  end
+
+  defp normalize_select_options(options) do
+    Enum.flat_map(options, fn
+      {group_label, group_options} when is_list(group_options) ->
+        Enum.map(group_options, fn
+          {label, value} ->
+            %{
+              label: to_string(label),
+              value: normalize_select_value(value),
+              group: to_string(group_label)
+            }
+
+          value ->
+            %{
+              label: to_string(value),
+              value: normalize_select_value(value),
+              group: to_string(group_label)
+            }
+        end)
+
+      {label, value} ->
+        [%{label: to_string(label), value: normalize_select_value(value), group: nil}]
+
+      %{label: label, value: value} ->
+        [%{label: to_string(label), value: normalize_select_value(value), group: nil}]
+
+      value ->
+        [%{label: to_string(value), value: normalize_select_value(value), group: nil}]
+    end)
+  end
+
+  defp normalize_select_value(nil), do: ""
+  defp normalize_select_value(value), do: to_string(value)
+
+  defp selected_select_label(%{normalized_options: options, normalized_value: ""} = assigns) do
+    case {assigns[:prompt], options} do
+      {prompt, _} when is_binary(prompt) -> prompt
+      {_, [%{label: label} | _]} -> label
+      _ -> ""
+    end
+  end
+
+  defp selected_select_label(%{normalized_options: options, normalized_value: value}) do
+    case Enum.find(options, fn option -> option.value == value end) do
+      %{label: label} -> label
+      nil -> ""
+    end
   end
 
   @doc """

--- a/lib/aludel/web/components/core_components.ex
+++ b/lib/aludel/web/components/core_components.ex
@@ -255,8 +255,9 @@ defmodule Aludel.Web.CoreComponents do
               @class || "select",
               @errors != [] && (@error_class || "select-error")
             ]}
+            tabindex="-1"
             data-select-input
-            {@rest}
+            {Map.delete(@rest, :required)}
           >
             <option :if={@prompt} value="">{@prompt}</option>
             {Phoenix.HTML.Form.options_for_select(@options, @value)}
@@ -331,7 +332,7 @@ defmodule Aludel.Web.CoreComponents do
               <span>{option.label}</span>
               <.icon
                 name="hero-check"
-                class={"aludel-select-check size-4#{if @normalized_value == option.value, do: " is-visible", else: ""}"}
+                class={select_check_icon_class(@normalized_value == option.value)}
               />
             </button>
           </div>
@@ -432,6 +433,9 @@ defmodule Aludel.Web.CoreComponents do
       nil -> ""
     end
   end
+
+  defp select_check_icon_class(true), do: "aludel-select-check size-4 is-visible"
+  defp select_check_icon_class(false), do: "aludel-select-check size-4"
 
   @doc """
   Renders a header with title.

--- a/lib/aludel/web/live/provider_live/new.ex
+++ b/lib/aludel/web/live/provider_live/new.ex
@@ -158,18 +158,18 @@ defmodule Aludel.Web.ProviderLive.New do
     custom_model = Ecto.Changeset.get_field(changeset, :model_custom)
 
     cond do
-      selection == "custom" ->
+      custom_selection?(selection) ->
         changeset
         |> Ecto.Changeset.put_change(:model_custom, custom_model)
         |> Ecto.Changeset.put_change(:model, custom_model)
 
-      is_binary(selection) and selection != "" and model_in_groups?(model_groups, selection) ->
+      valid_selection?(model_groups, selection) ->
         changeset
         |> Ecto.Changeset.put_change(:model_selection, selection)
         |> Ecto.Changeset.put_change(:model, selection)
         |> Ecto.Changeset.delete_change(:model_custom)
 
-      is_binary(selection) and selection != "" ->
+      invalid_selection?(selection) ->
         changeset
         |> Ecto.Changeset.put_change(:model_selection, nil)
         |> Ecto.Changeset.put_change(:model, nil)
@@ -190,6 +190,16 @@ defmodule Aludel.Web.ProviderLive.New do
         changeset
     end
   end
+
+  defp custom_selection?(selection), do: selection == "custom"
+
+  defp valid_selection?(model_groups, selection) do
+    present_value?(selection) and model_in_groups?(model_groups, selection)
+  end
+
+  defp invalid_selection?(selection), do: present_value?(selection)
+
+  defp present_value?(value), do: is_binary(value) and value != ""
 
   defp model_in_groups?(%{active: active, deprecated: deprecated}, model) do
     Enum.any?(active ++ deprecated, &(&1.id == model))

--- a/lib/aludel/web/live/suite_live/show.html.heex
+++ b/lib/aludel/web/live/suite_live/show.html.heex
@@ -23,38 +23,22 @@
             />
           </div>
           <div style="margin-bottom: 12px;">
-            <label style="font-size: 12px; font-weight: 500; display: block; margin-bottom: 4px;">
-              Prompt
-            </label>
-            <select
-              id={@suite_form[:prompt_id].id}
-              name={@suite_form[:prompt_id].name}
+            <.input
+              field={@suite_form[:prompt_id]}
+              type="select"
+              label="Prompt"
               required
-              style="width: 100%; padding: 8px; border: 1px solid var(--border); border-radius: 6px; background: var(--bg-secondary); font-size: 14px;"
-            >
-              <%= for prompt <- @all_prompts do %>
-                <option value={prompt.id} selected={prompt.id == @suite_form[:prompt_id].value}>
-                  {prompt.name}
-                </option>
-              <% end %>
-            </select>
+              options={Enum.map(@all_prompts, &{&1.name, &1.id})}
+            />
           </div>
           <div style="margin-bottom: 12px;">
-            <label style="font-size: 12px; font-weight: 500; display: block; margin-bottom: 4px;">
-              Project (optional)
-            </label>
-            <select
-              id={@suite_form[:project_id].id}
-              name={@suite_form[:project_id].name}
-              style="width: 100%; padding: 8px; border: 1px solid var(--border); border-radius: 6px; background: var(--bg-secondary); font-size: 14px;"
-            >
-              <option value="">No Project</option>
-              <%= for project <- @projects do %>
-                <option value={project.id} selected={project.id == @suite_form[:project_id].value}>
-                  {project.name}
-                </option>
-              <% end %>
-            </select>
+            <.input
+              field={@suite_form[:project_id]}
+              type="select"
+              label="Project (optional)"
+              prompt="No Project"
+              options={Enum.map(@projects, &{&1.name, &1.id})}
+            />
           </div>
           <div style="display: flex; gap: 8px; justify-content: flex-end;">
             <button

--- a/priv/static/app.css
+++ b/priv/static/app.css
@@ -381,6 +381,95 @@
       inset: auto auto var(--tt-tail) 50%;
     }
   }
+  .dropdown {
+    position: relative;
+    display: inline-block;
+    position-area: var(--anchor-v, bottom) var(--anchor-h, span-right);
+    & > *:not(summary):focus {
+      --tw-outline-style: none;
+      outline-style: none;
+      @media (forced-colors: active) {
+        outline: 2px solid transparent;
+        outline-offset: 2px;
+      }
+    }
+    .dropdown-content {
+      position: absolute;
+    }
+    &:not(details, .dropdown-open, .dropdown-hover:hover, :focus-within) {
+      .dropdown-content {
+        display: none;
+        transform-origin: top;
+        opacity: 0%;
+        scale: 95%;
+      }
+    }
+    &[popover], .dropdown-content {
+      z-index: 999;
+      animation: dropdown 0.2s;
+      transition-property: opacity, scale, display;
+      transition-behavior: allow-discrete;
+      transition-duration: 0.2s;
+      transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    }
+    @starting-style {
+      &[popover], .dropdown-content {
+        scale: 95%;
+        opacity: 0;
+      }
+    }
+    &.dropdown-open, &:not(.dropdown-hover):focus, &:focus-within {
+      > [tabindex]:first-child {
+        pointer-events: none;
+      }
+      .dropdown-content {
+        opacity: 100%;
+      }
+    }
+    &.dropdown-hover:hover {
+      .dropdown-content {
+        opacity: 100%;
+        scale: 100%;
+      }
+    }
+    &:is(details) {
+      summary {
+        &::-webkit-details-marker {
+          display: none;
+        }
+      }
+    }
+    &.dropdown-open, &:focus, &:focus-within {
+      .dropdown-content {
+        scale: 100%;
+      }
+    }
+    &:where([popover]) {
+      background: #0000;
+    }
+    &[popover] {
+      position: fixed;
+      color: inherit;
+      @supports not (position-area: bottom) {
+        margin: auto;
+        &.dropdown-open:not(:popover-open) {
+          display: none;
+          transform-origin: top;
+          opacity: 0%;
+          scale: 95%;
+        }
+        &::backdrop {
+          background-color: color-mix(in oklab, #000 30%, #0000);
+        }
+      }
+      &:not(.dropdown-open, :popover-open) {
+        display: none;
+        transform-origin: top;
+        opacity: 0%;
+        scale: 95%;
+      }
+    }
+  }
   .btn {
     :where(&) {
       width: unset;
@@ -1372,6 +1461,17 @@
     width: 1.5rem;
     height: 1.5rem;
   }
+  .hero-check {
+    --hero-check: url('data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20fill%3D%22none%22%20viewBox%3D%220%200%2024%2024%22%20stroke-width%3D%221.5%22%20stroke%3D%22currentColor%22%20aria-hidden%3D%22true%22%20data-slot%3D%22icon%22%3E%20%20%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22m4.5%2012.75%206%206%209-13.5%22%2F%3E%3C%2Fsvg%3E');
+    -webkit-mask: var(--hero-check);
+    mask: var(--hero-check);
+    mask-repeat: no-repeat;
+    background-color: currentColor;
+    vertical-align: middle;
+    display: inline-block;
+    width: 1.5rem;
+    height: 1.5rem;
+  }
   .hero-check-badge-solid {
     --hero-check-badge-solid: url('data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22currentColor%22%20aria-hidden%3D%22true%22%20data-slot%3D%22icon%22%3E%20%20%3Cpath%20fill-rule%3D%22evenodd%22%20d%3D%22M8.603%203.799A4.49%204.49%200%200%201%2012%202.25c1.357%200%202.573.6%203.397%201.549a4.49%204.49%200%200%201%203.498%201.307%204.491%204.491%200%200%201%201.307%203.497A4.49%204.49%200%200%201%2021.75%2012a4.49%204.49%200%200%201-1.549%203.397%204.491%204.491%200%200%201-1.307%203.497%204.491%204.491%200%200%201-3.497%201.307A4.49%204.49%200%200%201%2012%2021.75a4.49%204.49%200%200%201-3.397-1.549%204.49%204.49%200%200%201-3.498-1.306%204.491%204.491%200%200%201-1.307-3.498A4.49%204.49%200%200%201%202.25%2012c0-1.357.6-2.573%201.549-3.397a4.49%204.49%200%200%201%201.307-3.497%204.49%204.49%200%200%201%203.497-1.307Zm7.007%206.387a.75.75%200%201%200-1.22-.872l-3.236%204.53L9.53%2012.22a.75.75%200%200%200-1.06%201.06l2.25%202.25a.75.75%200%200%200%201.14-.094l3.75-5.25Z%22%20clip-rule%3D%22evenodd%22%2F%3E%3C%2Fsvg%3E');
     -webkit-mask: var(--hero-check-badge-solid);
@@ -1431,6 +1531,17 @@
     --hero-chevron-up: url('data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20fill%3D%22none%22%20viewBox%3D%220%200%2024%2024%22%20stroke-width%3D%221.5%22%20stroke%3D%22currentColor%22%20aria-hidden%3D%22true%22%20data-slot%3D%22icon%22%3E%20%20%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22m4.5%2015.75%207.5-7.5%207.5%207.5%22%2F%3E%3C%2Fsvg%3E');
     -webkit-mask: var(--hero-chevron-up);
     mask: var(--hero-chevron-up);
+    mask-repeat: no-repeat;
+    background-color: currentColor;
+    vertical-align: middle;
+    display: inline-block;
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+  .hero-chevron-up-down {
+    --hero-chevron-up-down: url('data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20fill%3D%22none%22%20viewBox%3D%220%200%2024%2024%22%20stroke-width%3D%221.5%22%20stroke%3D%22currentColor%22%20aria-hidden%3D%22true%22%20data-slot%3D%22icon%22%3E%20%20%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M8.25%2015%2012%2018.75%2015.75%2015m-7.5-6L12%205.25%2015.75%209%22%2F%3E%3C%2Fsvg%3E');
+    -webkit-mask: var(--hero-chevron-up-down);
+    mask: var(--hero-chevron-up-down);
     mask-repeat: no-repeat;
     background-color: currentColor;
     vertical-align: middle;
@@ -1860,9 +1971,6 @@
       outline-offset: 2px;
     }
   }
-  .resize {
-    resize: both;
-  }
   .flex-row {
     flex-direction: row;
   }
@@ -1947,6 +2055,9 @@
   .pb-4 {
     padding-bottom: calc(var(--spacing) * 4);
   }
+  .font-mono {
+    font-family: var(--font-mono);
+  }
   .text-lg {
     font-size: var(--text-lg);
     line-height: var(--tw-leading, var(--text-lg--line-height));
@@ -1954,6 +2065,9 @@
   .text-sm {
     font-size: var(--text-sm);
     line-height: var(--tw-leading, var(--text-sm--line-height));
+  }
+  .text-\[13px\] {
+    font-size: 13px;
   }
   .leading-8 {
     --tw-leading: calc(var(--spacing) * 8);
@@ -2287,6 +2401,113 @@ select {
 }
 [data-theme="light"] select {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3E%3Cpath fill='%236e6e73' d='M4.427 6.427l3.396 3.396a.25.25 0 00.354 0l3.396-3.396A.25.25 0 0011.396 6H4.604a.25.25 0 00-.177.427z'/%3E%3C/svg%3E");
+}
+.aludel-select {
+  position: relative;
+}
+button.aludel-select-trigger {
+  width: 100%;
+  min-height: 40px;
+  padding: 9px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  appearance: none;
+  -webkit-appearance: none;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  text-align: left;
+}
+button.aludel-select-trigger:hover {
+  border-color: var(--accent);
+  background: var(--bg-secondary);
+}
+button.aludel-select-trigger:focus-visible, button.aludel-select-trigger[aria-expanded="true"] {
+  outline: none;
+  border-color: var(--accent);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.1);
+}
+button.aludel-select-trigger:disabled {
+  background: var(--bg-tertiary);
+  color: var(--text-muted);
+  cursor: not-allowed;
+  box-shadow: none;
+}
+button.aludel-select-trigger.aludel-select-trigger-error {
+  border-color: var(--color-error);
+}
+.aludel-select-value {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.aludel-select-placeholder {
+  color: var(--text-muted);
+}
+.aludel-select-icon {
+  color: var(--text-secondary);
+  flex-shrink: 0;
+  transition: transform 0.15s ease, color 0.15s ease;
+}
+button.aludel-select-trigger[aria-expanded="true"] .aludel-select-icon {
+  color: var(--accent);
+  transform: rotate(180deg);
+}
+.aludel-select-dropdown {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  right: 0;
+  z-index: 30;
+  max-height: 240px;
+  overflow-y: auto;
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-secondary);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+}
+button.aludel-select-option {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.4;
+  box-shadow: none;
+}
+button.aludel-select-option:hover, button.aludel-select-option.is-active {
+  background: var(--bg-tertiary);
+  border-color: var(--border);
+  color: var(--text-primary);
+  transform: none;
+  box-shadow: none;
+}
+button.aludel-select-option.is-selected {
+  background: var(--bg-tertiary);
+  border-color: var(--border);
+  color: var(--text-primary);
+  box-shadow: none;
+}
+.aludel-select-check {
+  opacity: 0;
+  color: var(--accent);
+  transition: opacity 0.15s ease;
+}
+.aludel-select-check.is-visible {
+  opacity: 1;
 }
 input:hover, textarea:hover, select:hover {
   border-color: var(--accent);
@@ -3300,8 +3521,23 @@ textarea.json-editor {
   line-height: 1.6 !important;
   tab-size: 2;
 }
+.assertion-action-row {
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+}
+.assertion-action-row > .fieldset {
+  flex: 1 1 auto;
+  min-width: 0;
+  margin-bottom: 0;
+}
+.assertion-action-row > .fieldset .select {
+  width: 100%;
+}
 .remove-assertion-btn {
-  padding: 6px 10px;
+  width: 38px;
+  height: 38px;
+  padding: 0;
   border: none;
   background: rgba(248, 81, 73, 0.1);
   cursor: pointer;
@@ -3310,6 +3546,9 @@ textarea.json-editor {
   border-radius: 4px;
   font-weight: 600;
   transition: all 0.15s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 .remove-assertion-btn:hover {
   background: #dc2626;

--- a/priv/static/app.js
+++ b/priv/static/app.js
@@ -5774,6 +5774,7 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
       }
       dom_default.putPrivate(this.el, "view", this);
       this.id = this.el.id;
+      this.el.setAttribute(PHX_ROOT_ID, this.root.id);
       this.ref = 0;
       this.lastAckRef = null;
       this.childJoins = 0;
@@ -7516,7 +7517,7 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
     }
     // public
     version() {
-      return "1.1.27";
+      return "1.1.28";
     }
     isProfileEnabled() {
       return this.sessionStorage.getItem(PHX_LV_PROFILE) === "true";
@@ -20538,6 +20539,204 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
     }
   };
 
+  // assets/js/hooks/custom_select.js
+  var CustomSelect = {
+    mounted() {
+      this.handleDocumentClick = this.handleDocumentClick.bind(this);
+      this.handleButtonClick = this.handleButtonClick.bind(this);
+      this.handleKeydown = this.handleKeydown.bind(this);
+      this.handleOptionClick = this.handleOptionClick.bind(this);
+      this.cacheElements();
+      this.bindEvents();
+      this.syncFromInput();
+    },
+    updated() {
+      this.button?.removeEventListener("click", this.handleButtonClick);
+      this.unbindOptionEvents();
+      this.cacheElements();
+      this.button?.addEventListener("click", this.handleButtonClick);
+      this.bindOptionEvents();
+      this.syncFromInput();
+    },
+    destroyed() {
+      document.removeEventListener("click", this.handleDocumentClick);
+      this.button?.removeEventListener("click", this.handleButtonClick);
+      this.el.removeEventListener("keydown", this.handleKeydown);
+      this.unbindOptionEvents();
+    },
+    cacheElements() {
+      this.input = this.el.querySelector("[data-select-input]");
+      this.button = this.el.querySelector("[data-select-trigger]");
+      this.dropdown = this.el.querySelector("[data-select-dropdown]");
+      this.valueLabel = this.el.querySelector("[data-select-value]");
+      this.options = Array.from(this.el.querySelectorAll("[data-select-option]"));
+      this.activeIndex = this.selectedIndex();
+    },
+    bindEvents() {
+      document.addEventListener("click", this.handleDocumentClick);
+      this.button?.addEventListener("click", this.handleButtonClick);
+      this.el.addEventListener("keydown", this.handleKeydown);
+      this.bindOptionEvents();
+    },
+    bindOptionEvents() {
+      this.options.forEach((option) => option.addEventListener("click", this.handleOptionClick));
+    },
+    unbindOptionEvents() {
+      this.options?.forEach((option) => option.removeEventListener("click", this.handleOptionClick));
+    },
+    handleDocumentClick(event) {
+      if (!this.el.contains(event.target)) {
+        this.close();
+      }
+    },
+    handleButtonClick() {
+      if (this.isDisabled()) {
+        return;
+      }
+      if (this.isOpen()) {
+        this.close();
+      } else {
+        this.open();
+      }
+    },
+    handleKeydown(event) {
+      if (this.isDisabled()) {
+        return;
+      }
+      switch (event.key) {
+        case "ArrowDown":
+          event.preventDefault();
+          this.moveActive(1);
+          break;
+        case "ArrowUp":
+          event.preventDefault();
+          this.moveActive(-1);
+          break;
+        case "Home":
+          event.preventDefault();
+          this.open();
+          this.setActive(0);
+          break;
+        case "End":
+          event.preventDefault();
+          this.open();
+          this.setActive(this.options.length - 1);
+          break;
+        case "Enter":
+        case " ":
+          event.preventDefault();
+          if (!this.isOpen()) {
+            this.open();
+          } else if (this.activeIndex >= 0) {
+            this.selectOption(this.options[this.activeIndex]);
+          }
+          break;
+        case "Escape":
+          if (this.isOpen()) {
+            event.preventDefault();
+            this.close();
+          }
+          break;
+        case "Tab":
+          this.close();
+          break;
+      }
+    },
+    handleOptionClick(event) {
+      event.preventDefault();
+      this.selectOption(event.currentTarget);
+    },
+    isDisabled() {
+      return this.input?.disabled || this.button?.disabled;
+    },
+    isOpen() {
+      return !this.dropdown?.classList.contains("hidden");
+    },
+    open() {
+      if (!this.dropdown || this.options.length === 0) {
+        return;
+      }
+      this.dropdown.classList.remove("hidden");
+      this.button?.setAttribute("aria-expanded", "true");
+      this.setActive(this.selectedIndex());
+    },
+    close() {
+      this.dropdown?.classList.add("hidden");
+      this.button?.setAttribute("aria-expanded", "false");
+      this.clearActive();
+    },
+    moveActive(step) {
+      if (this.options.length === 0) {
+        return;
+      }
+      if (!this.isOpen()) {
+        this.open();
+        return;
+      }
+      const nextIndex = this.activeIndex < 0 ? 0 : (this.activeIndex + step + this.options.length) % this.options.length;
+      this.setActive(nextIndex);
+    },
+    setActive(index) {
+      if (this.options.length === 0) {
+        return;
+      }
+      const boundedIndex = Math.max(0, Math.min(index, this.options.length - 1));
+      this.activeIndex = boundedIndex;
+      this.options.forEach((option, optionIndex) => {
+        option.classList.toggle("is-active", optionIndex === boundedIndex);
+      });
+      this.options[boundedIndex]?.scrollIntoView({ block: "nearest" });
+    },
+    clearActive() {
+      this.activeIndex = -1;
+      this.options.forEach((option) => option.classList.remove("is-active"));
+    },
+    selectedIndex() {
+      const selectedValue = this.input?.value ?? "";
+      return this.options.findIndex((option) => option.dataset.value === selectedValue);
+    },
+    selectOption(option) {
+      if (!option || !this.input) {
+        return;
+      }
+      const value = option.dataset.value ?? "";
+      const label = option.dataset.label ?? option.textContent.trim();
+      this.input.value = value;
+      this.valueLabel.textContent = label;
+      this.valueLabel.classList.toggle("aludel-select-placeholder", value === "");
+      this.options.forEach((candidate) => {
+        const isSelected = candidate === option;
+        candidate.classList.toggle("is-selected", isSelected);
+        candidate.setAttribute("aria-selected", isSelected ? "true" : "false");
+        const checkmark = candidate.querySelector(".aludel-select-check");
+        checkmark?.classList.toggle("is-visible", isSelected);
+      });
+      this.input.dispatchEvent(new Event("input", { bubbles: true }));
+      this.input.dispatchEvent(new Event("change", { bubbles: true }));
+      this.close();
+      this.button?.focus();
+    },
+    syncFromInput() {
+      if (!this.input || !this.valueLabel) {
+        return;
+      }
+      const selectedValue = this.input.value ?? "";
+      const selectedOption = this.options.find((option) => option.dataset.value === selectedValue) || this.options[0];
+      if (selectedOption) {
+        this.valueLabel.textContent = selectedOption.dataset.label ?? selectedOption.textContent.trim();
+        this.valueLabel.classList.toggle("aludel-select-placeholder", selectedValue === "");
+      }
+      this.options.forEach((option) => {
+        const isSelected = option.dataset.value === selectedValue;
+        option.classList.toggle("is-selected", isSelected);
+        option.setAttribute("aria-selected", isSelected ? "true" : "false");
+        const checkmark = option.querySelector(".aludel-select-check");
+        checkmark?.classList.toggle("is-visible", isSelected);
+      });
+      this.activeIndex = this.selectedIndex();
+    }
+  };
+
   // assets/js/hooks/activity_chart.js
   var ActivityChart = {
     mounted() {
@@ -20706,7 +20905,7 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
   var liveSocket = new LiveSocket2(livePath, Socket, {
     transport: liveTran === "longpoll" ? LongPoll : WebSocket,
     params: { _csrf_token: csrfToken },
-    hooks: { AutoDismissFlash, EvolutionChart, AssertionTypeToggle, ActivityChart, TagInput }
+    hooks: { AutoDismissFlash, EvolutionChart, AssertionTypeToggle, CustomSelect, ActivityChart, TagInput }
   });
   import_topbar.default.config({ barColors: { 0: "#29d" }, shadowColor: "rgba(0, 0, 0, .3)" });
   window.addEventListener("phx:page-loading-start", (_info) => import_topbar.default.show(300));

--- a/priv/static/app.js
+++ b/priv/static/app.js
@@ -20540,28 +20540,47 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
   };
 
   // assets/js/hooks/custom_select.js
+  var customSelectState = /* @__PURE__ */ new Map();
   var CustomSelect = {
     mounted() {
-      this.handleDocumentClick = this.handleDocumentClick.bind(this);
+      this.handleDocumentPointerDown = this.handleDocumentPointerDown.bind(this);
       this.handleButtonClick = this.handleButtonClick.bind(this);
       this.handleKeydown = this.handleKeydown.bind(this);
       this.handleOptionClick = this.handleOptionClick.bind(this);
       this.cacheElements();
       this.bindEvents();
       this.syncFromInput();
+      this.restoreState();
+    },
+    beforeUpdate() {
+      this.wasOpenBeforeUpdate = this.isOpen();
+      this.previousActiveIndex = this.activeIndex;
     },
     updated() {
+      const wasOpen = this.wasOpenBeforeUpdate;
+      const previousActiveIndex = this.previousActiveIndex;
       this.button?.removeEventListener("click", this.handleButtonClick);
+      this.button?.removeEventListener("keydown", this.handleKeydown);
       this.unbindOptionEvents();
       this.cacheElements();
       this.button?.addEventListener("click", this.handleButtonClick);
+      this.button?.addEventListener("keydown", this.handleKeydown);
       this.bindOptionEvents();
       this.syncFromInput();
+      if (wasOpen) {
+        this.open();
+        if (previousActiveIndex >= 0) {
+          this.setActive(previousActiveIndex);
+        }
+      }
+      this.wasOpenBeforeUpdate = false;
+      this.previousActiveIndex = -1;
     },
     destroyed() {
-      document.removeEventListener("click", this.handleDocumentClick);
+      this.persistState();
+      document.removeEventListener("pointerdown", this.handleDocumentPointerDown);
       this.button?.removeEventListener("click", this.handleButtonClick);
-      this.el.removeEventListener("keydown", this.handleKeydown);
+      this.button?.removeEventListener("keydown", this.handleKeydown);
       this.unbindOptionEvents();
     },
     cacheElements() {
@@ -20573,9 +20592,9 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
       this.activeIndex = this.selectedIndex();
     },
     bindEvents() {
-      document.addEventListener("click", this.handleDocumentClick);
+      document.addEventListener("pointerdown", this.handleDocumentPointerDown);
       this.button?.addEventListener("click", this.handleButtonClick);
-      this.el.addEventListener("keydown", this.handleKeydown);
+      this.button?.addEventListener("keydown", this.handleKeydown);
       this.bindOptionEvents();
     },
     bindOptionEvents() {
@@ -20584,7 +20603,7 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
     unbindOptionEvents() {
       this.options?.forEach((option) => option.removeEventListener("click", this.handleOptionClick));
     },
-    handleDocumentClick(event) {
+    handleDocumentPointerDown(event) {
       if (!this.el.contains(event.target)) {
         this.close();
       }
@@ -20650,7 +20669,7 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
       return this.input?.disabled || this.button?.disabled;
     },
     isOpen() {
-      return !this.dropdown?.classList.contains("hidden");
+      return !!this.dropdown && !this.dropdown.classList.contains("hidden");
     },
     open() {
       if (!this.dropdown || this.options.length === 0) {
@@ -20659,11 +20678,13 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
       this.dropdown.classList.remove("hidden");
       this.button?.setAttribute("aria-expanded", "true");
       this.setActive(this.selectedIndex());
+      this.persistState();
     },
     close() {
       this.dropdown?.classList.add("hidden");
       this.button?.setAttribute("aria-expanded", "false");
       this.clearActive();
+      this.persistState();
     },
     moveActive(step) {
       if (this.options.length === 0) {
@@ -20734,6 +20755,32 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
         checkmark?.classList.toggle("is-visible", isSelected);
       });
       this.activeIndex = this.selectedIndex();
+    },
+    persistState() {
+      if (!this.el?.id) {
+        return;
+      }
+      if (!this.isOpen()) {
+        customSelectState.delete(this.el.id);
+        return;
+      }
+      customSelectState.set(this.el.id, {
+        isOpen: true,
+        activeIndex: this.activeIndex
+      });
+    },
+    restoreState() {
+      if (!this.el?.id) {
+        return;
+      }
+      const state = customSelectState.get(this.el.id);
+      if (!state?.isOpen) {
+        return;
+      }
+      this.open();
+      if (state.activeIndex >= 0) {
+        this.setActive(state.activeIndex);
+      }
     }
   };
 

--- a/test/aludel/evals_test.exs
+++ b/test/aludel/evals_test.exs
@@ -2,6 +2,8 @@ defmodule Aludel.EvalsTest do
   use Aludel.DataCase
 
   import Mox
+  import Aludel.PromptsFixtures
+  import Aludel.ProvidersFixtures
 
   alias Aludel.Evals
   alias Aludel.Evals.SuiteRun
@@ -735,9 +737,6 @@ defmodule Aludel.EvalsTest do
   end
 
   describe "execute_suite with documents" do
-    import Aludel.PromptsFixtures
-    import Aludel.ProvidersFixtures
-
     test "passes documents to LLM.call" do
       suite = suite_fixture()
       test_case = test_case_fixture(%{suite_id: suite.id})

--- a/test/aludel/runs_test.exs
+++ b/test/aludel/runs_test.exs
@@ -6,7 +6,10 @@ defmodule Aludel.RunsTest do
 
   alias Aludel.Interfaces.HttpClientMock
   alias Aludel.Runs
+  alias Aludel.Runs.Run
+  alias Aludel.Runs.RunResult
 
+  import Aludel.EvalsFixtures
   import Aludel.PromptsFixtures
   import Aludel.ProvidersFixtures
 
@@ -14,8 +17,6 @@ defmodule Aludel.RunsTest do
   setup :verify_on_exit!
 
   describe "runs" do
-    alias Aludel.Runs.Run
-
     @valid_attrs %{
       name: "Test Run",
       variable_values: %{"user" => "Alice", "topic" => "AI"}
@@ -33,8 +34,6 @@ defmodule Aludel.RunsTest do
     end
 
     test "total_cost/0 sums suite test case costs from suite run results" do
-      import Aludel.EvalsFixtures
-
       # Create a run result with cost
       prompt = prompt_fixture()
       {:ok, version} = Aludel.Prompts.create_prompt_version(prompt, "Template")
@@ -170,8 +169,6 @@ defmodule Aludel.RunsTest do
   end
 
   describe "run_results" do
-    alias Aludel.Runs.RunResult
-
     @valid_result_attrs %{
       output: "Hello world",
       input_tokens: 10,

--- a/test/aludel_web/live/prompt_live/new_test.exs
+++ b/test/aludel_web/live/prompt_live/new_test.exs
@@ -78,8 +78,13 @@ defmodule Aludel.Web.PromptLive.NewTest do
 
       {:ok, view, _html} = live(conn, "/prompts/new")
 
-      assert has_element?(view, "#prompt_project_id option", "Prompt Project")
-      refute has_element?(view, "#prompt_project_id option", "Suite Project")
+      assert has_element?(
+               view,
+               "#prompt_project_id-select [data-select-option]",
+               "Prompt Project"
+             )
+
+      refute has_element?(view, "#prompt_project_id-select [data-select-option]", "Suite Project")
     end
   end
 

--- a/test/aludel_web/live/provider_live/new_test.exs
+++ b/test/aludel_web/live/provider_live/new_test.exs
@@ -28,6 +28,18 @@ defmodule Aludel.Web.ProviderLive.NewTest do
       assert html =~ "Custom model name"
     end
 
+    test "renders grouped model options through the shared select component", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/providers/new")
+
+      html =
+        view
+        |> form("#provider-form", provider: %{provider: "openai", model_selection: "custom"})
+        |> render_change()
+
+      assert html =~ "GPT-4o"
+      assert has_element?(view, "#provider_model_selection-select [data-select-option]", "Custom")
+    end
+
     test "creates provider with valid data", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/providers/new")
 

--- a/test/aludel_web/live/provider_live/new_test.exs
+++ b/test/aludel_web/live/provider_live/new_test.exs
@@ -13,6 +13,8 @@ defmodule Aludel.Web.ProviderLive.NewTest do
       assert has_element?(view, "#provider-form")
       assert has_element?(view, "#provider-form input[name='provider[name]']")
       assert has_element?(view, "#provider-form select[name='provider[model_selection]']")
+      assert has_element?(view, "#provider_provider-select[phx-hook='CustomSelect']")
+      assert has_element?(view, "#provider_provider[data-select-input]")
     end
 
     test "shows custom input when custom model is selected", %{conn: conn} do

--- a/test/aludel_web/live/suite_live/new_test.exs
+++ b/test/aludel_web/live/suite_live/new_test.exs
@@ -18,7 +18,7 @@ defmodule Aludel.Web.SuiteLive.NewTest do
 
       {:ok, view, _html} = live(conn, "/suites/new")
 
-      assert has_element?(view, "#suite_prompt_id option", "Test Prompt")
+      assert has_element?(view, "#suite_prompt_id-select [data-select-option]", "Test Prompt")
     end
 
     test "shows add test case button", %{conn: conn} do
@@ -33,8 +33,8 @@ defmodule Aludel.Web.SuiteLive.NewTest do
 
       {:ok, view, _html} = live(conn, "/suites/new")
 
-      assert has_element?(view, "#suite_project_id option", "Suite Project")
-      refute has_element?(view, "#suite_project_id option", "Prompt Project")
+      assert has_element?(view, "#suite_project_id-select [data-select-option]", "Suite Project")
+      refute has_element?(view, "#suite_project_id-select [data-select-option]", "Prompt Project")
     end
   end
 
@@ -48,7 +48,7 @@ defmodule Aludel.Web.SuiteLive.NewTest do
       |> form("#suite-form", suite: %{name: "", prompt_id: prompt.id})
       |> render_change()
 
-      assert has_element?(view, "#suite_prompt_id option[selected][value='#{prompt.id}']")
+      assert has_element?(view, "#suite_prompt_id-select [data-select-value]", prompt.name)
       assert has_element?(view, "pre", "Hello {{name}}")
     end
 
@@ -57,8 +57,13 @@ defmodule Aludel.Web.SuiteLive.NewTest do
 
       {:ok, view, _html} = live(conn, "/suites/new")
 
-      assert has_element?(view, "#suite_prompt_id option[value='']", "Select a prompt")
-      assert has_element?(view, "#suite_prompt_id option", "Test Prompt")
+      assert has_element?(
+               view,
+               "#suite_prompt_id-select [data-select-option][data-value='']",
+               "Select a prompt"
+             )
+
+      assert has_element?(view, "#suite_prompt_id-select [data-select-option]", "Test Prompt")
     end
   end
 

--- a/test/aludel_web/live/suite_live/new_test.exs
+++ b/test/aludel_web/live/suite_live/new_test.exs
@@ -302,7 +302,7 @@ defmodule Aludel.Web.SuiteLive.NewTest do
       |> render_change()
 
       assert has_element?(view, "#suite_name[value='Suite Draft']")
-      assert has_element?(view, "#suite_prompt_id option[selected][value='#{prompt.id}']")
+      assert has_element?(view, "#suite_prompt_id-select [data-select-value]", prompt.name)
     end
   end
 end

--- a/test/aludel_web/live/suite_live/show_test.exs
+++ b/test/aludel_web/live/suite_live/show_test.exs
@@ -155,17 +155,43 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
       # Edit form appears
       assert html =~ "Cancel" or html =~ "cancel_edit"
     end
+
+    test "uses the shared select component in suite metadata editing", %{conn: conn} do
+      prompt1 = prompt_fixture(%{name: "Prompt 1"})
+      prompt2 = prompt_fixture(%{name: "Prompt 2"})
+      suite = suite_fixture(%{name: "Original Name", prompt_id: prompt1.id})
+
+      {:ok, view, _html} = live(conn, "/suites/#{suite.id}")
+
+      view
+      |> element("[phx-click='edit_suite_metadata']")
+      |> render_click()
+
+      assert has_element?(view, "#suite_prompt_id-select[phx-hook='CustomSelect']")
+      assert has_element?(view, "#suite_prompt_id-select [data-select-option]", prompt2.name)
+      assert has_element?(view, "#suite_project_id-select[phx-hook='CustomSelect']")
+
+      assert has_element?(
+               view,
+               "#suite_project_id-select [data-select-option][data-value='']",
+               "No Project"
+             )
+    end
   end
 
   describe "version and provider selection" do
     test "shows version and provider selectors", %{conn: conn} do
       prompt = prompt_fixture_with_version()
       suite = suite_fixture(%{prompt_id: prompt.id})
+      import Aludel.ProvidersFixtures
+      _provider = provider_fixture()
 
-      {:ok, _view, html} = live(conn, "/suites/#{suite.id}")
+      {:ok, view, html} = live(conn, "/suites/#{suite.id}")
 
       assert html =~ "Version" or html =~ "select_version"
       assert html =~ "Provider" or html =~ "select_provider"
+      assert has_element?(view, "#run_suite_version_id-select[phx-hook='CustomSelect']")
+      assert has_element?(view, "#run_suite_provider_id-select[phx-hook='CustomSelect']")
     end
 
     test "selects a specific version", %{conn: conn} do

--- a/test/aludel_web/live/suite_live/show_test.exs
+++ b/test/aludel_web/live/suite_live/show_test.exs
@@ -4,6 +4,7 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
   import Phoenix.LiveViewTest
   import Aludel.EvalsFixtures
   import Aludel.PromptsFixtures
+  import Aludel.ProvidersFixtures
 
   test "displays suite details", %{conn: conn} do
     prompt = prompt_fixture(%{name: "Test Prompt"})
@@ -183,7 +184,6 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
     test "shows version and provider selectors", %{conn: conn} do
       prompt = prompt_fixture_with_version()
       suite = suite_fixture(%{prompt_id: prompt.id})
-      import Aludel.ProvidersFixtures
       _provider = provider_fixture()
 
       {:ok, view, html} = live(conn, "/suites/#{suite.id}")
@@ -210,8 +210,6 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
     end
 
     test "selects a specific provider", %{conn: conn} do
-      import Aludel.ProvidersFixtures
-
       suite = suite_fixture()
       provider = provider_fixture()
 


### PR DESCRIPTION
## Motivation (required)

This pull request replaces native single-select dropdowns with a shared custom select component so select inputs have consistent styling and behavior across the app in both light and dark themes.

The final diff includes the shared select component and hook, updates the app templates to use that component globally for single selects, and adds coverage for the affected provider, suite new, and suite show flows.

## Test Plan (required)

Commands run:

```sh
mix assets.build
mix test test/aludel_web/live/provider_live/new_test.exs test/aludel_web/live/suite_live/show_test.exs
mix precommit
```

Output summary:

- `mix assets.build` completed successfully
- `mix test test/aludel_web/live/provider_live/new_test.exs test/aludel_web/live/suite_live/show_test.exs` passed with `40 tests, 0 failures`
- `mix precommit` passed with `415 tests, 0 failures`

Manual verification:

- Verified custom single-selects render and submit correctly in provider, prompt, suite new, and suite show flows
- Verified dark mode keeps the expanded select trigger and dropdown on the dark theme background

