### PR TITLE
perf: optimize live run result updates

### DIFF
--- a/lib/aludel/runs.ex
+++ b/lib/aludel/runs.ex
@@ -120,6 +120,19 @@ defmodule Aludel.Runs do
   end
 
   @doc """
+  Gets a run result by ID, raising if not found.
+
+  Preloads the associated provider so the result is ready for
+  rendering without additional database lookups.
+  """
+  @spec get_run_result!(binary()) :: RunResult.t()
+  def get_run_result!(id) do
+    RunResult
+    |> repo().get!(id)
+    |> repo().preload(:provider)
+  end
+
+  @doc """
   Updates an existing run result.
   """
   @spec update_run_result(RunResult.t(), map()) ::

--- a/lib/aludel/web/live/run_live/show.ex
+++ b/lib/aludel/web/live/run_live/show.ex
@@ -41,10 +41,30 @@ defmodule Aludel.Web.RunLive.Show do
 
   @impl Phoenix.LiveView
   def handle_info(
-        {:run_result_update, _result_id, _status, _output},
+        {:run_result_update, result_id, _status, _output},
         socket
       ) do
-    run = Runs.get_run!(socket.assigns.run.id)
-    {:noreply, assign(socket, run_results: run.run_results)}
+    updated_result = Runs.get_run_result!(result_id)
+    run_results = merge_run_result(socket.assigns.run_results, updated_result)
+    run = %{socket.assigns.run | run_results: run_results}
+
+    {:noreply, assign(socket, run: run, run_results: run_results)}
+  end
+
+  defp merge_run_result(run_results, updated_result) do
+    {updated_run_results, found_match?} =
+      Enum.map_reduce(run_results, false, fn run_result, found_match? ->
+        if run_result.id == updated_result.id do
+          {updated_result, true}
+        else
+          {run_result, found_match?}
+        end
+      end)
+
+    if found_match? do
+      updated_run_results
+    else
+      updated_run_results ++ [updated_result]
+    end
   end
 end

--- a/test/aludel/runs_test.exs
+++ b/test/aludel/runs_test.exs
@@ -246,6 +246,24 @@ defmodule Aludel.RunsTest do
       assert result.error == "API error"
     end
 
+    test "get_run_result!/1 preloads the provider", %{
+      run: run,
+      provider: provider
+    } do
+      attrs =
+        @valid_result_attrs
+        |> Map.put(:run_id, run.id)
+        |> Map.put(:provider_id, provider.id)
+
+      {:ok, result} = Runs.create_run_result(attrs)
+
+      loaded_result = Runs.get_run_result!(result.id)
+
+      assert loaded_result.id == result.id
+      assert Ecto.assoc_loaded?(loaded_result.provider)
+      assert loaded_result.provider.id == provider.id
+    end
+
     test "update_run_result/2 with invalid data returns error changeset", %{
       run: run,
       provider: provider

--- a/test/aludel_web/live/run_live/show_test.exs
+++ b/test/aludel_web/live/run_live/show_test.exs
@@ -104,6 +104,7 @@ defmodule Aludel.Web.RunLive.ShowTest do
       )
 
       html = render(view)
+      assert html =~ provider3.name
       assert html =~ "Streaming update from Cohere"
     end
 


### PR DESCRIPTION
## Motivation (required)

Closes #51.

The run show LiveView was reloading the full run and all of its preloaded associations on every `:run_result_update` PubSub event. That added unnecessary query and preload work during run execution, especially as the number of providers grew.

This change keeps the run configuration assign intact and updates only the affected `RunResult` in response to each event. The updated result is fetched with its provider preloaded so the LiveView can render it directly without reloading the full run.

## Test Plan (required)

Commands run:

```bash
mix format
mix test test/aludel/runs_test.exs test/aludel_web/live/run_live/show_test.exs
mix precommit
```

Observed results:

- `mix format` completed successfully
- targeted tests passed: `32 tests, 0 failures`
- `mix precommit` completed successfully

## Next Steps

This PR intentionally stays scoped to the selective-fetching performance fix in the run show LiveView. Broader execution-orchestration concerns remain tracked separately in #60.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Run results now include provider information when displayed.

* **Improvements**
  * Optimized real-time update handling for run results, improving responsiveness and data consistency through more efficient data fetching.

* **Tests**
  * Added comprehensive test coverage for run result retrieval and real-time update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->