### PR TITLE
fix: sync suite prompt preview with selected version

### DIFF
--- a/lib/aludel/web/live/suite_live/show.ex
+++ b/lib/aludel/web/live/suite_live/show.ex
@@ -42,6 +42,7 @@ defmodule Aludel.Web.SuiteLive.Show do
       |> assign(:page_title, suite.name)
       |> assign(:suite, suite)
       |> assign(:prompt, prompt)
+      |> assign(:selected_prompt_version, selected_prompt_version(prompt, default_version_id))
       |> assign(:all_prompts, all_prompts)
       |> assign(:projects, projects)
       |> assign(:providers, providers)
@@ -96,12 +97,19 @@ defmodule Aludel.Web.SuiteLive.Show do
     case Evals.update_suite(socket.assigns.suite, suite_params) do
       {:ok, suite} ->
         prompt = Prompts.get_prompt_with_versions!(suite.prompt_id)
+        default_version_id = List.first(prompt.versions) |> then(&if &1, do: &1.id, else: nil)
 
         {:noreply,
          socket
          |> assign(:suite, suite)
          |> assign(:prompt, prompt)
+         |> assign(:selected_version_id, default_version_id)
+         |> assign(:selected_prompt_version, selected_prompt_version(prompt, default_version_id))
          |> assign(:page_title, suite.name)
+         |> assign(
+           :run_suite_form,
+           build_run_suite_form(default_version_id, socket.assigns.selected_provider_id)
+         )
          |> assign(:editing_suite_metadata, false)
          |> put_flash(:info, "Suite updated successfully")}
 
@@ -115,6 +123,10 @@ defmodule Aludel.Web.SuiteLive.Show do
     {:noreply,
      socket
      |> assign(:selected_version_id, version_id)
+     |> assign(
+       :selected_prompt_version,
+       selected_prompt_version(socket.assigns.prompt, version_id)
+     )
      |> assign(
        :run_suite_form,
        build_run_suite_form(version_id, socket.assigns.selected_provider_id)
@@ -141,6 +153,10 @@ defmodule Aludel.Web.SuiteLive.Show do
      socket
      |> assign(:selected_version_id, version_id)
      |> assign(:selected_provider_id, provider_id)
+     |> assign(
+       :selected_prompt_version,
+       selected_prompt_version(socket.assigns.prompt, version_id)
+     )
      |> assign(:run_suite_form, to_form(run_suite_params, as: :run_suite))}
   end
 
@@ -467,5 +483,11 @@ defmodule Aludel.Web.SuiteLive.Show do
       },
       as: :run_suite
     )
+  end
+
+  defp selected_prompt_version(%{versions: versions}, version_id) when is_list(versions) do
+    Enum.find(versions, List.first(versions), fn version ->
+      to_string(version.id) == to_string(version_id)
+    end)
   end
 end

--- a/lib/aludel/web/live/suite_live/show.html.heex
+++ b/lib/aludel/web/live/suite_live/show.html.heex
@@ -122,7 +122,10 @@
       <%= if @prompt.versions != [] do %>
         <div style="margin-bottom: 24px;">
           <h3 style="font-size: 14px; font-weight: 600; margin-bottom: 8px;">Prompt Template</h3>
-          <pre style="background-color: var(--bg-tertiary); border: 1px solid var(--border); padding: 12px; border-radius: 6px; font-size: 12px; line-height: 1.5; overflow-x: auto; white-space: pre-wrap; word-wrap: break-word; color: var(--text-secondary);"><%= List.first(@prompt.versions).template %></pre>
+          <pre
+            id="selected-prompt-template"
+            style="background-color: var(--bg-tertiary); border: 1px solid var(--border); padding: 12px; border-radius: 6px; font-size: 12px; line-height: 1.5; overflow-x: auto; white-space: pre-wrap; word-wrap: break-word; color: var(--text-secondary);"
+          >{@selected_prompt_version.template}</pre>
         </div>
       <% end %>
     </div>

--- a/test/aludel_web/live/suite_live/show_test.exs
+++ b/test/aludel_web/live/suite_live/show_test.exs
@@ -195,18 +195,26 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
     end
 
     test "selects a specific version", %{conn: conn} do
-      prompt = prompt_fixture_with_version()
+      prompt = prompt_fixture_with_version(%{template: "Version 1 {{name}}"})
       suite = suite_fixture(%{prompt_id: prompt.id})
-      version = List.first(prompt.versions)
+      provider = provider_fixture()
+      {:ok, _version} = Aludel.Prompts.create_prompt_version(prompt, "Version 2 {{name}}")
+      prompt = Aludel.Prompts.get_prompt_with_versions!(prompt.id)
 
       {:ok, view, _html} = live(conn, "/suites/#{suite.id}")
 
-      render_click(view, "select_version", %{"version_id" => version.id})
+      assert has_element?(view, "#selected-prompt-template", "Version 2 {{name}}")
 
-      # Version selection should update assigns
-      state = :sys.get_state(view.pid)
-      socket = state.socket
-      assert socket.assigns.selected_version_id == version.id
+      view
+      |> form("#run-suite-form",
+        run_suite: %{
+          version_id: List.last(prompt.versions).id,
+          provider_id: provider.id
+        }
+      )
+      |> render_change()
+
+      assert has_element?(view, "#selected-prompt-template", "Version 1 {{name}}")
     end
 
     test "selects a specific provider", %{conn: conn} do

--- a/test/aludel_web/live/suite_live/show_test.exs
+++ b/test/aludel_web/live/suite_live/show_test.exs
@@ -200,6 +200,7 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
       provider = provider_fixture()
       {:ok, _version} = Aludel.Prompts.create_prompt_version(prompt, "Version 2 {{name}}")
       prompt = Aludel.Prompts.get_prompt_with_versions!(prompt.id)
+      version_1 = Enum.find(prompt.versions, &(&1.template == "Version 1 {{name}}"))
 
       {:ok, view, _html} = live(conn, "/suites/#{suite.id}")
 
@@ -208,7 +209,7 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
       view
       |> form("#run-suite-form",
         run_suite: %{
-          version_id: List.last(prompt.versions).id,
+          version_id: version_1.id,
           provider_id: provider.id
         }
       )


### PR DESCRIPTION
## Motivation (required)

Changing the prompt version on the suite show page updated the selected version used for execution, but the prompt template preview still always showed the first version in the prompt list. This made the UI inconsistent and could mislead users into thinking they were about to run a different template than the one actually selected.

This change makes the preview follow the currently selected prompt version and adds a regression test for that behavior.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prompt view now shows the actively selected prompt version in the suite interface.

* **Bug Fixes**
  * Selection and form flows consistently preserve and display the chosen prompt version after saves and validations.

* **Tests**
  * Improved tests to verify prompt version selection and the rendered prompt template in the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->