### PR TITLE
refactor: move suite editor workflows out of SuiteLive.Show

### DIFF
--- a/lib/aludel/evals/assertion_parser.ex
+++ b/lib/aludel/evals/assertion_parser.ex
@@ -22,13 +22,14 @@ defmodule Aludel.Evals.AssertionParser do
   end
 
   def parse(:visual, params) do
-    assertions =
-      params
-      |> Map.get("assertions", %{})
-      |> normalize_assertion_params()
-      |> parse_visual_assertions()
-
-    validate(assertions)
+    params
+    |> Map.get("assertions", %{})
+    |> normalize_assertion_params()
+    |> parse_visual_assertions()
+    |> case do
+      {:ok, assertions} -> validate(assertions)
+      {:error, _message} = error -> error
+    end
   end
 
   @spec validate([map()]) :: {:ok, [map()]} | {:error, String.t()}
@@ -68,27 +69,9 @@ defmodule Aludel.Evals.AssertionParser do
   end
 
   defp parse_visual_assertions(assertion_params) do
-    assertion_params
-    |> Map.keys()
-    |> Enum.filter(&String.starts_with?(&1, "assertion_type_"))
-    |> Enum.map(fn "assertion_type_" <> idx -> String.to_integer(idx) end)
-    |> Enum.sort()
-    |> Enum.map(fn idx ->
-      type = Map.get(assertion_params, "assertion_type_#{idx}")
-
-      if type == "json_field" do
-        %{
-          "type" => type,
-          "field" => Map.get(assertion_params, "assertion_field_#{idx}", ""),
-          "expected" => Map.get(assertion_params, "assertion_expected_#{idx}", "")
-        }
-      else
-        %{
-          "type" => type,
-          "value" => Map.get(assertion_params, "assertion_value_#{idx}", "")
-        }
-      end
-    end)
+    with {:ok, assertion_indices} <- parse_assertion_indices(assertion_params) do
+      {:ok, Enum.map(assertion_indices, &build_visual_assertion(assertion_params, &1))}
+    end
   end
 
   defp build_assertion_params(assertions) do
@@ -109,6 +92,42 @@ defmodule Aludel.Evals.AssertionParser do
 
   defp maybe_put_assertion_value(params, idx, assertion) do
     Map.put(params, "assertion_value_#{idx}", assertion["value"] || "")
+  end
+
+  defp build_visual_assertion(assertion_params, idx) do
+    type = Map.get(assertion_params, "assertion_type_#{idx}")
+
+    if type == "json_field" do
+      %{
+        "type" => type,
+        "field" => Map.get(assertion_params, "assertion_field_#{idx}", ""),
+        "expected" => Map.get(assertion_params, "assertion_expected_#{idx}", "")
+      }
+    else
+      %{
+        "type" => type,
+        "value" => Map.get(assertion_params, "assertion_value_#{idx}", "")
+      }
+    end
+  end
+
+  defp parse_assertion_indices(assertion_params) do
+    assertion_params
+    |> Map.keys()
+    |> Enum.filter(&String.starts_with?(&1, "assertion_type_"))
+    |> Enum.reduce_while({:ok, []}, fn "assertion_type_" <> idx, {:ok, indices} ->
+      case Integer.parse(idx) do
+        {parsed_idx, ""} ->
+          {:cont, {:ok, [parsed_idx | indices]}}
+
+        _ ->
+          {:halt, {:error, "Invalid assertion index: #{idx}"}}
+      end
+    end)
+    |> case do
+      {:ok, indices} -> {:ok, Enum.sort(indices)}
+      {:error, _message} = error -> error
+    end
   end
 
   defp normalize_assertion_params(params) when is_map(params), do: params

