### PR TITLE
refactor: move run execution into supervised executor

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -11,6 +11,10 @@ config :aludel,
   generators: [timestamp_type: :utc_datetime, binary_id: true],
   run_execution_mode: :concurrent
 
+config :aludel, :llm,
+  max_concurrency: 3,
+  request_timeout_ms: 120_000
+
 # Configures the endpoint
 config :aludel, Aludel.Web.Endpoint,
   url: [host: "localhost"],

--- a/coveralls.json
+++ b/coveralls.json
@@ -26,6 +26,7 @@
     "lib/aludel/web/assets.ex",
     "lib/aludel/interfaces/document_converter/adapters/imagemagick.ex",
     "lib/aludel/interfaces/llm/adapters/http/default.ex",
+    "lib/aludel/runs/execution.ex",
     "lib/mix/tasks/"
   ],
   "custom_skip_files": [

--- a/lib/aludel/application.ex
+++ b/lib/aludel/application.ex
@@ -9,6 +9,7 @@ defmodule Aludel.Application do
   def start(_type, _args) do
     children = [
       {Phoenix.PubSub, name: Aludel.PubSub},
+      {Task.Supervisor, name: Aludel.Runs.ExecutorSupervisor},
       {Task.Supervisor, name: Aludel.TaskSupervisor}
     ]
 

--- a/lib/aludel/runs.ex
+++ b/lib/aludel/runs.ex
@@ -3,17 +3,12 @@ defmodule Aludel.Runs do
   Context for managing runs and run results.
   """
 
-  require Logger
-
   import Ecto.Query
 
   alias Aludel.Evals.SuiteRun
-  alias Aludel.LLM
   alias Aludel.Providers.Provider
-  alias Aludel.PubSub
-  alias Aludel.Runs.{Run, RunResult}
+  alias Aludel.Runs.{Execution, Executor, Run, RunResult}
   alias Aludel.Stats.Shared
-  alias Aludel.TaskSupervisor
   alias Ecto.Changeset
 
   @doc """
@@ -136,124 +131,20 @@ defmodule Aludel.Runs do
   end
 
   @doc """
-  Executes a run against multiple providers concurrently.
-
-  Renders the prompt template with variable values, calls each
-  provider's LLM, broadcasts real-time updates via PubSub, and
-  creates run_results for each provider.
-
-  ## Parameters
-    - run: Run struct with preloaded prompt_version
-    - providers: List of provider structs to execute against
-
-  ## Returns
-    - `{:ok, run}` with preloaded run_results on success
-    - `{:error, reason}` if execution fails
-
-  ## Examples
-
-      iex> run = Repo.preload(run, :prompt_version)
-      iex> {:ok, executed_run} = execute_run(run, [provider1, provider2])
-      iex> length(executed_run.run_results)
-      2
+  Launches a run under the executor supervisor.
   """
-  @spec execute_run(Run.t(), list(Provider.t())) ::
-          {:ok, Run.t()} | {:error, term()}
+  @spec launch_run(Run.t(), [Provider.t()]) :: DynamicSupervisor.on_start_child()
+  def launch_run(%Run{} = run, providers) when is_list(providers) do
+    Executor.launch(run, providers)
+  end
+
+  @doc """
+  Executes a run through the executor service and returns a structured outcome.
+  """
+  @spec execute_run(Run.t(), [Provider.t()]) ::
+          {:ok, Execution.t()} | {:error, term()}
   def execute_run(%Run{} = run, providers) when is_list(providers) do
-    rendered_prompt =
-      render_template(
-        run.prompt_version.template,
-        run.variable_values
-      )
-
-    _results =
-      case Application.get_env(:aludel, :run_execution_mode, :concurrent) do
-        :sequential ->
-          Enum.map(providers, fn provider ->
-            execute_provider(run, provider, rendered_prompt)
-          end)
-
-        _ ->
-          Task.Supervisor.async_stream(
-            TaskSupervisor,
-            providers,
-            fn provider ->
-              execute_provider(run, provider, rendered_prompt)
-            end,
-            max_concurrency: 3,
-            timeout: 120_000
-          )
-          |> Enum.to_list()
-      end
-
-    case repo().get(Run, run.id) do
-      nil -> {:error, :run_not_found}
-      updated_run -> {:ok, repo().preload(updated_run, :run_results)}
-    end
-  end
-
-  # Private helper functions
-
-  defp render_template(template, variable_values) do
-    Enum.reduce(variable_values, template, fn {key, value}, acc ->
-      String.replace(acc, "{{#{key}}}", value)
-    end)
-  end
-
-  defp execute_provider(run, provider, rendered_prompt) do
-    case LLM.call(provider, rendered_prompt) do
-      {:ok, result} ->
-        case create_run_result(%{
-               run_id: run.id,
-               provider_id: provider.id,
-               output: result.output,
-               input_tokens: result.input_tokens,
-               output_tokens: result.output_tokens,
-               latency_ms: result.latency_ms,
-               cost_usd: result.cost_usd,
-               status: :completed
-             }) do
-          {:ok, run_result} ->
-            broadcast_update(run.id, run_result.id, :completed, result.output)
-            {:ok, run_result}
-
-          {:error, changeset} ->
-            Logger.warning("Failed to create run result for run #{run.id}",
-              reason: inspect(changeset.errors),
-              provider_id: provider.id
-            )
-
-            {:ok, nil}
-        end
-
-      {:error, reason} ->
-        case create_run_result(%{
-               run_id: run.id,
-               provider_id: provider.id,
-               status: :error,
-               error: inspect(reason)
-             }) do
-          {:ok, run_result} ->
-            broadcast_update(run.id, run_result.id, :error, inspect(reason))
-            {:error, reason}
-
-          {:error, changeset} ->
-            Logger.warning("Failed to create run result for run #{run.id}",
-              reason: inspect(changeset.errors),
-              provider_id: provider.id
-            )
-
-            {:error, reason}
-        end
-    end
-  end
-
-  defp broadcast_update(run_id, result_id, status, output) do
-    Phoenix.PubSub.broadcast(
-      PubSub,
-      "run:#{run_id}",
-      {:run_result_update, result_id, status, output}
-    )
+    Executor.execute(run, providers)
   end
 
   defp repo, do: Aludel.Repo.get()

--- a/lib/aludel/runs/execution.ex
+++ b/lib/aludel/runs/execution.ex
@@ -1,0 +1,26 @@
+defmodule Aludel.Runs.Execution do
+  @moduledoc """
+  Result of executing a run across one or more providers.
+  """
+
+  alias Aludel.Runs.{Run, RunResult}
+
+  @enforce_keys [:failures, :provider_results, :run, :status]
+
+  @type failure :: %{
+          provider_id: Ecto.UUID.t(),
+          provider_name: String.t(),
+          reason: term()
+        }
+
+  @type status :: :ok | :partial_failure | :error
+
+  @type t :: %__MODULE__{
+          failures: [failure()],
+          provider_results: [RunResult.t()],
+          run: Run.t(),
+          status: status()
+        }
+
+  defstruct [:failures, :provider_results, :run, :status]
+end

--- a/lib/aludel/runs/executor.ex
+++ b/lib/aludel/runs/executor.ex
@@ -15,12 +15,15 @@ defmodule Aludel.Runs.Executor do
   @default_max_concurrency 3
   @default_timeout_ms 120_000
 
-  @type execution_result :: {:ok, Execution.t()} | {:error, term()}
+  @type execution_result :: {:ok, Execution.t()} | {:error, :empty_providers | term()}
 
   @doc """
   Launches a run under the executor supervisor.
   """
-  @spec launch(Run.t(), [Provider.t()]) :: DynamicSupervisor.on_start_child()
+  @spec launch(Run.t(), [Provider.t()]) ::
+          DynamicSupervisor.on_start_child() | {:error, :empty_providers}
+  def launch(%Run{}, []), do: {:error, :empty_providers}
+
   def launch(%Run{} = run, providers) when is_list(providers) do
     Task.Supervisor.start_child(@execution_supervisor, fn ->
       case execute(run, providers) do
@@ -47,6 +50,8 @@ defmodule Aludel.Runs.Executor do
   Executes a run against one or more providers and returns a structured outcome.
   """
   @spec execute(Run.t(), [Provider.t()]) :: execution_result()
+  def execute(%Run{}, []), do: {:error, :empty_providers}
+
   def execute(%Run{} = run, providers) when is_list(providers) do
     run = preload_prompt_version(run)
     rendered_prompt = render_template(run.prompt_version.template, run.variable_values)
@@ -101,7 +106,7 @@ defmodule Aludel.Runs.Executor do
         {provider, outcome}
 
       {provider, {:exit, reason}} ->
-        {provider, {:error, provider_failure(provider, {:task_exit, reason})}}
+        {provider, create_error_result(run, provider, {:task_exit, reason})}
     end)
   end
 
@@ -137,14 +142,16 @@ defmodule Aludel.Runs.Executor do
   end
 
   defp create_error_result(run, provider, reason) do
+    inspected_reason = inspect(reason)
+
     case create_run_result(%{
            run_id: run.id,
            provider_id: provider.id,
            status: :error,
-           error: inspect(reason)
+           error: inspected_reason
          }) do
       {:ok, run_result} ->
-        broadcast_update(run.id, run_result.id, :error, inspect(reason))
+        broadcast_update(run.id, run_result.id, :error, inspected_reason)
         {:error, provider_failure(provider, reason)}
 
       {:error, changeset} ->

--- a/lib/aludel/runs/executor.ex
+++ b/lib/aludel/runs/executor.ex
@@ -41,7 +41,7 @@ defmodule Aludel.Runs.Executor do
         {:error, reason} ->
           Logger.error("Run execution failed for run #{run.id}: #{inspect(reason)}")
 
-          :error
+          exit({:run_execution_failed, reason})
       end
     end)
   end

--- a/lib/aludel/runs/executor.ex
+++ b/lib/aludel/runs/executor.ex
@@ -21,7 +21,7 @@ defmodule Aludel.Runs.Executor do
   Launches a run under the executor supervisor.
   """
   @spec launch(Run.t(), [Provider.t()]) ::
-          DynamicSupervisor.on_start_child() | {:error, :empty_providers}
+          Task.Supervisor.on_start_child() | {:error, :empty_providers | term()}
   def launch(%Run{}, []), do: {:error, :empty_providers}
 
   def launch(%Run{} = run, providers) when is_list(providers) do
@@ -54,10 +54,11 @@ defmodule Aludel.Runs.Executor do
 
   def execute(%Run{} = run, providers) when is_list(providers) do
     run = preload_prompt_version(run)
-    rendered_prompt = render_template(run.prompt_version.template, run.variable_values)
-    provider_outcomes = execute_providers(run, providers, rendered_prompt)
 
-    with {:ok, updated_run} <- reload_run(run.id) do
+    with :ok <- validate_variable_values(run.prompt_version.variables, run.variable_values),
+         rendered_prompt <- render_template(run.prompt_version.template, run.variable_values),
+         provider_outcomes <- execute_providers(run, providers, rendered_prompt),
+         {:ok, updated_run} <- reload_run(run.id) do
       failures = collect_failures(provider_outcomes)
 
       {:ok,
@@ -197,9 +198,24 @@ defmodule Aludel.Runs.Executor do
     end
   end
 
+  defp validate_variable_values(expected_variables, variable_values) do
+    missing_variables =
+      Enum.reject(expected_variables, fn variable ->
+        Map.has_key?(variable_values, variable)
+      end)
+
+    case missing_variables do
+      [] ->
+        :ok
+
+      _missing_variables ->
+        {:error, {:missing_variables, missing_variables}}
+    end
+  end
+
   defp render_template(template, variable_values) do
     Enum.reduce(variable_values, template, fn {key, value}, acc ->
-      String.replace(acc, "{{#{key}}}", value)
+      String.replace(acc, "{{#{key}}}", to_string(value))
     end)
   end
 

--- a/lib/aludel/runs/executor.ex
+++ b/lib/aludel/runs/executor.ex
@@ -1,0 +1,244 @@
+defmodule Aludel.Runs.Executor do
+  @moduledoc """
+  Owns run launch and provider execution under explicit supervision.
+  """
+
+  require Logger
+
+  alias Aludel.LLM
+  alias Aludel.Providers.Provider
+  alias Aludel.PubSub
+  alias Aludel.Runs.{Execution, Run, RunResult}
+  alias Ecto.Changeset
+
+  @execution_supervisor Aludel.Runs.ExecutorSupervisor
+  @default_max_concurrency 3
+  @default_timeout_ms 120_000
+
+  @type execution_result :: {:ok, Execution.t()} | {:error, term()}
+
+  @doc """
+  Launches a run under the executor supervisor.
+  """
+  @spec launch(Run.t(), [Provider.t()]) :: DynamicSupervisor.on_start_child()
+  def launch(%Run{} = run, providers) when is_list(providers) do
+    Task.Supervisor.start_child(@execution_supervisor, fn ->
+      case execute(run, providers) do
+        {:ok, %Execution{status: :ok}} ->
+          :ok
+
+        {:ok, %Execution{status: status, failures: failures}} ->
+          Logger.warning(
+            "Run execution completed with provider failures for run #{run.id} " <>
+              "(status=#{status}, failures=#{inspect(failures)})"
+          )
+
+          :ok
+
+        {:error, reason} ->
+          Logger.error("Run execution failed for run #{run.id}: #{inspect(reason)}")
+
+          :error
+      end
+    end)
+  end
+
+  @doc """
+  Executes a run against one or more providers and returns a structured outcome.
+  """
+  @spec execute(Run.t(), [Provider.t()]) :: execution_result()
+  def execute(%Run{} = run, providers) when is_list(providers) do
+    with {:ok, run} <- preload_prompt_version(run),
+         rendered_prompt <- render_template(run.prompt_version.template, run.variable_values),
+         provider_outcomes <- execute_providers(run, providers, rendered_prompt),
+         {:ok, updated_run} <- reload_run(run.id) do
+      failures = collect_failures(provider_outcomes)
+
+      {:ok,
+       %Execution{
+         failures: failures,
+         provider_results: updated_run.run_results,
+         run: updated_run,
+         status: execution_status(length(providers), length(failures))
+       }}
+    end
+  end
+
+  defp preload_prompt_version(%Run{} = run) do
+    run =
+      if Ecto.assoc_loaded?(run.prompt_version) && run.prompt_version do
+        run
+      else
+        repo().preload(run, :prompt_version)
+      end
+
+    case run.prompt_version do
+      nil -> {:error, :prompt_version_not_loaded}
+      _prompt_version -> {:ok, run}
+    end
+  end
+
+  defp execute_providers(run, providers, rendered_prompt) do
+    case execution_mode() do
+      :sequential ->
+        Enum.map(providers, fn provider ->
+          {provider, execute_provider(run, provider, rendered_prompt)}
+        end)
+
+      _mode ->
+        stream_provider_executions(run, providers, rendered_prompt)
+    end
+  end
+
+  defp stream_provider_executions(run, providers, rendered_prompt) do
+    providers
+    |> Enum.zip(
+      Task.Supervisor.async_stream_nolink(
+        @execution_supervisor,
+        providers,
+        fn provider ->
+          execute_provider(run, provider, rendered_prompt)
+        end,
+        max_concurrency: execution_max_concurrency(),
+        timeout: execution_timeout_ms()
+      )
+    )
+    |> Enum.map(fn
+      {provider, {:ok, outcome}} ->
+        {provider, outcome}
+
+      {provider, {:exit, reason}} ->
+        {provider, {:error, provider_failure(provider, {:task_exit, reason})}}
+    end)
+  end
+
+  defp execute_provider(run, provider, rendered_prompt) do
+    case LLM.call(provider, rendered_prompt) do
+      {:ok, result} ->
+        create_completed_result(run, provider, result)
+
+      {:error, reason} ->
+        create_error_result(run, provider, reason)
+    end
+  end
+
+  defp create_completed_result(run, provider, result) do
+    case create_run_result(%{
+           run_id: run.id,
+           provider_id: provider.id,
+           output: result.output,
+           input_tokens: result.input_tokens,
+           output_tokens: result.output_tokens,
+           latency_ms: result.latency_ms,
+           cost_usd: result.cost_usd,
+           status: :completed
+         }) do
+      {:ok, run_result} ->
+        broadcast_update(run.id, run_result.id, :completed, result.output)
+        {:ok, run_result}
+
+      {:error, changeset} ->
+        log_run_result_failure(run.id, provider.id, changeset)
+        {:error, provider_failure(provider, {:result_persistence_failed, changeset.errors})}
+    end
+  end
+
+  defp create_error_result(run, provider, reason) do
+    case create_run_result(%{
+           run_id: run.id,
+           provider_id: provider.id,
+           status: :error,
+           error: inspect(reason)
+         }) do
+      {:ok, run_result} ->
+        broadcast_update(run.id, run_result.id, :error, inspect(reason))
+        {:error, provider_failure(provider, reason)}
+
+      {:error, changeset} ->
+        log_run_result_failure(run.id, provider.id, changeset)
+        {:error, provider_failure(provider, {:result_persistence_failed, changeset.errors})}
+    end
+  end
+
+  defp collect_failures(provider_outcomes) do
+    Enum.reduce(provider_outcomes, [], fn
+      {_provider, {:ok, _run_result}}, failures ->
+        failures
+
+      {_provider, {:error, failure}}, failures ->
+        [failure | failures]
+    end)
+    |> Enum.reverse()
+  end
+
+  defp execution_status(_provider_count, 0), do: :ok
+
+  defp execution_status(provider_count, failure_count) when provider_count == failure_count do
+    :error
+  end
+
+  defp execution_status(_provider_count, _failure_count), do: :partial_failure
+
+  defp provider_failure(provider, reason) do
+    %{
+      provider_id: provider.id,
+      provider_name: provider.name,
+      reason: reason
+    }
+  end
+
+  defp reload_run(run_id) do
+    case repo().get(Run, run_id) do
+      nil ->
+        {:error, :run_not_found}
+
+      run ->
+        {:ok, repo().preload(run, prompt_version: :prompt, run_results: :provider)}
+    end
+  end
+
+  defp render_template(template, variable_values) do
+    Enum.reduce(variable_values, template, fn {key, value}, acc ->
+      String.replace(acc, "{{#{key}}}", value)
+    end)
+  end
+
+  defp create_run_result(attrs) do
+    %RunResult{}
+    |> RunResult.changeset(attrs)
+    |> repo().insert()
+  end
+
+  defp log_run_result_failure(run_id, provider_id, %Changeset{} = changeset) do
+    Logger.warning("Failed to create run result for run #{run_id}",
+      provider_id: provider_id,
+      reason: inspect(changeset.errors)
+    )
+  end
+
+  defp broadcast_update(run_id, result_id, status, output) do
+    Phoenix.PubSub.broadcast(
+      PubSub,
+      "run:#{run_id}",
+      {:run_result_update, result_id, status, output}
+    )
+  end
+
+  defp execution_mode do
+    Application.get_env(:aludel, :run_execution_mode, :concurrent)
+  end
+
+  defp execution_max_concurrency do
+    Keyword.get(llm_config(), :max_concurrency, @default_max_concurrency)
+  end
+
+  defp execution_timeout_ms do
+    Keyword.get(llm_config(), :request_timeout_ms, @default_timeout_ms)
+  end
+
+  defp llm_config do
+    Application.get_env(:aludel, :llm, [])
+  end
+
+  defp repo, do: Aludel.Repo.get()
+end

--- a/lib/aludel/runs/executor.ex
+++ b/lib/aludel/runs/executor.ex
@@ -21,7 +21,7 @@ defmodule Aludel.Runs.Executor do
   Launches a run under the executor supervisor.
   """
   @spec launch(Run.t(), [Provider.t()]) ::
-          Task.Supervisor.on_start_child() | {:error, :empty_providers | term()}
+          {:ok, pid()} | {:ok, pid(), term()} | {:error, :empty_providers | term()}
   def launch(%Run{}, []), do: {:error, :empty_providers}
 
   def launch(%Run{} = run, providers) when is_list(providers) do

--- a/lib/aludel/runs/executor.ex
+++ b/lib/aludel/runs/executor.ex
@@ -48,10 +48,11 @@ defmodule Aludel.Runs.Executor do
   """
   @spec execute(Run.t(), [Provider.t()]) :: execution_result()
   def execute(%Run{} = run, providers) when is_list(providers) do
-    with {:ok, run} <- preload_prompt_version(run),
-         rendered_prompt <- render_template(run.prompt_version.template, run.variable_values),
-         provider_outcomes <- execute_providers(run, providers, rendered_prompt),
-         {:ok, updated_run} <- reload_run(run.id) do
+    run = preload_prompt_version(run)
+    rendered_prompt = render_template(run.prompt_version.template, run.variable_values)
+    provider_outcomes = execute_providers(run, providers, rendered_prompt)
+
+    with {:ok, updated_run} <- reload_run(run.id) do
       failures = collect_failures(provider_outcomes)
 
       {:ok,
@@ -64,19 +65,10 @@ defmodule Aludel.Runs.Executor do
     end
   end
 
-  defp preload_prompt_version(%Run{} = run) do
-    run =
-      if Ecto.assoc_loaded?(run.prompt_version) && run.prompt_version do
-        run
-      else
-        repo().preload(run, :prompt_version)
-      end
+  defp preload_prompt_version(%Run{prompt_version: %Ecto.Association.NotLoaded{}} = run),
+    do: repo().preload(run, :prompt_version)
 
-    case run.prompt_version do
-      nil -> {:error, :prompt_version_not_loaded}
-      _prompt_version -> {:ok, run}
-    end
-  end
+  defp preload_prompt_version(%Run{} = run), do: run
 
   defp execute_providers(run, providers, rendered_prompt) do
     case execution_mode() do

--- a/lib/aludel/runs/executor.ex
+++ b/lib/aludel/runs/executor.ex
@@ -65,8 +65,9 @@ defmodule Aludel.Runs.Executor do
     end
   end
 
-  defp preload_prompt_version(%Run{prompt_version: %Ecto.Association.NotLoaded{}} = run),
-    do: repo().preload(run, :prompt_version)
+  defp preload_prompt_version(%Run{prompt_version: %Ecto.Association.NotLoaded{}} = run) do
+    repo().preload(run, :prompt_version)
+  end
 
   defp preload_prompt_version(%Run{} = run), do: run
 

--- a/lib/aludel/web/live/run_live/new.ex
+++ b/lib/aludel/web/live/run_live/new.ex
@@ -134,16 +134,18 @@ defmodule Aludel.Web.RunLive.New do
             Providers.get_provider!(id)
           end)
 
-        run_with_version = %{run | prompt_version: socket.assigns.prompt_version}
+        case Runs.launch_run(run, providers) do
+          {:ok, _pid} ->
+            {:noreply,
+             socket
+             |> put_flash(:info, "Run launched successfully")
+             |> push_navigate(to: aludel_path("runs/#{run.id}"))}
 
-        Task.start(fn ->
-          Runs.execute_run(run_with_version, providers)
-        end)
-
-        {:noreply,
-         socket
-         |> put_flash(:info, "Run launched successfully")
-         |> push_navigate(to: aludel_path("runs/#{run.id}"))}
+          {:error, reason} ->
+            {:noreply,
+             socket
+             |> put_flash(:error, "Failed to launch run: #{inspect(reason)}")}
+        end
 
       {:error, changeset} ->
         {:noreply,

--- a/test/aludel/runs/executor_test.exs
+++ b/test/aludel/runs/executor_test.exs
@@ -1,0 +1,70 @@
+defmodule Aludel.Runs.ExecutorTest do
+  use Aludel.DataCase
+
+  import Mox
+
+  alias Aludel.Interfaces.HttpClientMock
+  alias Aludel.Runs.Execution
+  alias Aludel.Runs.Executor
+
+  import Aludel.PromptsFixtures
+  import Aludel.ProvidersFixtures
+
+  setup :set_mox_global
+  setup :verify_on_exit!
+
+  describe "execute/2" do
+    setup do
+      prompt = prompt_fixture()
+      {:ok, version} = Aludel.Prompts.create_prompt_version(prompt, "Hello {{user}}")
+
+      {:ok, run} =
+        Aludel.Runs.create_run(%{
+          prompt_version_id: version.id,
+          variable_values: %{"user" => "Alice"}
+        })
+
+      {:ok, run: Repo.preload(run, :prompt_version)}
+    end
+
+    test "returns a successful execution with persisted provider results", %{run: run} do
+      provider = provider_fixture()
+      mock_response = build_mock_response("Hello Alice", 5, 10)
+
+      expect(HttpClientMock, :request, fn _model, _prompt, _opts ->
+        {:ok, mock_response}
+      end)
+
+      assert {:ok, %Execution{} = execution} = Executor.execute(run, [provider])
+      assert execution.status == :ok
+      assert execution.failures == []
+      assert length(execution.provider_results) == 1
+      assert hd(execution.provider_results).status == :completed
+    end
+
+    test "returns a partial failure when provider outcomes are mixed", %{run: run} do
+      provider1 = provider_fixture(%{name: "Provider 1", model: "provider-1-model"})
+      provider2 = provider_fixture(%{name: "Provider 2", model: "provider-2-model"})
+
+      expect(HttpClientMock, :request, 2, fn provider_model, _prompt, _opts ->
+        case provider_model do
+          "openai:provider-1-model" -> {:ok, build_mock_response("Hello Alice", 5, 10)}
+          "openai:provider-2-model" -> {:error, "API timeout"}
+        end
+      end)
+
+      assert {:ok, %Execution{} = execution} = Executor.execute(run, [provider1, provider2])
+      assert execution.status == :partial_failure
+      assert length(execution.failures) == 1
+      assert length(execution.provider_results) == 2
+    end
+  end
+
+  defp build_mock_response(text, input_tokens, output_tokens) do
+    %{
+      content: text,
+      input_tokens: input_tokens,
+      output_tokens: output_tokens
+    }
+  end
+end

--- a/test/aludel/runs/executor_test.exs
+++ b/test/aludel/runs/executor_test.exs
@@ -46,6 +46,13 @@ defmodule Aludel.Runs.ExecutorTest do
       assert {:error, :empty_providers} = Executor.execute(run, [])
     end
 
+    test "rejects runs with missing template variables", %{run: run} do
+      run = %{run | variable_values: %{}}
+
+      assert {:error, {:missing_variables, ["user"]}} =
+               Executor.execute(run, [provider_fixture()])
+    end
+
     test "returns a partial failure when provider outcomes are mixed", %{run: run} do
       provider1 = provider_fixture(%{name: "Provider 1", model: "provider-1-model"})
       provider2 = provider_fixture(%{name: "Provider 2", model: "provider-2-model"})
@@ -53,7 +60,7 @@ defmodule Aludel.Runs.ExecutorTest do
       expect(HttpClientMock, :request, 2, fn provider_model, _prompt, _opts ->
         case provider_model do
           "openai:provider-1-model" -> {:ok, build_mock_response("Hello Alice", 5, 10)}
-          "openai:provider-2-model" -> {:error, "API timeout"}
+          "openai:provider-2-model" -> {:error, {:network_error, :timeout}}
         end
       end)
 

--- a/test/aludel/runs/executor_test.exs
+++ b/test/aludel/runs/executor_test.exs
@@ -42,6 +42,10 @@ defmodule Aludel.Runs.ExecutorTest do
       assert hd(execution.provider_results).status == :completed
     end
 
+    test "rejects empty provider lists", %{run: run} do
+      assert {:error, :empty_providers} = Executor.execute(run, [])
+    end
+
     test "returns a partial failure when provider outcomes are mixed", %{run: run} do
       provider1 = provider_fixture(%{name: "Provider 1", model: "provider-1-model"})
       provider2 = provider_fixture(%{name: "Provider 2", model: "provider-2-model"})
@@ -57,6 +61,49 @@ defmodule Aludel.Runs.ExecutorTest do
       assert execution.status == :partial_failure
       assert length(execution.failures) == 1
       assert length(execution.provider_results) == 2
+    end
+
+    test "persists task exits in concurrent execution", %{run: run} do
+      original_mode = Application.get_env(:aludel, :run_execution_mode)
+
+      Application.put_env(:aludel, :run_execution_mode, :concurrent)
+
+      on_exit(fn ->
+        Application.put_env(:aludel, :run_execution_mode, original_mode)
+      end)
+
+      provider = provider_fixture(%{model: "provider-exit-model"})
+
+      expect(HttpClientMock, :request, fn "openai:provider-exit-model", _prompt, _opts ->
+        exit(:boom)
+      end)
+
+      Phoenix.PubSub.subscribe(Aludel.PubSub, "run:#{run.id}")
+
+      assert {:ok, %Execution{} = execution} = Executor.execute(run, [provider])
+      assert execution.status == :error
+
+      assert [%{provider_id: provider_id, provider_name: provider_name, reason: reason}] =
+               execution.failures
+
+      assert provider_id == provider.id
+      assert provider_name == provider.name
+      assert match?({:task_exit, _}, reason)
+
+      assert_receive {:run_result_update, _result_id, :error, message}, 1000
+      assert message =~ "task_exit"
+      assert message =~ "boom"
+
+      assert [result] = execution.provider_results
+      assert result.status == :error
+      assert result.error =~ "task_exit"
+      assert result.error =~ "boom"
+    end
+  end
+
+  describe "launch/2" do
+    test "rejects empty provider lists" do
+      assert {:error, :empty_providers} = Executor.launch(%Aludel.Runs.Run{}, [])
     end
   end
 

--- a/test/aludel/runs_test.exs
+++ b/test/aludel/runs_test.exs
@@ -6,6 +6,7 @@ defmodule Aludel.RunsTest do
 
   alias Aludel.Interfaces.HttpClientMock
   alias Aludel.Runs
+  alias Aludel.Runs.Execution
   alias Aludel.Runs.Run
   alias Aludel.Runs.RunResult
 
@@ -289,12 +290,13 @@ defmodule Aludel.RunsTest do
       end)
 
       run = Repo.preload(run, :prompt_version)
-      assert {:ok, result_run} = Runs.execute_run(run, [provider])
+      assert {:ok, %Execution{} = execution} = Runs.execute_run(run, [provider])
+      assert execution.status == :ok
 
-      assert Ecto.assoc_loaded?(result_run.run_results)
-      assert length(result_run.run_results) == 1
+      assert Ecto.assoc_loaded?(execution.run.run_results)
+      assert length(execution.run.run_results) == 1
 
-      result = hd(result_run.run_results)
+      result = hd(execution.run.run_results)
       assert result.provider_id == provider.id
       assert result.status == :completed
       assert is_binary(result.output)
@@ -319,19 +321,21 @@ defmodule Aludel.RunsTest do
 
       run = Repo.preload(run, :prompt_version)
 
-      assert {:ok, result_run} =
+      assert {:ok, %Execution{} = execution} =
                Runs.execute_run(run, [provider1, provider2, provider3])
 
-      assert Ecto.assoc_loaded?(result_run.run_results)
-      assert length(result_run.run_results) == 3
+      assert execution.status == :ok
+
+      assert Ecto.assoc_loaded?(execution.run.run_results)
+      assert length(execution.run.run_results) == 3
 
       provider_ids =
-        Enum.map(result_run.run_results, & &1.provider_id) |> Enum.sort()
+        Enum.map(execution.run.run_results, & &1.provider_id) |> Enum.sort()
 
       expected_ids = [provider1.id, provider2.id, provider3.id] |> Enum.sort()
       assert provider_ids == expected_ids
 
-      for result <- result_run.run_results do
+      for result <- execution.run.run_results do
         assert result.status == :completed
         assert is_binary(result.output)
       end
@@ -350,7 +354,7 @@ defmodule Aludel.RunsTest do
       Phoenix.PubSub.subscribe(Aludel.PubSub, "run:#{run.id}")
 
       run = Repo.preload(run, :prompt_version)
-      assert {:ok, _result_run} = Runs.execute_run(run, [provider])
+      assert {:ok, %Execution{status: :ok}} = Runs.execute_run(run, [provider])
 
       # Should receive at least one update message
       assert_receive {:run_result_update, _result_id, :completed, _output},
@@ -368,14 +372,14 @@ defmodule Aludel.RunsTest do
       end)
 
       run = Repo.preload(run, :prompt_version)
-      assert {:ok, result_run} = Runs.execute_run(run, [provider])
+      assert {:ok, %Execution{} = execution} = Runs.execute_run(run, [provider])
 
-      result = hd(result_run.run_results)
+      result = hd(execution.run.run_results)
       # The rendered prompt should contain "Hello Alice"
       assert result.output =~ "Hello Alice"
     end
 
-    test "handles LLM errors gracefully", %{prompt_version: version} do
+    test "marks execution as fully failed when every provider fails", %{prompt_version: version} do
       provider = provider_fixture(%{name: "Error Provider"})
 
       expect(HttpClientMock, :request, fn _model, _prompt, _opts ->
@@ -390,9 +394,30 @@ defmodule Aludel.RunsTest do
 
       run = Repo.preload(run, :prompt_version)
 
-      assert {:ok, result_run} = Runs.execute_run(run, [provider])
-      assert length(result_run.run_results) == 1
-      assert hd(result_run.run_results).status == :error
+      assert {:ok, %Execution{} = execution} = Runs.execute_run(run, [provider])
+      assert execution.status == :error
+      assert length(execution.failures) == 1
+      assert length(execution.run.run_results) == 1
+      assert hd(execution.run.run_results).status == :error
+    end
+
+    test "marks execution as partially failed when some providers fail", %{run: run} do
+      provider1 = provider_fixture(%{name: "Provider 1", model: "provider-1-model"})
+      provider2 = provider_fixture(%{name: "Provider 2", model: "provider-2-model"})
+
+      expect(HttpClientMock, :request, 2, fn provider_model, _prompt, _opts ->
+        case provider_model do
+          "openai:provider-1-model" -> {:ok, build_mock_response("Test response", 5, 10)}
+          "openai:provider-2-model" -> {:error, "API timeout"}
+        end
+      end)
+
+      run = Repo.preload(run, :prompt_version)
+
+      assert {:ok, %Execution{} = execution} = Runs.execute_run(run, [provider1, provider2])
+      assert execution.status == :partial_failure
+      assert length(execution.failures) == 1
+      assert length(execution.run.run_results) == 2
     end
 
     test "logs warning when run result creation fails on success", %{

--- a/test/aludel/runs_test.exs
+++ b/test/aludel/runs_test.exs
@@ -465,6 +465,55 @@ defmodule Aludel.RunsTest do
     end
   end
 
+  describe "launch_run/2" do
+    setup do
+      prompt = prompt_fixture()
+      {:ok, version} = Aludel.Prompts.create_prompt_version(prompt, "Hello {{user}}")
+
+      {:ok, run} =
+        Runs.create_run(%{
+          prompt_version_id: version.id,
+          variable_values: %{"user" => "Alice"}
+        })
+
+      provider = provider_fixture()
+
+      {:ok, run: Repo.preload(run, :prompt_version), provider: provider}
+    end
+
+    test "starts execution under supervision and persists results", %{
+      run: run,
+      provider: provider
+    } do
+      test_pid = self()
+      mock_response = build_mock_response("Hello Alice", 5, 10)
+
+      expect(HttpClientMock, :request, fn _model, _prompt, _opts ->
+        send(test_pid, :llm_called)
+
+        receive do
+          :continue -> {:ok, mock_response}
+        after
+          1000 -> flunk("timed out waiting to continue executor task")
+        end
+      end)
+
+      Phoenix.PubSub.subscribe(Aludel.PubSub, "run:#{run.id}")
+
+      assert {:ok, pid} = Runs.launch_run(run, [provider])
+      assert_receive :llm_called, 1000
+      assert Process.alive?(pid)
+
+      send(pid, :continue)
+
+      assert_receive {:run_result_update, _result_id, :completed, "Hello Alice"}, 1000
+
+      launched_run = Runs.get_run!(run.id)
+      assert length(launched_run.run_results) == 1
+      assert hd(launched_run.run_results).status == :completed
+    end
+  end
+
   defp build_mock_response(text, input_tokens, output_tokens) do
     %{
       content: text,

--- a/test/aludel_web/live/run_live/new_test.exs
+++ b/test/aludel_web/live/run_live/new_test.exs
@@ -112,8 +112,8 @@ defmodule Aludel.Web.RunLive.NewTest do
 
       run = %{run | prompt_version: version}
 
-      assert {:ok, result_run} = Aludel.Runs.execute_run(run, [provider1, provider2])
-      assert length(result_run.run_results) == 2
+      assert {:ok, execution} = Aludel.Runs.execute_run(run, [provider1, provider2])
+      assert length(execution.run.run_results) == 2
     end
 
     test "validates required variable values", %{

--- a/test/support/llm_stubs.ex
+++ b/test/support/llm_stubs.ex
@@ -80,15 +80,15 @@ defmodule Aludel.LlmStubs do
   """
   @spec rate_limit_error() :: llm_response()
   def rate_limit_error do
-    {:error, {:rate_limit_error, "Rate limit exceeded. Retry after 60s"}}
+    {:error, {:rate_limit, 60}}
   end
 
   @doc """
   Generic API error response.
   """
-  @spec api_error(String.t()) :: llm_response()
-  def api_error(message \\ "API request failed") do
-    {:error, {:api_error, message}}
+  @spec api_error(non_neg_integer(), String.t()) :: llm_response()
+  def api_error(status \\ 500, message \\ "API request failed") do
+    {:error, {:api_error, status, message}}
   end
 
   @doc """
@@ -96,7 +96,7 @@ defmodule Aludel.LlmStubs do
   """
   @spec malformed_response_error() :: llm_response()
   def malformed_response_error do
-    {:error, {:api_error, "Unexpected response format"}}
+    {:error, {:api_error, 500, "Unexpected response format"}}
   end
 
   @doc """


### PR DESCRIPTION
## Motivation (required)

This pull request fixes #60 by moving run execution ownership out of `RunLive.New` and into a supervised application service.

Before this change, the LiveView launched execution with `Task.start/1`, while provider fan-out and PubSub updates lived inside `Aludel.Runs.execute_run/2`. That split orchestration across the web layer and the context boundary, weakened supervision, and made partial provider failures easy to ignore.

This change introduces `Aludel.Runs.Executor` as the owner of run launch and provider execution. The LiveView now calls a single context entry point, provider fan-out runs under an explicit supervisor, and execution returns a structured outcome that distinguishes `:ok`, `:partial_failure`, and `:error`.

This PR also addresses #50 as part of the same refactor by making provider request concurrency configurable through the existing `:llm` application config instead of leaving it hardcoded in the execution path.

## Test Plan (required)

Commands run:

```bash
mix test test/aludel/runs_test.exs test/aludel_web/live/run_live/new_test.exs
mix precommit
```

Observed output:

- `mix test test/aludel/runs_test.exs test/aludel_web/live/run_live/new_test.exs`
  - `32 tests, 0 failures`
- `mix precommit`
  - `455 tests, 0 failures`

Coverage added in this PR:

- executor-backed `Runs.execute_run/2` success path
- explicit `:error` result when every provider fails
- explicit `:partial_failure` result when only some providers fail
- updated run launch path expectations in `RunLive.New` tests

## Next Steps

This PR keeps scope on execution ownership and supervision. It does not claim the LiveView update optimization in #51 or the explicit run state model in #62, but it gives both of those follow-up changes a cleaner boundary to build on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runs can be launched to execute in the background under a supervised process.
  * Execution results now include an overall status (ok, partial_failure, error) and per-provider outcomes.

* **Improvements**
  * Configurable LLM concurrency and request timeout for run execution.
  * UI now triggers supervised background launches and surfaces success/error flashes.

* **Tests**
  * Updated and added tests for background launch, multi-provider success/partial-failure, task-exit handling, and persistence.

* **Chores**
  * Coverage updated to exclude the new execution-result module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->