### PR TITLE
docs: use hexdocs badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <p>
     <a href="https://hex.pm/packages/aludel"><img src="https://img.shields.io/hexpm/v/aludel.svg" alt="Hex.pm"/></a>
     <a href="https://github.com/ccarvalho-eng/aludel/actions/workflows/ci.yml"><img src="https://github.com/ccarvalho-eng/aludel/actions/workflows/ci.yml/badge.svg" alt="CI"/></a>
-    <a href="https://hexdocs.pm/aludel"><img src="https://img.shields.io/badge/Hex%20Docs-gray" alt="Hex Docs"/></a>
+    <a href="https://hexdocs.pm/aludel"><img src="https://img.shields.io/badge/docs-hexdocs-purple" alt="Hex Docs"/></a>
     <a href="https://github.com/ccarvalho-eng/aludel/blob/main/LICENSE"><img src="https://img.shields.io/github/license/ccarvalho-eng/aludel" alt="License"/></a>
   </p>
 </div>
@@ -156,11 +156,18 @@ mix assets.build
 mix compile --force
 ```
 
-For full-app development with watchers, run the standalone app:
+For standalone development, run the app from the `standalone` directory:
 
 ```bash
 cd standalone
 mix phx.server
+```
+
+If you change frontend assets, rebuild them from the repo root and restart the standalone server:
+
+```bash
+mix assets.build
+mix compile --force
 ```
 
 ## License


### PR DESCRIPTION
## Motivation (required)

The merged README refresh on `main` still uses a generic gray badge for HexDocs. This follow-up switches it to the same `docs-hexdocs` badge style used by projects like Ash, which reads more clearly and looks more intentional in the hero row.

## Test Plan (required)

- No code changes; README-only update
- Verified the badge markup locally in `README.md`
- Existing `main` CI status checked on GitHub for the current head commit (`32be70ba28aad5453c820324c90df5a2468b3ef8`), which is green

## Next Steps

Merge if the updated badge appearance looks right in the GitHub README preview.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development instructions for running the application standalone
  * Added clarification on rebuilding and redeploying frontend assets after changes
  * Refreshed documentation styling and formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->