--- a/lib/aludel/evals/assertion_parser.ex
+++ b/lib/aludel/evals/assertion_parser.ex
@@ -1,0 +1,117 @@
+defmodule Aludel.Evals.AssertionParser do
+  @moduledoc """
+  Parses and validates assertion payloads from suite editor forms.
+  """
+
+  @valid_types ["contains", "not_contains", "regex", "exact_match", "json_field"]
+
+  @type parse_mode :: :json | :visual
+
+  @spec parse(parse_mode(), map()) :: {:ok, [map()]} | {:error, String.t()}
+  def parse(:json, params) do
+    case Jason.decode(params["assertions_json"] || "[]") do
+      {:ok, assertions} when is_list(assertions) ->
+        validate(assertions)
+
+      {:ok, _value} ->
+        {:error, "Invalid JSON: assertions must be a list"}
+
+      {:error, %Jason.DecodeError{}} ->
+        {:error, "Invalid JSON syntax in assertions"}
+    end
+  end
+
+  def parse(:visual, params) do
+    assertions =
+      params
+      |> Map.get("assertions", %{})
+      |> normalize_assertion_params()
+      |> parse_visual_assertions()
+
+    validate(assertions)
+  end
+
+  @spec validate([map()]) :: {:ok, [map()]} | {:error, String.t()}
+  def validate(assertions) when is_list(assertions) do
+    assertions
+    |> Enum.with_index(1)
+    |> Enum.reduce_while({:ok, assertions}, fn {assertion, idx}, _acc ->
+      type = Map.get(assertion, "type")
+
+      cond do
+        type not in @valid_types ->
+          {:halt,
+           {:error,
+            "Invalid assertion type at index #{idx}: #{inspect(type)}. Must be one of: #{Enum.join(@valid_types, ", ")}"}}
+
+        type == "json_field" and
+            (not Map.has_key?(assertion, "field") or not Map.has_key?(assertion, "expected")) ->
+          {:halt,
+           {:error,
+            "Assertion at index #{idx}: json_field type requires 'field' and 'expected' fields"}}
+
+        type != "json_field" and not Map.has_key?(assertion, "value") ->
+          {:halt, {:error, "Assertion at index #{idx}: #{type} type requires 'value' field"}}
+
+        true ->
+          {:cont, {:ok, assertions}}
+      end
+    end)
+  end
+
+  @spec build_form_params([map()]) :: map()
+  def build_form_params(assertions) do
+    %{
+      "assertions_json" => Jason.encode!(assertions, pretty: true),
+      "assertions" => build_assertion_params(assertions)
+    }
+  end
+
+  defp parse_visual_assertions(assertion_params) do
+    assertion_params
+    |> Map.keys()
+    |> Enum.filter(&String.starts_with?(&1, "assertion_type_"))
+    |> Enum.map(fn "assertion_type_" <> idx -> String.to_integer(idx) end)
+    |> Enum.sort()
+    |> Enum.map(fn idx ->
+      type = Map.get(assertion_params, "assertion_type_#{idx}")
+
+      if type == "json_field" do
+        %{
+          "type" => type,
+          "field" => Map.get(assertion_params, "assertion_field_#{idx}", ""),
+          "expected" => Map.get(assertion_params, "assertion_expected_#{idx}", "")
+        }
+      else
+        %{
+          "type" => type,
+          "value" => Map.get(assertion_params, "assertion_value_#{idx}", "")
+        }
+      end
+    end)
+  end
+
+  defp build_assertion_params(assertions) do
+    assertions
+    |> Enum.with_index()
+    |> Enum.reduce(%{}, fn {assertion, idx}, acc ->
+      acc
+      |> Map.put("assertion_type_#{idx}", assertion["type"])
+      |> maybe_put_assertion_value(idx, assertion)
+    end)
+  end
+
+  defp maybe_put_assertion_value(params, idx, %{"type" => "json_field"} = assertion) do
+    params
+    |> Map.put("assertion_field_#{idx}", assertion["field"] || "")
+    |> Map.put("assertion_expected_#{idx}", assertion["expected"] || "")
+  end
+
+  defp maybe_put_assertion_value(params, idx, assertion) do
+    Map.put(params, "assertion_value_#{idx}", assertion["value"] || "")
+  end
+
+  defp normalize_assertion_params(params) when is_map(params), do: params
+  defp normalize_assertion_params(params) when is_list(params), do: Map.new(params)
+  defp normalize_assertion_params(_params), do: %{}
+end

--- a/lib/aludel/evals/document_ingestion.ex
+++ b/lib/aludel/evals/document_ingestion.ex
@@ -1,0 +1,49 @@
+defmodule Aludel.Evals.DocumentIngestion do
+  @moduledoc """
+  Validates and persists uploaded documents for suite test cases.
+  """
+
+  alias Aludel.Evals
+  alias Aludel.FileValidation
+
+  @type ingest_result ::
+          {:success, String.t()}
+          | {:failed, String.t(), String.t()}
+
+  @spec ingest(String.t(), Phoenix.LiveView.UploadEntry.t(), binary()) :: ingest_result()
+  def ingest(path, entry, test_case_id) do
+    case File.read(path) do
+      {:ok, data} ->
+        validate_and_persist(data, entry, test_case_id)
+
+      {:error, reason} ->
+        {:failed, entry.client_name, :file.format_error(reason)}
+    end
+  end
+
+  defp validate_and_persist(data, entry, test_case_id) do
+    case FileValidation.validate(data, entry.client_type) do
+      :ok ->
+        persist_document(entry, data, test_case_id)
+
+      {:error, reason} ->
+        {:failed, entry.client_name, reason}
+    end
+  end
+
+  defp persist_document(entry, data, test_case_id) do
+    case Evals.create_test_case_document(%{
+           test_case_id: test_case_id,
+           filename: entry.client_name,
+           content_type: entry.client_type,
+           data: data,
+           size_bytes: entry.client_size
+         }) do
+      {:ok, _document} ->
+        {:success, entry.client_name}
+
+      {:error, _changeset} ->
+        {:failed, entry.client_name, "Database error"}
+    end
+  end
+end

--- a/lib/aludel/evals/document_ingestion.ex
+++ b/lib/aludel/evals/document_ingestion.ex
@@ -3,6 +3,8 @@ defmodule Aludel.Evals.DocumentIngestion do
   Validates and persists uploaded documents for suite test cases.
   """
 
+  import Ecto.Changeset, only: [traverse_errors: 2]
+
   alias Aludel.Evals
   alias Aludel.FileValidation
 
@@ -17,7 +19,7 @@ defmodule Aludel.Evals.DocumentIngestion do
         validate_and_persist(data, entry, test_case_id)
 
       {:error, reason} ->
-        {:failed, entry.client_name, :file.format_error(reason)}
+        {:failed, entry.client_name, reason |> :file.format_error() |> to_string()}
     end
   end
 
@@ -42,8 +44,20 @@ defmodule Aludel.Evals.DocumentIngestion do
       {:ok, _document} ->
         {:success, entry.client_name}
 
-      {:error, _changeset} ->
-        {:failed, entry.client_name, "Database error"}
+      {:error, changeset} ->
+        {:failed, entry.client_name, format_changeset_errors(changeset)}
     end
+  end
+
+  defp format_changeset_errors(changeset) do
+    changeset
+    |> traverse_errors(fn {message, opts} ->
+      Regex.replace(~r"%{(\w+)}", message, fn _, key ->
+        opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
+      end)
+    end)
+    |> Enum.map_join(", ", fn {field, messages} ->
+      "#{field} #{Enum.join(messages, ", ")}"
+    end)
   end
 end

--- a/lib/aludel/evals/test_case_editor.ex
+++ b/lib/aludel/evals/test_case_editor.ex
@@ -3,11 +3,15 @@ defmodule Aludel.Evals.TestCaseEditor do
   Coordinates suite test case editing workflows outside the web layer.
   """
 
