### PR TITLE
feat: add google gemini provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ DNS_CLUSTER_QUERY=
 # LLM Provider API Keys (optional - Ollama works locally without keys)
 OPENAI_API_KEY=your_openai_api_key_here
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
+GOOGLE_API_KEY=your_google_api_key_here
 
 # Environment
 MIX_ENV=dev

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <em>Like jinn answering invocation, LLMs respond to prompts; here, their nature is revealed, tested, and distilled.</em></p>
 </div>
 
-Run prompts across OpenAI, Anthropic, and Ollama simultaneously. Compare output quality, latency, token usage, and cost in real-time.
+Run prompts across OpenAI, Anthropic, Google Gemini, and Ollama simultaneously. Compare output quality, latency, token usage, and cost in real-time.
 
 ![Aludel dashboard screenshot](https://github.com/user-attachments/assets/16e8caa6-81e2-44fa-b205-2dd9f6477760)
 
@@ -120,7 +120,8 @@ Aludel reads provider API keys from application config. Add to your host app's c
 # config/dev.exs (or config/runtime.exs for production)
 config :aludel, :llm,
   openai_api_key: System.get_env("OPENAI_API_KEY"),
-  anthropic_api_key: System.get_env("ANTHROPIC_API_KEY")
+  anthropic_api_key: System.get_env("ANTHROPIC_API_KEY"),
+  google_api_key: System.get_env("GOOGLE_API_KEY")
 ```
 
 Then set environment variables before starting the server:
@@ -128,6 +129,7 @@ Then set environment variables before starting the server:
 ```bash
 export OPENAI_API_KEY=sk-...
 export ANTHROPIC_API_KEY=sk-ant-...
+export GOOGLE_API_KEY=...
 mix phx.server
 ```
 
@@ -185,7 +187,7 @@ Edit `standalone/config/dev.exs` to configure:
 
 - **Database** — Default: `postgres://postgres:postgres@localhost/aludel_dash_dev`
 - **Port** — Default: `4000`
-- **API Keys** — Set `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` environment variables
+- **API Keys** — Set `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, and `GOOGLE_API_KEY` environment variables
 
 ### Docker
 
@@ -217,6 +219,7 @@ export DATABASE_URL=postgres://...
 export SECRET_KEY_BASE=$(mix phx.gen.secret)
 export OPENAI_API_KEY=sk-...
 export ANTHROPIC_API_KEY=sk-ant-...
+export GOOGLE_API_KEY=...
 
 # Optional: Enable basic auth
 export BASIC_AUTH_USER=admin
@@ -239,6 +242,7 @@ _build/prod/rel/aludel_dash/bin/aludel_dash start
 | **Ollama** ⭐ | No | Local models - works out of the box |
 | **OpenAI** | Yes | Add `OPENAI_API_KEY` to `.env` ([Get key](https://platform.openai.com)) |
 | **Anthropic** | Yes | Add `ANTHROPIC_API_KEY` to `.env` ([Get key](https://console.anthropic.com)) |
+| **Google Gemini** | Yes | Add `GOOGLE_API_KEY` to `.env` ([Get key](https://aistudio.google.com/apikey)) |
 
 ### Ollama quickstart
 
@@ -249,7 +253,7 @@ ollama pull llama3  # or: mistral, codellama
 mix run priv/repo/seeds.exs
 ```
 
-Seeds create providers for Ollama, OpenAI, and Anthropic, along with 3 sample prompts and 3 evaluation suites with document attachments.
+Seeds create providers for Ollama, OpenAI, Anthropic, and Google Gemini, along with 3 sample prompts and 3 evaluation suites with document attachments.
 
 ---
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -21,7 +21,8 @@ config :aludel, Aludel.Web.Endpoint,
 
 config :aludel, :llm,
   openai_api_key: System.get_env("OPENAI_API_KEY"),
-  anthropic_api_key: System.get_env("ANTHROPIC_API_KEY")
+  anthropic_api_key: System.get_env("ANTHROPIC_API_KEY"),
+  google_api_key: System.get_env("GOOGLE_API_KEY")
 
 # ## SSL Support
 #

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -41,7 +41,8 @@ if config_env() == :prod do
   # LLM Provider API Keys
   config :aludel, :llm,
     openai_api_key: System.get_env("OPENAI_API_KEY"),
-    anthropic_api_key: System.get_env("ANTHROPIC_API_KEY")
+    anthropic_api_key: System.get_env("ANTHROPIC_API_KEY"),
+    google_api_key: System.get_env("GOOGLE_API_KEY")
 
   config :aludel, Aludel.Web.Endpoint,
     url: [host: host, port: 443, scheme: "https"],

--- a/config/test.exs
+++ b/config/test.exs
@@ -35,7 +35,8 @@ config :phoenix_live_view,
 # LLM Provider API Keys - use bogus keys to prevent hitting real APIs in tests
 config :aludel, :llm,
   openai_api_key: "sk-test-fake-openai-key-for-testing",
-  anthropic_api_key: "sk-ant-test-fake-anthropic-key-for-testing"
+  anthropic_api_key: "sk-ant-test-fake-anthropic-key-for-testing",
+  google_api_key: "sk-test-fake-google-api-key-for-testing"
 
 # Use mocked HTTP client for all tests
 config :aludel,

--- a/lib/aludel/interfaces/llm.ex
+++ b/lib/aludel/interfaces/llm.ex
@@ -121,7 +121,7 @@ defmodule Aludel.LLM do
   end
 
   defp get_openai_api_key do
-    case Application.get_env(:aludel, :llm)[:openai_api_key] do
+    case Application.get_env(:aludel, :llm, [])[:openai_api_key] do
       nil -> :error
       "" -> :error
       api_key -> {:ok, api_key}
@@ -129,7 +129,7 @@ defmodule Aludel.LLM do
   end
 
   defp get_anthropic_api_key do
-    case Application.get_env(:aludel, :llm)[:anthropic_api_key] do
+    case Application.get_env(:aludel, :llm, [])[:anthropic_api_key] do
       nil -> :error
       "" -> :error
       api_key -> {:ok, api_key}
@@ -137,7 +137,7 @@ defmodule Aludel.LLM do
   end
 
   defp get_google_api_key do
-    case Application.get_env(:aludel, :llm)[:google_api_key] do
+    case Application.get_env(:aludel, :llm, [])[:google_api_key] do
       nil -> :error
       "" -> :error
       api_key -> {:ok, api_key}

--- a/lib/aludel/interfaces/llm.ex
+++ b/lib/aludel/interfaces/llm.ex
@@ -2,7 +2,7 @@ defmodule Aludel.LLM do
   @moduledoc """
   LLM client abstraction for multi-provider support.
 
-  Supports OpenAI, Anthropic, and Ollama providers via direct HTTP calls.
+  Supports OpenAI, Anthropic, Google Gemini, and Ollama providers via direct HTTP calls.
   Provides unified interface for generating text completions and tracking usage metrics.
 
   Returns structured responses containing:
@@ -25,13 +25,14 @@ defmodule Aludel.LLM do
           cost_usd: float()
         }
 
-  alias Aludel.Interfaces.LLM.Providers.{Anthropic, Ollama, OpenAI}
+  alias Aludel.Interfaces.LLM.Providers.{Anthropic, Google, Ollama, OpenAI}
   alias Aludel.Providers.Provider
 
   @providers %{
     openai: OpenAI,
     anthropic: Anthropic,
-    ollama: Ollama
+    ollama: Ollama,
+    google: Google
   }
 
   @type error_reason ::
@@ -109,6 +110,7 @@ defmodule Aludel.LLM do
       case provider.provider do
         :openai -> get_openai_api_key()
         :anthropic -> get_anthropic_api_key()
+        :google -> get_google_api_key()
         :ollama -> nil
       end
 
@@ -134,6 +136,14 @@ defmodule Aludel.LLM do
     end
   end
 
+  defp get_google_api_key do
+    case Application.get_env(:aludel, :llm)[:google_api_key] do
+      nil -> :error
+      "" -> :error
+      api_key -> {:ok, api_key}
+    end
+  end
+
   defp calculate_cost(provider, response) do
     case provider.provider do
       :openai ->
@@ -146,6 +156,12 @@ defmodule Aludel.LLM do
         # Anthropic Claude pricing: $3/million input, $15/million output
         input_cost = response.input_tokens * 3.0 / 1_000_000
         output_cost = response.output_tokens * 15.0 / 1_000_000
+        Float.round(input_cost + output_cost, 6)
+
+      :google ->
+        # Google Gemini Flash pricing: $0.15/million input, $0.60/million output
+        input_cost = response.input_tokens * 0.15 / 1_000_000
+        output_cost = response.output_tokens * 0.60 / 1_000_000
         Float.round(input_cost + output_cost, 6)
 
       :ollama ->

--- a/lib/aludel/interfaces/llm/README.md
+++ b/lib/aludel/interfaces/llm/README.md
@@ -14,6 +14,7 @@ lib/aludel/interfaces/
     ├── providers/
     │   ├── openai.ex
     │   ├── anthropic.ex
+    │   ├── google.ex
     │   └── ollama.ex
     ├── behaviour.ex            # Provider contract
     ├── config.ex               # HTTP adapter + API key utils
@@ -39,20 +40,22 @@ config :aludel,
 
 ## Adding a Provider
 
-Create `lib/aludel/interfaces/llm/providers/gemini.ex`:
+Create a new provider module, e.g. `lib/aludel/interfaces/llm/providers/google.ex`:
 
 ```elixir
-defmodule Aludel.Interfaces.LLM.Providers.Gemini do
+defmodule Aludel.Interfaces.LLM.Providers.Google do
   alias Aludel.Interfaces.LLM.{Config, ErrorParser}
 
   @behaviour Aludel.Interfaces.LLM.Behaviour
 
   @impl true
-  def generate(model, prompt, config, _opts) do
+  def generate(model, prompt, config, opts) do
     with {:ok, api_key} <- Config.get_api_key(config) do
-      opts = [api_key: api_key, temperature: config["temperature"] || 0.7]
+      req_opts =
+        [api_key: api_key, temperature: config["temperature"] || 0.7]
+        |> Keyword.merge(opts)
 
-      case Config.http_adapter().request("gemini:#{model}", prompt, opts) do
+      case Config.http_adapter().request("google:#{model}", prompt, req_opts) do
         {:ok, response} -> {:ok, response}
         {:error, reason} -> ErrorParser.parse_error(reason)
       end
@@ -68,7 +71,7 @@ Register in `lib/aludel/interfaces/llm.ex`:
   openai: OpenAI,
   anthropic: Anthropic,
   ollama: Ollama,
-  gemini: Gemini
+  google: Google
 }
 ```
 

--- a/lib/aludel/interfaces/llm/providers/google.ex
+++ b/lib/aludel/interfaces/llm/providers/google.ex
@@ -1,0 +1,35 @@
+defmodule Aludel.Interfaces.LLM.Providers.Google do
+  @moduledoc """
+  Google Gemini LLM provider implementation.
+
+  Handles provider-specific logic (API keys, error handling) while
+  delegating HTTP communication to the configured HTTP adapter.
+  """
+
+  alias Aludel.Interfaces.LLM.{Config, ErrorParser}
+
+  @behaviour Aludel.Interfaces.LLM.Behaviour
+
+  @impl true
+  def generate(model, prompt, config, opts) do
+    with {:ok, api_key} <- Config.get_api_key(config) do
+      req_opts =
+        [
+          api_key: api_key,
+          temperature: config["temperature"] || 0.7,
+          max_tokens: config["max_tokens"] || 1024
+        ]
+        |> Keyword.merge(opts)
+
+      model_spec = "google:#{model}"
+
+      case Config.http_adapter().request(model_spec, prompt, req_opts) do
+        {:ok, response} ->
+          {:ok, response}
+
+        {:error, reason} ->
+          ErrorParser.parse_error(reason)
+      end
+    end
+  end
+end

--- a/lib/aludel/providers.ex
+++ b/lib/aludel/providers.ex
@@ -91,6 +91,7 @@ defmodule Aludel.Providers do
       "openai" -> fetch_model_groups(:openai)
       "anthropic" -> fetch_model_groups(:anthropic)
       "ollama" -> fetch_model_groups(:ollama)
+      "google" -> fetch_model_groups(:google)
       _ -> %{active: [], deprecated: []}
     end
   end

--- a/lib/aludel/providers/provider.ex
+++ b/lib/aludel/providers/provider.ex
@@ -19,7 +19,7 @@ defmodule Aludel.Providers.Provider do
 
   schema "providers" do
     field :name, :string
-    field :provider, Ecto.Enum, values: [:openai, :anthropic, :ollama]
+    field :provider, Ecto.Enum, values: [:openai, :anthropic, :ollama, :google]
     field :model, :string
     field :config, :map
     field :model_selection, :string, virtual: true

--- a/lib/aludel/web/helpers.ex
+++ b/lib/aludel/web/helpers.ex
@@ -57,6 +57,7 @@ defmodule Aludel.Web.Helpers do
       :openai -> "/images/open-ai-icon.svg"
       :anthropic -> "/images/anthropic-icon.svg"
       :ollama -> "/images/ollama-icon.svg"
+      :google -> "/images/gemini-icon.svg"
       _ -> nil
     end
   end

--- a/lib/aludel/web/live/provider_live/index.html.heex
+++ b/lib/aludel/web/live/provider_live/index.html.heex
@@ -5,7 +5,7 @@
         <.icon name="hero-server-stack" class="size-7 text-muted" />
         <h1 style="margin: 0; font-size: 28px; font-weight: 600;">Providers</h1>
       </div>
-      <.link navigate={aludel_path("providers/new")} class="button-primary">
+      <.link navigate={aludel_path("providers/new")} class="button-primary" id="new-provider-btn">
         <.icon name="hero-plus" class="size-4" /> New Provider
       </.link>
     </div>
@@ -19,7 +19,7 @@
           </div>
         </div>
       <% else %>
-        <table style="width: 100%; border-collapse: collapse;">
+        <table id="providers-table" style="width: 100%; border-collapse: collapse;">
           <thead style="background-color: var(--bg-secondary); border-bottom: 1px solid var(--border);">
             <tr>
               <th style="text-align: left; padding: 12px 16px; font-weight: 600; font-size: 13px; color: var(--text-secondary);">
@@ -35,7 +35,7 @@
           </thead>
           <tbody>
             <%= for provider <- @providers do %>
-              <tr style="border-bottom: 1px solid var(--border);">
+              <tr id={"provider-#{provider.id}"} style="border-bottom: 1px solid var(--border);">
                 <td style="padding: 12px 16px;">
                   <div style="display: flex; align-items: center; gap: 12px;">
                     <%= if icon_path = provider_icon(provider.provider) do %>

--- a/lib/aludel/web/live/provider_live/new.html.heex
+++ b/lib/aludel/web/live/provider_live/new.html.heex
@@ -27,7 +27,12 @@
             label="Provider Type"
             required
             prompt="Select a provider type"
-            options={[{"OpenAI", "openai"}, {"Anthropic", "anthropic"}, {"Ollama", "ollama"}]}
+            options={[
+              {"OpenAI", "openai"},
+              {"Anthropic", "anthropic"},
+              {"Google Gemini", "google"},
+              {"Ollama", "ollama"}
+            ]}
           />
         </div>
 

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -69,10 +69,28 @@ case Providers.list_providers() do
         config: %{"temperature" => 0.7, "max_tokens" => 1000}
       })
 
-    IO.puts("✓ Created 6 default providers:")
+    # Google Gemini Providers
+    {:ok, _} =
+      Providers.create_provider(%{
+        name: "Gemini 2.5 Flash",
+        provider: :google,
+        model: "gemini-2.5-flash",
+        config: %{"temperature" => 0.7, "max_tokens" => 1024}
+      })
+
+    {:ok, _} =
+      Providers.create_provider(%{
+        name: "Gemini 2.5 Pro",
+        provider: :google,
+        model: "gemini-2.5-pro",
+        config: %{"temperature" => 0.7, "max_tokens" => 1024}
+      })
+
+    IO.puts("✓ Created 8 default providers:")
     IO.puts("  - OpenAI: GPT-4o, GPT-4o Mini")
     IO.puts("  - Anthropic: Claude Sonnet 4.5, Claude Haiku 4.5")
     IO.puts("  - Ollama: Llava (vision), Llama 2 (text)")
+    IO.puts("  - Google Gemini: Gemini 2.5 Flash, Gemini 2.5 Pro")
 
   _ ->
     IO.puts("→ Providers already exist, skipping")

--- a/standalone/config/dev.exs
+++ b/standalone/config/dev.exs
@@ -20,4 +20,5 @@ config :aludel_dash, AludelDash.Endpoint,
 
 config :aludel, :llm,
   openai_api_key: System.get_env("OPENAI_API_KEY"),
-  anthropic_api_key: System.get_env("ANTHROPIC_API_KEY")
+  anthropic_api_key: System.get_env("ANTHROPIC_API_KEY"),
+  google_api_key: System.get_env("GOOGLE_API_KEY")

--- a/standalone/config/runtime.exs
+++ b/standalone/config/runtime.exs
@@ -36,5 +36,6 @@ if config_env() == :prod do
 
   config :aludel, :llm,
     openai_api_key: System.get_env("OPENAI_API_KEY"),
-    anthropic_api_key: System.get_env("ANTHROPIC_API_KEY")
+    anthropic_api_key: System.get_env("ANTHROPIC_API_KEY"),
+    google_api_key: System.get_env("GOOGLE_API_KEY")
 end

--- a/test/aludel/llm_test.exs
+++ b/test/aludel/llm_test.exs
@@ -301,6 +301,162 @@ defmodule Aludel.LLMTest do
     end
   end
 
+  describe "call/3 with Google provider" do
+    test "returns structured response with all required fields" do
+      mock_response = build_mock_response("Hello from Gemini!", 8, 6)
+
+      expect(HttpClientMock, :request, fn _model, _prompt, _opts ->
+        {:ok, mock_response}
+      end)
+
+      provider =
+        provider_fixture(%{
+          provider: :google,
+          model: "gemini-2.5-flash",
+          config: %{"temperature" => 0.7}
+        })
+
+      assert {:ok, result} = LLM.call(provider, "test prompt", [])
+      assert is_binary(result.output)
+      assert result.output != ""
+      assert is_integer(result.input_tokens)
+      assert result.input_tokens > 0
+      assert is_integer(result.output_tokens)
+      assert result.output_tokens > 0
+      assert is_integer(result.latency_ms)
+      assert result.latency_ms >= 0
+      assert is_float(result.cost_usd)
+    end
+
+    test "calculates cost for Google" do
+      mock_response = build_mock_response("Test response", 5, 10)
+
+      expect(HttpClientMock, :request, fn _model, _prompt, _opts ->
+        {:ok, mock_response}
+      end)
+
+      provider =
+        provider_fixture(%{
+          provider: :google,
+          model: "gemini-2.5-flash",
+          config: %{}
+        })
+
+      {:ok, result} = LLM.call(provider, "test", [])
+      assert result.cost_usd > 0
+
+      # Verify exact cost: (5 * 0.15 / 1_000_000) + (10 * 0.60 / 1_000_000)
+      expected_cost = Float.round(5 * 0.15 / 1_000_000 + 10 * 0.60 / 1_000_000, 6)
+      assert result.cost_usd == expected_cost
+    end
+
+    test "calls Google adapter successfully" do
+      mock_response = build_mock_response("Hello!", 3, 2)
+
+      expect(HttpClientMock, :request, fn _model, _prompt, _opts ->
+        {:ok, mock_response}
+      end)
+
+      provider =
+        provider_fixture(%{
+          provider: :google,
+          model: "gemini-2.5-flash",
+          config: %{"temperature" => 0.7, "max_tokens" => 100}
+        })
+
+      assert {:ok, result} = LLM.call(provider, "Say hello", [])
+      assert is_binary(result.output)
+      assert result.output != ""
+      assert result.input_tokens > 0
+      assert result.output_tokens > 0
+    end
+
+    test "returns error when API key is missing" do
+      original_config = Application.get_env(:aludel, :llm)
+      Application.put_env(:aludel, :llm, google_api_key: nil)
+
+      provider =
+        provider_fixture(%{
+          provider: :google,
+          model: "gemini-2.5-flash",
+          config: %{}
+        })
+
+      result = LLM.call(provider, "test", [])
+      Application.put_env(:aludel, :llm, original_config)
+
+      assert {:error, :missing_api_key} = result
+    end
+
+    test "returns error when API key is empty string" do
+      original_config = Application.get_env(:aludel, :llm)
+      Application.put_env(:aludel, :llm, google_api_key: "")
+
+      provider =
+        provider_fixture(%{
+          provider: :google,
+          model: "gemini-2.5-flash",
+          config: %{}
+        })
+
+      result = LLM.call(provider, "test", [])
+      Application.put_env(:aludel, :llm, original_config)
+
+      assert {:error, :missing_api_key} = result
+    end
+
+    test "returns auth error for invalid API key" do
+      expect(HttpClientMock, :request, fn _model, _prompt, _opts ->
+        {:error, %{status: 401}}
+      end)
+
+      provider =
+        provider_fixture(%{
+          provider: :google,
+          model: "gemini-2.5-flash",
+          config: %{}
+        })
+
+      result = LLM.call(provider, "test", [])
+
+      assert {:error, {:auth_error, _message}} = result
+    end
+
+    test "returns invalid_request error for bad parameters" do
+      expect(HttpClientMock, :request, fn _model, _prompt, _opts ->
+        {:error, %{status: 400}}
+      end)
+
+      provider =
+        provider_fixture(%{
+          provider: :google,
+          model: "invalid-model-name",
+          config: %{}
+        })
+
+      result = LLM.call(provider, "test", [])
+
+      assert {:error, {:invalid_request, _}} = result
+    end
+
+    test "returns rate_limit error" do
+      expect(HttpClientMock, :request, fn _model, _prompt, _opts ->
+        {:error, %{status: 429}}
+      end)
+
+      provider =
+        provider_fixture(%{
+          provider: :google,
+          model: "gemini-2.5-flash",
+          config: %{}
+        })
+
+      result = LLM.call(provider, "test", [])
+
+      assert {:error, {:rate_limit, nil}} = result
+    end
+  end
+
   describe "call/3 error handling" do
     test "handles network errors gracefully" do
       expect(HttpClientMock, :request, fn _model, _prompt, _opts ->

--- a/test/aludel/llm_test.exs
+++ b/test/aludel/llm_test.exs
@@ -458,6 +458,18 @@ defmodule Aludel.LLMTest do
   end
 
   describe "call/3 error handling" do
+    test "returns missing_api_key when :llm config is entirely absent" do
+      original_config = Application.get_env(:aludel, :llm)
+      Application.delete_env(:aludel, :llm)
+
+      for provider_type <- [:openai, :anthropic, :google] do
+        provider = provider_fixture(%{provider: provider_type, model: "test-model", config: %{}})
+        assert {:error, :missing_api_key} = LLM.call(provider, "test", [])
+      end
+
+      Application.put_env(:aludel, :llm, original_config)
+    end
+
     test "handles network errors gracefully" do
       expect(HttpClientMock, :request, fn _model, _prompt, _opts ->
         {:error, :timeout}

--- a/test/aludel/llm_test.exs
+++ b/test/aludel/llm_test.exs
@@ -1,5 +1,5 @@
 defmodule Aludel.LLMTest do
-  use Aludel.DataCase, async: true
+  use Aludel.DataCase, async: false
 
   import Mox
 
@@ -13,34 +13,36 @@ defmodule Aludel.LLMTest do
       original_config = Application.get_env(:aludel, :llm)
       Application.put_env(:aludel, :llm, openai_api_key: nil)
 
-      provider =
-        provider_fixture(%{
-          provider: :openai,
-          model: "gpt-4o",
-          config: %{}
-        })
+      try do
+        provider =
+          provider_fixture(%{
+            provider: :openai,
+            model: "gpt-4o",
+            config: %{}
+          })
 
-      result = LLM.call(provider, "test", [])
-      Application.put_env(:aludel, :llm, original_config)
-
-      assert {:error, :missing_api_key} = result
+        assert {:error, :missing_api_key} = LLM.call(provider, "test", [])
+      after
+        Application.put_env(:aludel, :llm, original_config)
+      end
     end
 
     test "returns error when API key is empty string" do
       original_config = Application.get_env(:aludel, :llm)
       Application.put_env(:aludel, :llm, openai_api_key: "")
 
-      provider =
-        provider_fixture(%{
-          provider: :openai,
-          model: "gpt-4o",
-          config: %{}
-        })
+      try do
+        provider =
+          provider_fixture(%{
+            provider: :openai,
+            model: "gpt-4o",
+            config: %{}
+          })
 
-      result = LLM.call(provider, "test", [])
-      Application.put_env(:aludel, :llm, original_config)
-
-      assert {:error, :missing_api_key} = result
+        assert {:error, :missing_api_key} = LLM.call(provider, "test", [])
+      after
+        Application.put_env(:aludel, :llm, original_config)
+      end
     end
 
     test "returns structured response with all required fields" do
@@ -143,42 +145,39 @@ defmodule Aludel.LLMTest do
 
   describe "call/3 with Anthropic provider" do
     test "returns error when API key is missing" do
-      # Temporarily clear the config
       original_config = Application.get_env(:aludel, :llm)
       Application.put_env(:aludel, :llm, anthropic_api_key: nil)
 
-      provider =
-        provider_fixture(%{
-          provider: :anthropic,
-          model: "claude-3-5-sonnet-20241022",
-          config: %{}
-        })
+      try do
+        provider =
+          provider_fixture(%{
+            provider: :anthropic,
+            model: "claude-3-5-sonnet-20241022",
+            config: %{}
+          })
 
-      result = LLM.call(provider, "test", [])
-
-      # Restore original config
-      Application.put_env(:aludel, :llm, original_config)
-
-      assert {:error, :missing_api_key} = result
+        assert {:error, :missing_api_key} = LLM.call(provider, "test", [])
+      after
+        Application.put_env(:aludel, :llm, original_config)
+      end
     end
 
     test "returns error when API key is empty string" do
       original_config = Application.get_env(:aludel, :llm)
       Application.put_env(:aludel, :llm, anthropic_api_key: "")
 
-      provider =
-        provider_fixture(%{
-          provider: :anthropic,
-          model: "claude-3-5-sonnet-20241022",
-          config: %{}
-        })
+      try do
+        provider =
+          provider_fixture(%{
+            provider: :anthropic,
+            model: "claude-3-5-sonnet-20241022",
+            config: %{}
+          })
 
-      result = LLM.call(provider, "test", [])
-
-      # Restore original config
-      Application.put_env(:aludel, :llm, original_config)
-
-      assert {:error, :missing_api_key} = result
+        assert {:error, :missing_api_key} = LLM.call(provider, "test", [])
+      after
+        Application.put_env(:aludel, :llm, original_config)
+      end
     end
 
     test "returns structured response" do
@@ -375,34 +374,36 @@ defmodule Aludel.LLMTest do
       original_config = Application.get_env(:aludel, :llm)
       Application.put_env(:aludel, :llm, google_api_key: nil)
 
-      provider =
-        provider_fixture(%{
-          provider: :google,
-          model: "gemini-2.5-flash",
-          config: %{}
-        })
+      try do
+        provider =
+          provider_fixture(%{
+            provider: :google,
+            model: "gemini-2.5-flash",
+            config: %{}
+          })
 
-      result = LLM.call(provider, "test", [])
-      Application.put_env(:aludel, :llm, original_config)
-
-      assert {:error, :missing_api_key} = result
+        assert {:error, :missing_api_key} = LLM.call(provider, "test", [])
+      after
+        Application.put_env(:aludel, :llm, original_config)
+      end
     end
 
     test "returns error when API key is empty string" do
       original_config = Application.get_env(:aludel, :llm)
       Application.put_env(:aludel, :llm, google_api_key: "")
 
-      provider =
-        provider_fixture(%{
-          provider: :google,
-          model: "gemini-2.5-flash",
-          config: %{}
-        })
+      try do
+        provider =
+          provider_fixture(%{
+            provider: :google,
+            model: "gemini-2.5-flash",
+            config: %{}
+          })
 
-      result = LLM.call(provider, "test", [])
-      Application.put_env(:aludel, :llm, original_config)
-
-      assert {:error, :missing_api_key} = result
+        assert {:error, :missing_api_key} = LLM.call(provider, "test", [])
+      after
+        Application.put_env(:aludel, :llm, original_config)
+      end
     end
 
     test "returns auth error for invalid API key" do
@@ -462,12 +463,16 @@ defmodule Aludel.LLMTest do
       original_config = Application.get_env(:aludel, :llm)
       Application.delete_env(:aludel, :llm)
 
-      for provider_type <- [:openai, :anthropic, :google] do
-        provider = provider_fixture(%{provider: provider_type, model: "test-model", config: %{}})
-        assert {:error, :missing_api_key} = LLM.call(provider, "test", [])
-      end
+      try do
+        for provider_type <- [:openai, :anthropic, :google] do
+          provider =
+            provider_fixture(%{provider: provider_type, model: "test-model", config: %{}})
 
-      Application.put_env(:aludel, :llm, original_config)
+          assert {:error, :missing_api_key} = LLM.call(provider, "test", [])
+        end
+      after
+        Application.put_env(:aludel, :llm, original_config)
+      end
     end
 
     test "handles network errors gracefully" do

--- a/test/aludel/providers_models_test.exs
+++ b/test/aludel/providers_models_test.exs
@@ -42,5 +42,27 @@ defmodule Aludel.ProvidersModelsTest do
       assert is_list(groups.active)
       assert is_list(groups.deprecated)
     end
+
+    test "fetches model groups for google provider" do
+      groups = Providers.fetch_model_groups(:google)
+
+      assert Map.has_key?(groups, :active)
+      assert Map.has_key?(groups, :deprecated)
+      assert is_list(groups.active)
+      assert is_list(groups.deprecated)
+    end
+
+    test "fetches model groups for google string type" do
+      groups = Providers.fetch_model_groups("google")
+
+      assert Map.has_key?(groups, :active)
+      assert Map.has_key?(groups, :deprecated)
+      assert is_list(groups.active)
+      assert is_list(groups.deprecated)
+    end
+
+    test "returns empty groups for unknown provider string" do
+      assert %{active: [], deprecated: []} = Providers.fetch_model_groups("unknown")
+    end
   end
 end

--- a/test/aludel/providers_test.exs
+++ b/test/aludel/providers_test.exs
@@ -74,6 +74,31 @@ defmodule Aludel.ProvidersTest do
       assert "can't be blank" in errors_on(changeset).model
     end
 
+    test "create_provider/1 with google provider" do
+      attrs = %{
+        name: "Google Gemini Flash",
+        provider: :google,
+        model: "gemini-2.5-flash",
+        config: %{"temperature" => 0.7, "max_tokens" => 1024}
+      }
+
+      assert {:ok, provider} = Providers.create_provider(attrs)
+      assert provider.name == "Google Gemini Flash"
+      assert provider.provider == :google
+      assert provider.model == "gemini-2.5-flash"
+    end
+
+    test "lists providers including google type" do
+      _openai = provider_fixture(%{name: "OpenAI", provider: :openai, model: "gpt-4o"})
+
+      _google =
+        provider_fixture(%{name: "Gemini Flash", provider: :google, model: "gemini-2.5-flash"})
+
+      providers = Providers.list_providers()
+      assert length(providers) == 2
+      assert Enum.any?(providers, fn p -> p.provider == :google end)
+    end
+
     test "create_provider/1 with JSONB config storage" do
       attrs = %{
         name: "Anthropic Claude",

--- a/test/aludel_web/live/provider_live/index_test.exs
+++ b/test/aludel_web/live/provider_live/index_test.exs
@@ -40,6 +40,20 @@ defmodule Aludel.Web.ProviderLive.IndexTest do
       assert html =~ "Test Provider"
       assert html =~ "gpt-4o"
     end
+
+    test "displays Google provider with Google icon", %{conn: conn} do
+      _provider =
+        provider_fixture(%{
+          name: "Gemini Flash",
+          provider: :google,
+          model: "gemini-2.5-flash"
+        })
+
+      {:ok, _view, html} = live(conn, "/providers")
+
+      assert html =~ "Gemini Flash"
+      assert html =~ "gemini-icon.svg"
+    end
   end
 
   describe "delete functionality" do

--- a/test/aludel_web/live/provider_live/index_test.exs
+++ b/test/aludel_web/live/provider_live/index_test.exs
@@ -6,53 +6,53 @@ defmodule Aludel.Web.ProviderLive.IndexTest do
 
   describe "provider list" do
     test "mounts successfully", %{conn: conn} do
-      {:ok, _view, html} = live(conn, "/providers")
+      {:ok, view, _html} = live(conn, "/providers")
 
-      assert html =~ "Providers"
+      assert has_element?(view, "h1", "Providers")
     end
 
     test "displays list of providers", %{conn: conn} do
-      _provider1 = provider_fixture(%{name: "OpenAI GPT-4"})
-      _provider2 = provider_fixture(%{name: "Claude Sonnet"})
+      provider1 = provider_fixture(%{name: "OpenAI GPT-4"})
+      provider2 = provider_fixture(%{name: "Claude Sonnet"})
 
-      {:ok, _view, html} = live(conn, "/providers")
+      {:ok, view, _html} = live(conn, "/providers")
 
-      assert html =~ "OpenAI GPT-4"
-      assert html =~ "Claude Sonnet"
+      assert has_element?(view, "#provider-#{provider1.id}", "OpenAI GPT-4")
+      assert has_element?(view, "#provider-#{provider2.id}", "Claude Sonnet")
     end
 
     test "shows new provider button", %{conn: conn} do
-      {:ok, _view, html} = live(conn, "/providers")
+      {:ok, view, _html} = live(conn, "/providers")
 
-      assert html =~ "New Provider" or html =~ "Add Provider"
+      assert has_element?(view, "#new-provider-btn", "New Provider")
     end
 
     test "displays provider details", %{conn: conn} do
-      _provider =
+      provider =
         provider_fixture(%{
           name: "Test Provider",
           provider: :openai,
           model: "gpt-4o"
         })
 
-      {:ok, _view, html} = live(conn, "/providers")
+      {:ok, view, _html} = live(conn, "/providers")
 
-      assert html =~ "Test Provider"
-      assert html =~ "gpt-4o"
+      assert has_element?(view, "#provider-#{provider.id}", "Test Provider")
+      assert has_element?(view, "#provider-#{provider.id}", "gpt-4o")
     end
 
     test "displays Google provider with Google icon", %{conn: conn} do
-      _provider =
+      provider =
         provider_fixture(%{
           name: "Gemini Flash",
           provider: :google,
           model: "gemini-2.5-flash"
         })
 
-      {:ok, _view, html} = live(conn, "/providers")
+      {:ok, view, _html} = live(conn, "/providers")
 
-      assert html =~ "Gemini Flash"
-      assert html =~ "gemini-icon.svg"
+      assert has_element?(view, "#provider-#{provider.id}", "Gemini Flash")
+      assert has_element?(view, ".provider-icon-google")
     end
   end
 
@@ -62,25 +62,25 @@ defmodule Aludel.Web.ProviderLive.IndexTest do
 
       {:ok, view, _html} = live(conn, "/providers")
 
-      html = render_click(view, "delete", %{"id" => provider.id})
+      render_click(view, "delete", %{"id" => provider.id})
 
-      assert html =~ "Provider deleted successfully"
-      refute html =~ "Delete Me"
+      assert render(view) =~ "Provider deleted successfully"
+      refute has_element?(view, "#provider-#{provider.id}")
     end
 
     test "refreshes provider list after deletion", %{conn: conn} do
       provider1 = provider_fixture(%{name: "Provider 1"})
-      _provider2 = provider_fixture(%{name: "Provider 2"})
+      provider2 = provider_fixture(%{name: "Provider 2"})
 
       {:ok, view, _html} = live(conn, "/providers")
 
-      assert render(view) =~ "Provider 1"
-      assert render(view) =~ "Provider 2"
+      assert has_element?(view, "#provider-#{provider1.id}", "Provider 1")
+      assert has_element?(view, "#provider-#{provider2.id}", "Provider 2")
 
-      html = render_click(view, "delete", %{"id" => provider1.id})
+      render_click(view, "delete", %{"id" => provider1.id})
 
-      refute html =~ "Provider 1"
-      assert html =~ "Provider 2"
+      refute has_element?(view, "#provider-#{provider1.id}")
+      assert has_element?(view, "#provider-#{provider2.id}", "Provider 2")
     end
   end
 end

--- a/test/aludel_web/live/provider_live/new_test.exs
+++ b/test/aludel_web/live/provider_live/new_test.exs
@@ -68,6 +68,39 @@ defmodule Aludel.Web.ProviderLive.NewTest do
       assert provider.config == %{"temperature" => 0.2, "max_tokens" => 512}
     end
 
+    test "shows Google Gemini in provider type dropdown", %{conn: conn} do
+      {:ok, _view, html} = live(conn, "/providers/new")
+
+      assert html =~ "Google Gemini"
+    end
+
+    test "creates a Gemini provider through the form", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/providers/new")
+
+      view
+      |> form("#provider-form", provider: %{provider: "google", model_selection: "custom"})
+      |> render_change()
+
+      view
+      |> form("#provider-form",
+        provider: %{
+          name: "Gemini Flash",
+          provider: "google",
+          model_selection: "custom",
+          model_custom: "gemini-2.5-flash",
+          config: ~s({"temperature":0.7,"max_tokens":1024})
+        }
+      )
+      |> render_submit()
+
+      assert_redirect(view, "/providers")
+
+      [provider] = Providers.list_providers()
+      assert provider.name == "Gemini Flash"
+      assert provider.provider == :google
+      assert provider.model == "gemini-2.5-flash"
+    end
+
     test "shows validation errors for invalid data", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/providers/new")
 


### PR DESCRIPTION
## Motivation (required)

Closes #72 by adding Google Gemini as a first-class LLM provider.

Gemini was one of the major cloud provider missing from Aludel. Users had no way to evaluate Google's models alongside OpenAI, Anthropic, and Ollama. This change adds full support across all five layers of the provider system (schema, LLM dispatch, provider module, UI, and helpers) so users can create Gemini providers, run prompts against them, and compare results with other providers.

Key decisions:
- **Provider atom is `:google`** (not `:gemini`) to match LLMDB's `LLMDB.Sources.Google` naming and ReqLLM's `"google:<model>"` spec format. The UI display name is "Google Gemini".
- **No database migration needed** — the `provider` column is stored as `:string` in PostgreSQL; only the Ecto.Enum values were updated.

## Test Plan (required)

Added new LLM integration tests for the Google provider and updated existing test files. Total suite grew from 425 to 433 tests.

```
$ mix precommit

Checking 126 source files (this might take a while) ...
Analysis took 0.2 seconds (0.03s to load, 0.2s running 67 checks on 126 files)
733 mods/funs, found no issues.

... SCAN COMPLETE ...

Running ExUnit with seed: 306257, max_cases: 28
.................................................................................................................
Finished in 1.2 seconds (0.5s async, 0.7s sync)
433 tests, 0 failures
```

### Manual tests

1. Get the API Key from https://aistudio.google.com/api-keys
2. Run the standalone app with `GOOGLE_API_KEY=<api-key> mix phx.server` or set it in `.env` then run it with `docker-compose up -d --build web`
3. Create a new provider in http://localhost:4000/providers (for testing I recommend any Gemini 3.1 Flash Lite model for reduced costs)
4. Create and run a new suite and check the results

## Next Steps

- Issue #31 will add configurable per-provider pricing with user overrides, replacing the hardcoded cost calculation.