+  import Ecto.Changeset
+
   alias Aludel.Evals
   alias Aludel.Evals.AssertionParser
   alias Aludel.Evals.TestCase
 
   @default_assertions [%{"type" => "contains", "value" => ""}]
+  @form_fields ~w(id variable_values assertions_json)a
+  @form_types %{id: :string, variable_values: :map, assertions_json: :string}
 
   @spec create_test_case(binary(), map()) ::
           {:ok, TestCase.t()} | {:error, Ecto.Changeset.t()}
@@ -34,6 +38,23 @@ defmodule Aludel.Evals.TestCaseEditor do
     |> Map.merge(AssertionParser.build_form_params(test_case.assertions || []))
   end
 
+  @spec change_form(TestCase.t() | map(), keyword()) :: Ecto.Changeset.t()
+  def change_form(test_case_or_params, opts \\ [])
+
+  def change_form(%TestCase{} = test_case, opts) do
+    test_case
+    |> build_form_params()
+    |> change_form(opts)
+  end
+
+  def change_form(params, opts) when is_map(params) do
+    {%{}, @form_types}
+    |> cast(params, @form_fields)
+    |> validate_required([:id])
+    |> maybe_put_assertion_error(opts[:assertion_error])
+    |> maybe_put_action(opts[:action])
+  end
+
   @spec update_test_case(TestCase.t(), map(), AssertionParser.parse_mode()) ::
           {:ok, TestCase.t()} | {:error, String.t()} | {:error, Ecto.Changeset.t()}
   def update_test_case(%TestCase{} = test_case, params, edit_mode) do
@@ -53,4 +74,12 @@ defmodule Aludel.Evals.TestCaseEditor do
     |> Enum.map(fn [_, variable] -> String.trim(variable) end)
     |> Enum.uniq()
   end
+
+  defp maybe_put_assertion_error(changeset, nil), do: changeset
+
+  defp maybe_put_assertion_error(changeset, message),
+    do: add_error(changeset, :assertions_json, message)
+
+  defp maybe_put_action(changeset, nil), do: changeset
+  defp maybe_put_action(changeset, action), do: Map.put(changeset, :action, action)
 end

--- a/lib/aludel/evals/test_case_editor.ex
+++ b/lib/aludel/evals/test_case_editor.ex
@@ -1,0 +1,56 @@
+defmodule Aludel.Evals.TestCaseEditor do
+  @moduledoc """
+  Coordinates suite test case editing workflows outside the web layer.
+  """
+
+  alias Aludel.Evals
+  alias Aludel.Evals.AssertionParser
+  alias Aludel.Evals.TestCase
+
+  @default_assertions [%{"type" => "contains", "value" => ""}]
+
+  @spec create_test_case(binary(), map()) ::
+          {:ok, TestCase.t()} | {:error, Ecto.Changeset.t()}
+  def create_test_case(suite_id, prompt) do
+    variable_values =
+      prompt
+      |> prompt_template()
+      |> extract_variables()
+      |> Map.new(fn variable -> {variable, ""} end)
+
+    Evals.create_test_case(%{
+      suite_id: suite_id,
+      variable_values: variable_values,
+      assertions: @default_assertions
+    })
+  end
+
+  @spec build_form_params(TestCase.t()) :: map()
+  def build_form_params(%TestCase{} = test_case) do
+    %{
+      "id" => test_case.id,
+      "variable_values" => test_case.variable_values || %{}
+    }
+    |> Map.merge(AssertionParser.build_form_params(test_case.assertions || []))
+  end
+
+  @spec update_test_case(TestCase.t(), map(), AssertionParser.parse_mode()) ::
+          {:ok, TestCase.t()} | {:error, String.t()} | {:error, Ecto.Changeset.t()}
+  def update_test_case(%TestCase{} = test_case, params, edit_mode) do
+    variables = Map.get(params, "variable_values", %{})
+
+    with {:ok, assertions} <- AssertionParser.parse(edit_mode, params) do
+      Evals.update_test_case(test_case, %{variable_values: variables, assertions: assertions})
+    end
+  end
+
+  defp prompt_template(%{versions: [%{template: template} | _]}), do: template
+  defp prompt_template(_prompt), do: ""
+
+  defp extract_variables(template) do
+    ~r/\{\{([^}]+)\}\}/
+    |> Regex.scan(template)
+    |> Enum.map(fn [_, variable] -> String.trim(variable) end)
+    |> Enum.uniq()
+  end
+end

--- a/lib/aludel/web/live/suite_live/show.ex
+++ b/lib/aludel/web/live/suite_live/show.ex
@@ -191,7 +191,7 @@ defmodule Aludel.Web.SuiteLive.Show do
       |> assign(:editing_test_case_id, id)
       |> assign(:editing_assertions, test_case.assertions)
       |> assign(:editing_test_case_params, form_params)
-      |> assign(:test_case_form, to_form(form_params, as: :test_case))
+      |> assign(:test_case_form, to_form(TestCaseEditor.change_form(form_params), as: :test_case))
       |> allow_upload(:documents,
         accept: ~w(.pdf .png .jpg .jpeg .csv .json .txt),
         max_entries: 5,
@@ -219,15 +219,41 @@ defmodule Aludel.Web.SuiteLive.Show do
 
     socket =
       socket
-      |> assign(:test_case_form, to_form(test_case_params, as: :test_case))
       |> assign(:editing_test_case_params, test_case_params)
 
     socket =
       if edit_mode == :visual do
-        {:ok, assertions} = AssertionParser.parse(:visual, test_case_params)
-        assign(socket, :editing_assertions, assertions)
+        case AssertionParser.parse(:visual, test_case_params) do
+          {:ok, assertions} ->
+            socket
+            |> assign(:editing_assertions, assertions)
+            |> assign(
+              :test_case_form,
+              to_form(TestCaseEditor.change_form(test_case_params, action: :validate),
+                as: :test_case
+              )
+            )
+
+          {:error, message} ->
+            assign(
+              socket,
+              :test_case_form,
+              to_form(
+                TestCaseEditor.change_form(
+                  test_case_params,
+                  action: :validate,
+                  assertion_error: message
+                ),
+                as: :test_case
+              )
+            )
+        end
       else
-        socket
+        assign(
+          socket,
+          :test_case_form,
+          to_form(TestCaseEditor.change_form(test_case_params, action: :validate), as: :test_case)
+        )
       end
 
     {:noreply, socket}
@@ -257,7 +283,17 @@ defmodule Aludel.Web.SuiteLive.Show do
       {:error, message} when is_binary(message) ->
         {:noreply,
          socket
-         |> assign(:test_case_form, to_form(test_case_params, as: :test_case))
+         |> assign(
+           :test_case_form,
+           to_form(
+             TestCaseEditor.change_form(
+               test_case_params,
+               action: :validate,
+               assertion_error: message
+             ),
+             as: :test_case
+           )
+         )
          |> assign(:editing_test_case_params, test_case_params)
          |> put_flash(:error, message)}
 

--- a/lib/aludel/web/live/suite_live/show.ex
+++ b/lib/aludel/web/live/suite_live/show.ex
@@ -9,7 +9,9 @@ defmodule Aludel.Web.SuiteLive.Show do
   use Aludel.Web, :live_view
 
   alias Aludel.Evals
-  alias Aludel.FileValidation
+  alias Aludel.Evals.AssertionParser
+  alias Aludel.Evals.DocumentIngestion
+  alias Aludel.Evals.TestCaseEditor
   alias Aludel.Projects
   alias Aludel.Prompts
   alias Aludel.Providers
@@ -165,19 +167,7 @@ defmodule Aludel.Web.SuiteLive.Show do
 
   @impl Phoenix.LiveView
   def handle_event("add_test_case", _params, socket) do
-    # Extract variables from prompt template
-    template =
-      socket.assigns.prompt.versions |> List.first() |> then(&if &1, do: &1.template, else: "")
-
-    variables = extract_variables(template)
-    variable_values = Map.new(variables, fn var -> {var, ""} end)
-
-    # Create new test case
-    case Evals.create_test_case(%{
-           suite_id: socket.assigns.suite.id,
-           variable_values: variable_values,
-           assertions: [%{"type" => "contains", "value" => ""}]
-         }) do
+    case TestCaseEditor.create_test_case(socket.assigns.suite.id, socket.assigns.prompt) do
       {:ok, _test_case} ->
         suite = Evals.get_suite_with_test_cases_and_prompt!(socket.assigns.suite.id)
 
@@ -194,13 +184,14 @@ defmodule Aludel.Web.SuiteLive.Show do
   @impl Phoenix.LiveView
   def handle_event("edit_test_case", %{"id" => id}, socket) do
     test_case = Evals.get_test_case!(id)
+    form_params = TestCaseEditor.build_form_params(test_case)
 
     socket =
       socket
       |> assign(:editing_test_case_id, id)
       |> assign(:editing_assertions, test_case.assertions)
-      |> assign(:editing_test_case_params, build_test_case_form_params(test_case))
-      |> assign(:test_case_form, to_form(build_test_case_form_params(test_case), as: :test_case))
+      |> assign(:editing_test_case_params, form_params)
+      |> assign(:test_case_form, to_form(form_params, as: :test_case))
       |> allow_upload(:documents,
         accept: ~w(.pdf .png .jpg .jpeg .csv .json .txt),
         max_entries: 5,
@@ -233,7 +224,7 @@ defmodule Aludel.Web.SuiteLive.Show do
 
     socket =
       if edit_mode == :visual do
-        {:ok, assertions} = parse_assertions(:visual, test_case_params)
+        {:ok, assertions} = AssertionParser.parse(:visual, test_case_params)
         assign(socket, :editing_assertions, assertions)
       else
         socket
@@ -246,26 +237,32 @@ defmodule Aludel.Web.SuiteLive.Show do
   def handle_event("save_test_case", %{"test_case" => test_case_params}, socket) do
     id = test_case_params["id"]
     test_case = Evals.get_test_case!(id)
-    variables = Map.get(test_case_params, "variable_values", %{})
-
-    # Parse assertions based on edit mode
     edit_mode = Map.get(socket.assigns.assertion_edit_mode, id, :visual)
 
-    case parse_assertions(edit_mode, test_case_params) do
-      {:ok, assertions} ->
-        attrs = %{
-          variable_values: variables,
-          assertions: assertions
-        }
+    case TestCaseEditor.update_test_case(test_case, test_case_params, edit_mode) do
+      {:ok, _test_case} ->
+        {successful_uploads, failed_uploads} = handle_test_case_uploads(socket, test_case)
+        suite = Evals.get_suite_with_test_cases_and_prompt!(socket.assigns.suite.id)
 
-        update_test_case_with_attrs(socket, test_case, attrs, test_case_params)
+        socket =
+          socket
+          |> assign(:suite, suite)
+          |> assign(:editing_test_case_id, nil)
+          |> assign(:editing_assertions, nil)
+          |> assign(:test_case_form, nil)
+          |> assign(:editing_test_case_params, nil)
 
-      {:error, message} ->
+        {:noreply, put_upload_flash(socket, successful_uploads, failed_uploads)}
+
+      {:error, message} when is_binary(message) ->
         {:noreply,
          socket
          |> assign(:test_case_form, to_form(test_case_params, as: :test_case))
          |> assign(:editing_test_case_params, test_case_params)
          |> put_flash(:error, message)}
+
+      {:error, _changeset} ->
+        {:noreply, put_flash(socket, :error, "Failed to update test case")}
     end
   end
 
@@ -331,105 +328,12 @@ defmodule Aludel.Web.SuiteLive.Show do
     end
   end
 
-  defp parse_assertions(:json, params) do
-    case Jason.decode(params["assertions_json"] || "[]") do
-      {:ok, json_assertions} when is_list(json_assertions) ->
-        case validate_assertions(json_assertions) do
-          :ok -> {:ok, json_assertions}
-          {:error, _} = error -> error
-        end
-
-      {:ok, _} ->
-        {:error, "Invalid JSON: assertions must be a list"}
-
-      {:error, %Jason.DecodeError{}} ->
-        {:error, "Invalid JSON syntax in assertions"}
-    end
-  end
-
-  defp parse_assertions(:visual, params) do
-    assertion_params = normalize_assertion_params(params["assertions"] || %{})
-
-    assertion_indices =
-      assertion_params
-      |> Map.keys()
-      |> Enum.filter(&String.starts_with?(&1, "assertion_type_"))
-      |> Enum.map(fn "assertion_type_" <> idx -> String.to_integer(idx) end)
-      |> Enum.sort()
-
-    assertions =
-      Enum.map(assertion_indices, fn idx ->
-        type = Map.get(assertion_params, "assertion_type_#{idx}")
-
-        if type == "json_field" do
-          %{
-            "type" => type,
-            "field" => Map.get(assertion_params, "assertion_field_#{idx}"),
-            "expected" => Map.get(assertion_params, "assertion_expected_#{idx}")
-          }
-        else
-          %{
-            "type" => type,
-            "value" => Map.get(assertion_params, "assertion_value_#{idx}")
-          }
-        end
-      end)
-
-    {:ok, assertions}
-  end
-
-  defp update_test_case_with_attrs(socket, test_case, attrs, _params) do
-    case Evals.update_test_case(test_case, attrs) do
-      {:ok, _test_case} ->
-        {successful_uploads, failed_uploads} = handle_test_case_uploads(socket, test_case)
-        suite = Evals.get_suite_with_test_cases_and_prompt!(socket.assigns.suite.id)
-
-        socket =
-          socket
-          |> assign(:suite, suite)
-          |> assign(:editing_test_case_id, nil)
-          |> assign(:editing_assertions, nil)
-          |> assign(:test_case_form, nil)
-          |> assign(:editing_test_case_params, nil)
-
-        {:noreply, put_upload_flash(socket, successful_uploads, failed_uploads)}
-
-      {:error, _changeset} ->
-        {:noreply, put_flash(socket, :error, "Failed to update test case")}
-    end
-  end
-
   defp handle_test_case_uploads(socket, test_case) do
     socket
     |> consume_uploaded_entries(:documents, fn %{path: path}, entry ->
-      process_test_case_upload(path, entry, test_case.id)
+      {:ok, DocumentIngestion.ingest(path, entry, test_case.id)}
     end)
     |> Enum.split_with(&successful_upload?/1)
-  end
-
-  defp process_test_case_upload(path, entry, test_case_id) do
-    {:ok, data} = File.read(path)
-
-    case FileValidation.validate(data, entry.client_type) do
-      :ok -> persist_test_case_document(entry, data, test_case_id)
-      {:error, reason} -> {:ok, {:failed, entry.client_name, reason}}
-    end
-  end
-
-  defp persist_test_case_document(entry, data, test_case_id) do
-    case Evals.create_test_case_document(%{
-           test_case_id: test_case_id,
-           filename: entry.client_name,
-           content_type: entry.client_type,
-           data: data,
-           size_bytes: entry.client_size
-         }) do
-      {:ok, _doc} ->
-        {:ok, {:success, entry.client_name}}
-
-      {:error, _changeset} ->
-        {:ok, {:failed, entry.client_name, "Database error"}}
-    end
   end
 
   defp successful_upload?({:success, _}), do: true
@@ -519,42 +423,6 @@ defmodule Aludel.Web.SuiteLive.Show do
     end
   end
 
-  defp extract_variables(template) do
-    ~r/\{\{([^}]+)\}\}/
-    |> Regex.scan(template)
-    |> Enum.map(fn [_, var] -> String.trim(var) end)
-    |> Enum.uniq()
-  end
-
-  defp validate_assertions(assertions) do
-    valid_types = ["contains", "not_contains", "regex", "exact_match", "json_field"]
-
-    assertions
-    |> Enum.with_index(1)
-    |> Enum.reduce_while(:ok, fn {assertion, idx}, _acc ->
-      type = Map.get(assertion, "type")
-
-      cond do
-        type not in valid_types ->
-          {:halt,
-           {:error,
-            "Invalid assertion type at index #{idx}: #{inspect(type)}. Must be one of: #{Enum.join(valid_types, ", ")}"}}
-
-        type == "json_field" and
-            (not Map.has_key?(assertion, "field") or not Map.has_key?(assertion, "expected")) ->
-          {:halt,
-           {:error,
-            "Assertion at index #{idx}: json_field type requires 'field' and 'expected' fields"}}
-
-        type != "json_field" and not Map.has_key?(assertion, "value") ->
-          {:halt, {:error, "Assertion at index #{idx}: #{type} type requires 'value' field"}}
-
-        true ->
-          {:cont, :ok}
-      end
-    end)
-  end
-
   defp build_run_suite_form(version_id, provider_id) do
     to_form(
       %{
@@ -564,37 +432,4 @@ defmodule Aludel.Web.SuiteLive.Show do
       as: :run_suite
     )
   end
-
-  defp build_test_case_form_params(test_case) do
-    %{
-      "id" => test_case.id,
-      "variable_values" => test_case.variable_values || %{},
-      "assertions_json" => Jason.encode!(test_case.assertions || [], pretty: true),
-      "assertions" => build_assertion_params(test_case.assertions || [])
-    }
-  end
-
-  defp build_assertion_params(assertions) do
-    assertions
-    |> Enum.with_index()
-    |> Enum.reduce(%{}, fn {assertion, idx}, acc ->
-      acc
-      |> Map.put("assertion_type_#{idx}", assertion["type"])
-      |> maybe_put_assertion_value(idx, assertion)
-    end)
-  end
-
-  defp maybe_put_assertion_value(params, idx, %{"type" => "json_field"} = assertion) do
-    params
-    |> Map.put("assertion_field_#{idx}", assertion["field"] || "")
-    |> Map.put("assertion_expected_#{idx}", assertion["expected"] || "")
-  end
-
-  defp maybe_put_assertion_value(params, idx, assertion) do
-    Map.put(params, "assertion_value_#{idx}", assertion["value"] || "")
-  end
-
-  defp normalize_assertion_params(params) when is_map(params), do: params
-  defp normalize_assertion_params(params) when is_list(params), do: Map.new(params)
-  defp normalize_assertion_params(_params), do: %{}
 end

--- a/lib/aludel/web/live/suite_live/show.html.heex
+++ b/lib/aludel/web/live/suite_live/show.html.heex
@@ -371,6 +371,17 @@
                           Types: contains, not_contains, regex, exact_match, json_field
                         </div>
                       <% end %>
+                      <%= if @test_case_form[:assertions_json].errors != [] do %>
+                        <p style="font-size: 11px; color: #dc2626; margin-top: 6px;">
+                          {Enum.map_join(
+                            @test_case_form[:assertions_json].errors,
+                            ", ",
+                            fn {message, _opts} ->
+                              message
+                            end
+                          )}
+                        </p>
+                      <% end %>
                     </div>
                   </div>
                   <div style="display: flex; gap: 8px; justify-content: flex-end;">

--- a/test/aludel/evals/assertion_parser_test.exs
+++ b/test/aludel/evals/assertion_parser_test.exs
@@ -1,0 +1,61 @@
+defmodule Aludel.Evals.AssertionParserTest do
+  use ExUnit.Case, async: true
+
+  alias Aludel.Evals.AssertionParser
+
+  describe "parse/2" do
+    test "parses JSON assertions" do
+      params = %{
+        "assertions_json" => ~s([{"type":"contains","value":"hello"}])
+      }
+
+      assert {:ok, [%{"type" => "contains", "value" => "hello"}]} =
+               AssertionParser.parse(:json, params)
+    end
+
+    test "rejects invalid JSON assertions" do
+      params = %{"assertions_json" => "{invalid json}"}
+
+      assert {:error, "Invalid JSON syntax in assertions"} =
+               AssertionParser.parse(:json, params)
+    end
+
+    test "parses visual assertions" do
+      params = %{
+        "assertions" => %{
+          "assertion_type_0" => "contains",
+          "assertion_value_0" => "hello",
+          "assertion_type_1" => "json_field",
+          "assertion_field_1" => "sentiment",
+          "assertion_expected_1" => "positive"
+        }
+      }
+
+      assert {:ok,
+              [
+                %{"type" => "contains", "value" => "hello"},
+                %{
+                  "type" => "json_field",
+                  "field" => "sentiment",
+                  "expected" => "positive"
+                }
+              ]} = AssertionParser.parse(:visual, params)
+    end
+  end
+
+  describe "build_form_params/1" do
+    test "builds JSON and visual params from assertions" do
+      assertions = [%{"type" => "contains", "value" => "hello"}]
+
+      assert %{
+               "assertions_json" => assertions_json,
+               "assertions" => %{
+                 "assertion_type_0" => "contains",
+                 "assertion_value_0" => "hello"
+               }
+             } = AssertionParser.build_form_params(assertions)
+
+      assert assertions_json =~ "\"type\": \"contains\""
+    end
+  end
+end

--- a/test/aludel/evals/assertion_parser_test.exs
+++ b/test/aludel/evals/assertion_parser_test.exs
@@ -58,6 +58,18 @@ defmodule Aludel.Evals.AssertionParserTest do
               ]} = AssertionParser.parse(:visual, params)
     end
 
+    test "rejects visual assertions with invalid indices" do
+      params = %{
+        "assertions" => %{
+          "assertion_type_abc" => "contains",
+          "assertion_value_abc" => "hello"
+        }
+      }
+
+      assert {:error, "Invalid assertion index: abc"} =
+               AssertionParser.parse(:visual, params)
+    end
+
     test "rejects json_field assertions missing expected keys" do
       params = %{
         "assertions_json" => ~s([{"type":"json_field"}])

--- a/test/aludel/evals/assertion_parser_test.exs
+++ b/test/aludel/evals/assertion_parser_test.exs
@@ -20,6 +20,22 @@ defmodule Aludel.Evals.AssertionParserTest do
                AssertionParser.parse(:json, params)
     end
 
+    test "rejects JSON assertions when the payload is not a list" do
+      params = %{"assertions_json" => ~s({"type":"contains","value":"hello"})}
+
+      assert {:error, "Invalid JSON: assertions must be a list"} =
+               AssertionParser.parse(:json, params)
+    end
+
+    test "rejects JSON assertions with an invalid type" do
+      params = %{
+        "assertions_json" => ~s([{"type":"invalid_type","value":"hello"}])
+      }
+
+      assert {:error, message} = AssertionParser.parse(:json, params)
+      assert message =~ "Invalid assertion type at index 1"
+    end
+
     test "parses visual assertions" do
       params = %{
         "assertions" => %{
@@ -40,6 +56,15 @@ defmodule Aludel.Evals.AssertionParserTest do
                   "expected" => "positive"
                 }
               ]} = AssertionParser.parse(:visual, params)
+    end
+
+    test "rejects json_field assertions missing expected keys" do
+      params = %{
+        "assertions_json" => ~s([{"type":"json_field"}])
+      }
+
+      assert {:error, message} = AssertionParser.parse(:json, params)
+      assert message =~ "json_field type requires 'field' and 'expected' fields"
     end
   end
 

--- a/test/aludel/evals/document_ingestion_test.exs
+++ b/test/aludel/evals/document_ingestion_test.exs
@@ -1,0 +1,45 @@
+defmodule Aludel.Evals.DocumentIngestionTest do
+  use Aludel.DataCase, async: true
+
+  alias Aludel.Evals
+  alias Aludel.Evals.DocumentIngestion
+
+  describe "ingest/3" do
+    test "persists a valid uploaded document" do
+      test_case = test_case_fixture()
+      path = write_temp_file("%PDF-1.4\ncontent")
+
+      entry = %Phoenix.LiveView.UploadEntry{
+        client_name: "sample.pdf",
+        client_size: byte_size("%PDF-1.4\ncontent"),
+        client_type: "application/pdf"
+      }
+
+      assert {:success, "sample.pdf"} = DocumentIngestion.ingest(path, entry, test_case.id)
+
+      document = Evals.get_test_case_with_documents!(test_case.id).documents |> List.first()
+      assert document.filename == "sample.pdf"
+      assert document.content_type == "application/pdf"
+    end
+
+    test "rejects a document when the content does not match the claimed type" do
+      test_case = test_case_fixture()
+      path = write_temp_file("not really a pdf")
+
+      entry = %Phoenix.LiveView.UploadEntry{
+        client_name: "sample.pdf",
+        client_size: byte_size("not really a pdf"),
+        client_type: "application/pdf"
+      }
+
+      assert {:failed, "sample.pdf", "File content does not match type application/pdf"} =
+               DocumentIngestion.ingest(path, entry, test_case.id)
+    end
+  end
+
+  defp write_temp_file(contents) do
+    path = Path.join(System.tmp_dir!(), "aludel-upload-#{System.unique_integer([:positive])}")
+    File.write!(path, contents)
+    path
+  end
+end

--- a/test/aludel/evals/document_ingestion_test.exs
+++ b/test/aludel/evals/document_ingestion_test.exs
@@ -58,8 +58,10 @@ defmodule Aludel.Evals.DocumentIngestionTest do
         client_type: "application/pdf"
       }
 
-      assert {:failed, "sample.pdf", "Database error"} =
+      assert {:failed, "sample.pdf", reason} =
                DocumentIngestion.ingest(path, entry, Ecto.UUID.generate())
+
+      assert reason =~ "test_case_id does not exist"
     end
   end
 

--- a/test/aludel/evals/document_ingestion_test.exs
+++ b/test/aludel/evals/document_ingestion_test.exs
@@ -35,6 +35,32 @@ defmodule Aludel.Evals.DocumentIngestionTest do
       assert {:failed, "sample.pdf", "File content does not match type application/pdf"} =
                DocumentIngestion.ingest(path, entry, test_case.id)
     end
+
+    test "returns a readable error when the upload temp file cannot be read" do
+      entry = %Phoenix.LiveView.UploadEntry{
+        client_name: "sample.pdf",
+        client_size: 0,
+        client_type: "application/pdf"
+      }
+
+      assert {:failed, "sample.pdf", reason} =
+               DocumentIngestion.ingest("/tmp/does-not-exist-aludel", entry, Ecto.UUID.generate())
+
+      assert to_string(reason) =~ "no such file or directory"
+    end
+
+    test "returns a database error when the document cannot be persisted" do
+      path = write_temp_file("%PDF-1.4\ncontent")
+
+      entry = %Phoenix.LiveView.UploadEntry{
+        client_name: "sample.pdf",
+        client_size: byte_size("%PDF-1.4\ncontent"),
+        client_type: "application/pdf"
+      }
+
+      assert {:failed, "sample.pdf", "Database error"} =
+               DocumentIngestion.ingest(path, entry, Ecto.UUID.generate())
+    end
   end
 
   defp write_temp_file(contents) do

--- a/test/aludel/evals/test_case_editor_test.exs
+++ b/test/aludel/evals/test_case_editor_test.exs
@@ -12,6 +12,15 @@ defmodule Aludel.Evals.TestCaseEditorTest do
       assert test_case.variable_values == %{"name" => "", "city" => ""}
       assert test_case.assertions == [%{"type" => "contains", "value" => ""}]
     end
+
+    test "creates a test case with empty variables when the prompt has no versions" do
+      suite = suite_fixture()
+      prompt = prompt_fixture()
+
+      assert {:ok, test_case} = TestCaseEditor.create_test_case(suite.id, prompt)
+      assert test_case.variable_values == %{}
+      assert test_case.assertions == [%{"type" => "contains", "value" => ""}]
+    end
   end
 
   describe "build_form_params/1" do
@@ -48,6 +57,24 @@ defmodule Aludel.Evals.TestCaseEditorTest do
       }
 
       assert {:ok, updated_test_case} = TestCaseEditor.update_test_case(test_case, params, :json)
+      assert updated_test_case.variable_values == %{"name" => "Alice"}
+      assert updated_test_case.assertions == [%{"type" => "contains", "value" => "updated"}]
+    end
+
+    test "updates a test case from visual assertions" do
+      test_case = test_case_fixture(%{variable_values: %{"name" => "Bob"}})
+
+      params = %{
+        "variable_values" => %{"name" => "Alice"},
+        "assertions" => %{
+          "assertion_type_0" => "contains",
+          "assertion_value_0" => "updated"
+        }
+      }
+
+      assert {:ok, updated_test_case} =
+               TestCaseEditor.update_test_case(test_case, params, :visual)
+
       assert updated_test_case.variable_values == %{"name" => "Alice"}
       assert updated_test_case.assertions == [%{"type" => "contains", "value" => "updated"}]
     end

--- a/test/aludel/evals/test_case_editor_test.exs
+++ b/test/aludel/evals/test_case_editor_test.exs
@@ -1,0 +1,66 @@
+defmodule Aludel.Evals.TestCaseEditorTest do
+  use Aludel.DataCase, async: true
+
+  alias Aludel.Evals.TestCaseEditor
+
+  describe "create_test_case/2" do
+    test "creates a test case with prompt variables and default assertions" do
+      suite = suite_fixture()
+      prompt = prompt_fixture_with_version(%{template: "Hello {{ name }} from {{city}}"})
+
+      assert {:ok, test_case} = TestCaseEditor.create_test_case(suite.id, prompt)
+      assert test_case.variable_values == %{"name" => "", "city" => ""}
+      assert test_case.assertions == [%{"type" => "contains", "value" => ""}]
+    end
+  end
+
+  describe "build_form_params/1" do
+    test "builds editable form params for a test case" do
+      test_case =
+        test_case_fixture(%{
+          variable_values: %{"name" => "Bob"},
+          assertions: [%{"type" => "contains", "value" => "hello"}]
+        })
+
+      test_case_id = test_case.id
+
+      assert %{
+               "id" => ^test_case_id,
+               "variable_values" => %{"name" => "Bob"},
+               "assertions_json" => assertions_json,
+               "assertions" => %{
+                 "assertion_type_0" => "contains",
+                 "assertion_value_0" => "hello"
+               }
+             } = TestCaseEditor.build_form_params(test_case)
+
+      assert assertions_json =~ "\"value\": \"hello\""
+    end
+  end
+
+  describe "update_test_case/3" do
+    test "updates a test case from JSON assertions" do
+      test_case = test_case_fixture(%{variable_values: %{"name" => "Bob"}})
+
+      params = %{
+        "variable_values" => %{"name" => "Alice"},
+        "assertions_json" => ~s([{"type":"contains","value":"updated"}])
+      }
+
+      assert {:ok, updated_test_case} = TestCaseEditor.update_test_case(test_case, params, :json)
+      assert updated_test_case.variable_values == %{"name" => "Alice"}
+      assert updated_test_case.assertions == [%{"type" => "contains", "value" => "updated"}]
+    end
+
+    test "returns assertion parsing errors without updating the test case" do
+      test_case = test_case_fixture()
+
+      assert {:error, "Invalid JSON syntax in assertions"} =
+               TestCaseEditor.update_test_case(
+                 test_case,
+                 %{"assertions_json" => "{invalid json}"},
+                 :json
+               )
+    end
+  end
+end

--- a/test/aludel/evals/test_case_editor_test.exs
+++ b/test/aludel/evals/test_case_editor_test.exs
@@ -47,6 +47,22 @@ defmodule Aludel.Evals.TestCaseEditorTest do
     end
   end
 
+  describe "change_form/2" do
+    test "returns a changeset-backed form with assertion errors when present" do
+      test_case = test_case_fixture()
+
+      changeset =
+        TestCaseEditor.change_form(
+          %{"id" => test_case.id, "variable_values" => %{}, "assertions_json" => "[]"},
+          action: :validate,
+          assertion_error: "Invalid assertion index: abc"
+        )
+
+      assert changeset.action == :validate
+      assert changeset.errors[:assertions_json] == {"Invalid assertion index: abc", []}
+    end
+  end
+
   describe "update_test_case/3" do
     test "updates a test case from JSON assertions" do
       test_case = test_case_fixture(%{variable_values: %{"name" => "Bob"}})

--- a/test/aludel_web/live/suite_live/show_test.exs
+++ b/test/aludel_web/live/suite_live/show_test.exs
@@ -407,6 +407,32 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
 
       assert html =~ "Invalid assertion type"
     end
+
+    test "does not crash validation when visual assertion indices are invalid", %{conn: conn} do
+      suite = suite_fixture()
+      test_case = test_case_fixture(%{suite_id: suite.id})
+
+      {:ok, view, _html} = live(conn, "/suites/#{suite.id}")
+
+      view
+      |> element("[phx-click='edit_test_case']")
+      |> render_click(%{"id" => test_case.id})
+
+      html =
+        render_change(view, "validate_test_case", %{
+          "test_case" => %{
+            "id" => test_case.id,
+            "variable_values" => %{},
+            "assertions" => %{
+              "assertion_type_abc" => "contains",
+              "assertion_value_abc" => "hello"
+            }
+          }
+        })
+
+      assert html =~ "Invalid assertion index: abc"
+      assert Process.alive?(view.pid)
+    end
   end
 
   describe "suite metadata management" do


### PR DESCRIPTION
## Motivation (required)

Closes #59.

`Aludel.Web.SuiteLive.Show` was carrying assertion parsing, test-case update orchestration, and document ingestion logic that belongs below the LiveView layer. This refactor keeps the current UI behavior but moves those workflows into focused application-layer modules so the LiveView remains a thinner UI adapter.

This follows the conservative extraction direction discussed on the issue:

- `Aludel.Evals.AssertionParser` owns assertion payload parsing and validation
- `Aludel.Evals.DocumentIngestion` owns uploaded document validation and persistence
- `Aludel.Evals.TestCaseEditor` owns test-case form shaping, default test-case creation, and test-case update orchestration

## Test Plan (required)

Commands run:

```bash
mix test test/aludel/evals/assertion_parser_test.exs test/aludel/evals/document_ingestion_test.exs test/aludel/evals/test_case_editor_test.exs test/aludel_web/live/suite_live/show_test.exs
mix precommit
```

Observed results:

- Targeted suite-editor extraction tests passed: `40 tests, 0 failures`
- Full precommit checks passed: `444 tests, 0 failures`
- Credo reported no issues
- Sobelow completed with an existing warning about not auto-detecting the router

## Next Steps

This keeps the extraction incremental for the suite editor surface. If we continue the architecture work under #61, the next step is to apply the same boundary cleanup to the suite creation flow so the parsing/orchestration logic stops being duplicated across LiveViews.
