### PR TITLE
fix: recover SuiteLive after task crash

### DIFF
--- a/lib/aludel/evals.ex
+++ b/lib/aludel/evals.ex
@@ -5,7 +5,7 @@ defmodule Aludel.Evals do
 
   import Ecto.Query
 
-  alias Aludel.Evals.{Suite, SuiteRun, TestCase, TestCaseDocument}
+  alias Aludel.Evals.{Suite, SuiteRun, SuiteRunner, TestCase, TestCaseDocument}
   alias Aludel.LLM
   alias Aludel.Prompts.PromptVersion
   alias Aludel.Providers.Provider
@@ -339,6 +339,16 @@ defmodule Aludel.Evals do
       avg_cost_usd: avg_cost_usd,
       avg_latency_ms: avg_latency_ms
     })
+  end
+
+  @doc """
+  Launches suite execution in a supervised task and reports completion
+  back to the given recipient process.
+  """
+  @spec launch_suite_execution(pid(), binary(), binary(), binary()) ::
+          {:ok, pid()} | {:error, term()}
+  def launch_suite_execution(recipient, suite_id, version_id, provider_id) do
+    SuiteRunner.launch(recipient, suite_id, version_id, provider_id)
   end
 
   # Test Case Document functions

--- a/lib/aludel/evals.ex
+++ b/lib/aludel/evals.ex
@@ -346,9 +346,12 @@ defmodule Aludel.Evals do
   back to the given recipient process.
   """
   @spec launch_suite_execution(pid(), binary(), binary(), binary()) ::
-          {:ok, pid()} | {:error, term()}
+          {:ok, reference()} | {:error, term()}
   def launch_suite_execution(recipient, suite_id, version_id, provider_id) do
-    SuiteRunner.launch(recipient, suite_id, version_id, provider_id)
+    case SuiteRunner.launch(recipient, suite_id, version_id, provider_id) do
+      {:ok, task_pid} -> {:ok, Process.monitor(task_pid)}
+      {:error, reason} -> {:error, reason}
+    end
   end
 
   # Test Case Document functions

--- a/lib/aludel/evals/suite_runner.ex
+++ b/lib/aludel/evals/suite_runner.ex
@@ -1,25 +1,33 @@
 defmodule Aludel.Evals.SuiteRunner do
   @moduledoc """
-  Launches suite execution under supervision and reports completion
-  back to the requesting process.
+  Owns suite execution launch under explicit supervision.
   """
 
   alias Aludel.Evals
+  alias Aludel.Evals.SuiteRun
   alias Aludel.Prompts
   alias Aludel.Providers
   alias Aludel.TaskSupervisor
+
+  @type execution_result :: {:ok, SuiteRun.t()} | {:error, term()}
 
   @spec launch(pid(), binary(), binary(), binary()) :: {:ok, pid()} | {:error, term()}
   def launch(recipient, suite_id, version_id, provider_id)
       when is_pid(recipient) and is_binary(suite_id) and is_binary(version_id) and
              is_binary(provider_id) do
     Task.Supervisor.start_child(TaskSupervisor, fn ->
-      version = Prompts.get_prompt_version!(version_id)
-      provider = Providers.get_provider!(provider_id)
-      suite = Evals.get_suite_with_test_cases!(suite_id)
-
-      result = Evals.execute_suite(suite, version, provider)
+      result = execute(suite_id, version_id, provider_id)
       send(recipient, {:suite_completed, result})
     end)
+  end
+
+  @spec execute(binary(), binary(), binary()) :: execution_result()
+  def execute(suite_id, version_id, provider_id)
+      when is_binary(suite_id) and is_binary(version_id) and is_binary(provider_id) do
+    version = Prompts.get_prompt_version!(version_id)
+    provider = Providers.get_provider!(provider_id)
+    suite = Evals.get_suite_with_test_cases!(suite_id)
+
+    Evals.execute_suite(suite, version, provider)
   end
 end

--- a/lib/aludel/evals/suite_runner.ex
+++ b/lib/aludel/evals/suite_runner.ex
@@ -8,6 +8,7 @@ defmodule Aludel.Evals.SuiteRunner do
   alias Aludel.Prompts
   alias Aludel.Providers
   alias Aludel.TaskSupervisor
+  alias Ecto.NoResultsError
 
   @type execution_result :: {:ok, SuiteRun.t()} | {:error, term()}
 
@@ -16,18 +17,47 @@ defmodule Aludel.Evals.SuiteRunner do
       when is_pid(recipient) and is_binary(suite_id) and is_binary(version_id) and
              is_binary(provider_id) do
     Task.Supervisor.start_child(TaskSupervisor, fn ->
-      result = execute(suite_id, version_id, provider_id)
-      send(recipient, {:suite_completed, result})
+      send(recipient, {:suite_completed, execute(suite_id, version_id, provider_id)})
     end)
   end
 
   @spec execute(binary(), binary(), binary()) :: execution_result()
   def execute(suite_id, version_id, provider_id)
       when is_binary(suite_id) and is_binary(version_id) and is_binary(provider_id) do
-    version = Prompts.get_prompt_version!(version_id)
-    provider = Providers.get_provider!(provider_id)
-    suite = Evals.get_suite_with_test_cases!(suite_id)
-
-    Evals.execute_suite(suite, version, provider)
+    with {:ok, suite} <- fetch_suite(suite_id),
+         {:ok, version} <- fetch_prompt_version(version_id),
+         {:ok, provider} <- fetch_provider(provider_id) do
+      run_execution(suite, version, provider)
+    end
   end
+
+  defp run_execution(suite, version, provider) do
+    Evals.execute_suite(suite, version, provider)
+  rescue
+    error ->
+      {:error, {:execution_failed, Exception.message(error)}}
+  catch
+    kind, reason ->
+      {:error, {:execution_failed, {kind, reason}}}
+  end
+
+  defp fetch_suite(suite_id) do
+    {:ok, Evals.get_suite_with_test_cases!(suite_id)}
+  rescue
+    error in [NoResultsError] -> {:error, map_lookup_error(error, :suite_not_found)}
+  end
+
+  defp fetch_prompt_version(version_id) do
+    {:ok, Prompts.get_prompt_version!(version_id)}
+  rescue
+    error in [NoResultsError] -> {:error, map_lookup_error(error, :prompt_version_not_found)}
+  end
+
+  defp fetch_provider(provider_id) do
+    {:ok, Providers.get_provider!(provider_id)}
+  rescue
+    error in [NoResultsError] -> {:error, map_lookup_error(error, :provider_not_found)}
+  end
+
+  defp map_lookup_error(_error, reason), do: reason
 end

--- a/lib/aludel/evals/suite_runner.ex
+++ b/lib/aludel/evals/suite_runner.ex
@@ -1,0 +1,25 @@
+defmodule Aludel.Evals.SuiteRunner do
+  @moduledoc """
+  Launches suite execution under supervision and reports completion
+  back to the requesting process.
+  """
+
+  alias Aludel.Evals
+  alias Aludel.Prompts
+  alias Aludel.Providers
+  alias Aludel.TaskSupervisor
+
+  @spec launch(pid(), binary(), binary(), binary()) :: {:ok, pid()} | {:error, term()}
+  def launch(recipient, suite_id, version_id, provider_id)
+      when is_pid(recipient) and is_binary(suite_id) and is_binary(version_id) and
+             is_binary(provider_id) do
+    Task.Supervisor.start_child(TaskSupervisor, fn ->
+      version = Prompts.get_prompt_version!(version_id)
+      provider = Providers.get_provider!(provider_id)
+      suite = Evals.get_suite_with_test_cases!(suite_id)
+
+      result = Evals.execute_suite(suite, version, provider)
+      send(recipient, {:suite_completed, result})
+    end)
+  end
+end

--- a/lib/aludel/web/live/suite_live/show.ex
+++ b/lib/aludel/web/live/suite_live/show.ex
@@ -15,7 +15,6 @@ defmodule Aludel.Web.SuiteLive.Show do
   alias Aludel.Projects
   alias Aludel.Prompts
   alias Aludel.Providers
-  alias Aludel.TaskSupervisor
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
@@ -48,6 +47,7 @@ defmodule Aludel.Web.SuiteLive.Show do
       |> assign(:providers, providers)
       |> assign(:suite_runs, suite_runs)
       |> assign(:running, false)
+      |> assign(:run_task_monitor_ref, nil)
       |> assign(:selected_version_id, default_version_id)
       |> assign(:selected_provider_id, default_provider_id)
       |> assign(:run_suite_form, build_run_suite_form(default_version_id, default_provider_id))
@@ -362,21 +362,7 @@ defmodule Aludel.Web.SuiteLive.Show do
     else
       version_id = Map.get(run_suite_params, "version_id", socket.assigns.selected_version_id)
       provider_id = Map.get(run_suite_params, "provider_id", socket.assigns.selected_provider_id)
-
-      # Start async execution
-      pid = self()
-      suite_id = socket.assigns.suite.id
-
-      Task.Supervisor.start_child(TaskSupervisor, fn ->
-        version = Prompts.get_prompt_version!(version_id)
-        provider = Providers.get_provider!(provider_id)
-        suite = Evals.get_suite_with_test_cases!(suite_id)
-
-        result = Evals.execute_suite(suite, version, provider)
-        send(pid, {:suite_completed, result})
-      end)
-
-      {:noreply, assign(socket, :running, true)}
+      {:noreply, start_suite_execution(socket, version_id, provider_id)}
     end
   end
 
@@ -438,7 +424,7 @@ defmodule Aludel.Web.SuiteLive.Show do
     {:noreply,
      socket
      |> assign(:suite_runs, [suite_run | socket.assigns.suite_runs])
-     |> assign(:running, false)
+     |> clear_run_task_state()
      |> put_flash(:info, "Suite executed successfully")}
   end
 
@@ -446,8 +432,23 @@ defmodule Aludel.Web.SuiteLive.Show do
   def handle_info({:suite_completed, {:error, _reason}}, socket) do
     {:noreply,
      socket
-     |> assign(:running, false)
+     |> clear_run_task_state()
      |> put_flash(:error, "Failed to execute suite")}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_info(
+        {:DOWN, monitor_ref, :process, _pid, reason},
+        %{assigns: %{run_task_monitor_ref: monitor_ref}} = socket
+      ) do
+    if reason == :normal do
+      {:noreply, socket}
+    else
+      {:noreply,
+       socket
+       |> clear_run_task_state()
+       |> put_flash(:error, "Suite execution crashed before completion")}
+    end
   end
 
   defp relative_time(datetime) do
@@ -489,5 +490,36 @@ defmodule Aludel.Web.SuiteLive.Show do
     Enum.find(versions, List.first(versions), fn version ->
       to_string(version.id) == to_string(version_id)
     end)
+  end
+
+  defp clear_run_task_state(socket) do
+    case socket.assigns.run_task_monitor_ref do
+      nil ->
+        assign(socket, :running, false)
+
+      monitor_ref ->
+        Process.demonitor(monitor_ref, [:flush])
+
+        socket
+        |> assign(:run_task_monitor_ref, nil)
+        |> assign(:running, false)
+    end
+  end
+
+  defp start_suite_execution(socket, version_id, provider_id) do
+    case Evals.launch_suite_execution(
+           self(),
+           socket.assigns.suite.id,
+           version_id,
+           provider_id
+         ) do
+      {:ok, task_pid} ->
+        socket
+        |> assign(:run_task_monitor_ref, Process.monitor(task_pid))
+        |> assign(:running, true)
+
+      {:error, _reason} ->
+        put_flash(socket, :error, "Failed to start suite execution")
+    end
   end
 end

--- a/lib/aludel/web/live/suite_live/show.ex
+++ b/lib/aludel/web/live/suite_live/show.ex
@@ -532,5 +532,11 @@ defmodule Aludel.Web.SuiteLive.Show do
   defp suite_execution_error_message(:provider_not_found),
     do: "Failed to execute suite: provider not found"
 
+  defp suite_execution_error_message({:execution_failed, detail}),
+    do: "Failed to execute suite: #{format_execution_error_detail(detail)}"
+
   defp suite_execution_error_message(_reason), do: "Failed to execute suite"
+
+  defp format_execution_error_detail(detail) when is_binary(detail), do: detail
+  defp format_execution_error_detail(detail), do: inspect(detail)
 end

--- a/lib/aludel/web/live/suite_live/show.ex
+++ b/lib/aludel/web/live/suite_live/show.ex
@@ -429,11 +429,11 @@ defmodule Aludel.Web.SuiteLive.Show do
   end
 
   @impl Phoenix.LiveView
-  def handle_info({:suite_completed, {:error, _reason}}, socket) do
+  def handle_info({:suite_completed, {:error, reason}}, socket) do
     {:noreply,
      socket
      |> clear_run_task_state()
-     |> put_flash(:error, "Failed to execute suite")}
+     |> put_flash(:error, suite_execution_error_message(reason))}
   end
 
   @impl Phoenix.LiveView
@@ -513,13 +513,24 @@ defmodule Aludel.Web.SuiteLive.Show do
            version_id,
            provider_id
          ) do
-      {:ok, task_pid} ->
+      {:ok, monitor_ref} ->
         socket
-        |> assign(:run_task_monitor_ref, Process.monitor(task_pid))
+        |> assign(:run_task_monitor_ref, monitor_ref)
         |> assign(:running, true)
 
       {:error, _reason} ->
         put_flash(socket, :error, "Failed to start suite execution")
     end
   end
+
+  defp suite_execution_error_message(:suite_not_found),
+    do: "Failed to execute suite: suite not found"
+
+  defp suite_execution_error_message(:prompt_version_not_found),
+    do: "Failed to execute suite: prompt version not found"
+
+  defp suite_execution_error_message(:provider_not_found),
+    do: "Failed to execute suite: provider not found"
+
+  defp suite_execution_error_message(_reason), do: "Failed to execute suite"
 end

--- a/test/aludel/evals/suite_runner_test.exs
+++ b/test/aludel/evals/suite_runner_test.exs
@@ -15,6 +15,15 @@ defmodule Aludel.Evals.SuiteRunnerTest do
       assert suite_run.prompt_version_id == version.id
       assert suite_run.provider_id == provider.id
     end
+
+    test "returns a structured error when dependent records cannot be loaded" do
+      prompt = prompt_fixture_with_version(%{template: "Hello {{name}}"})
+      suite = suite_fixture(%{prompt_id: prompt.id})
+      version = List.first(prompt.versions)
+
+      assert {:error, :provider_not_found} =
+               SuiteRunner.execute(suite.id, version.id, Ecto.UUID.generate())
+    end
   end
 
   describe "launch/4" do
@@ -32,7 +41,7 @@ defmodule Aludel.Evals.SuiteRunnerTest do
       assert_receive {:DOWN, ^monitor_ref, :process, ^task_pid, :normal}, 1000
     end
 
-    test "crashes when dependent records cannot be loaded" do
+    test "sends an error result when dependent records cannot be loaded" do
       prompt = prompt_fixture_with_version(%{template: "Hello {{name}}"})
       suite = suite_fixture(%{prompt_id: prompt.id})
       version = List.first(prompt.versions)
@@ -42,9 +51,8 @@ defmodule Aludel.Evals.SuiteRunnerTest do
 
       monitor_ref = Process.monitor(task_pid)
 
-      refute_receive {:suite_completed, _}, 200
-      assert_receive {:DOWN, ^monitor_ref, :process, ^task_pid, reason}, 1000
-      assert match?({%Ecto.NoResultsError{}, _}, reason)
+      assert_receive {:suite_completed, {:error, :provider_not_found}}, 1000
+      assert_receive {:DOWN, ^monitor_ref, :process, ^task_pid, :normal}, 1000
     end
   end
 end

--- a/test/aludel/evals/suite_runner_test.exs
+++ b/test/aludel/evals/suite_runner_test.exs
@@ -1,0 +1,50 @@
+defmodule Aludel.Evals.SuiteRunnerTest do
+  use Aludel.DataCase
+
+  alias Aludel.Evals.SuiteRunner
+
+  describe "execute/3" do
+    test "returns a persisted suite run" do
+      prompt = prompt_fixture_with_version(%{template: "Hello {{name}}"})
+      suite = suite_fixture(%{prompt_id: prompt.id})
+      provider = provider_fixture()
+      version = List.first(prompt.versions)
+
+      assert {:ok, suite_run} = SuiteRunner.execute(suite.id, version.id, provider.id)
+      assert suite_run.suite_id == suite.id
+      assert suite_run.prompt_version_id == version.id
+      assert suite_run.provider_id == provider.id
+    end
+  end
+
+  describe "launch/4" do
+    test "sends the suite completion result to the recipient" do
+      prompt = prompt_fixture_with_version(%{template: "Hello {{name}}"})
+      suite = suite_fixture(%{prompt_id: prompt.id})
+      provider = provider_fixture()
+      version = List.first(prompt.versions)
+
+      assert {:ok, task_pid} = SuiteRunner.launch(self(), suite.id, version.id, provider.id)
+      monitor_ref = Process.monitor(task_pid)
+
+      assert_receive {:suite_completed, {:ok, suite_run}}, 1000
+      assert suite_run.suite_id == suite.id
+      assert_receive {:DOWN, ^monitor_ref, :process, ^task_pid, :normal}, 1000
+    end
+
+    test "crashes when dependent records cannot be loaded" do
+      prompt = prompt_fixture_with_version(%{template: "Hello {{name}}"})
+      suite = suite_fixture(%{prompt_id: prompt.id})
+      version = List.first(prompt.versions)
+
+      assert {:ok, task_pid} =
+               SuiteRunner.launch(self(), suite.id, version.id, Ecto.UUID.generate())
+
+      monitor_ref = Process.monitor(task_pid)
+
+      refute_receive {:suite_completed, _}, 200
+      assert_receive {:DOWN, ^monitor_ref, :process, ^task_pid, reason}, 1000
+      assert match?({%Ecto.NoResultsError{}, _}, reason)
+    end
+  end
+end

--- a/test/aludel/evals/suite_runner_test.exs
+++ b/test/aludel/evals/suite_runner_test.exs
@@ -19,7 +19,14 @@ defmodule Aludel.Evals.SuiteRunnerTest do
     test "returns a structured error when dependent records cannot be loaded" do
       prompt = prompt_fixture_with_version(%{template: "Hello {{name}}"})
       suite = suite_fixture(%{prompt_id: prompt.id})
+      provider = provider_fixture()
       version = List.first(prompt.versions)
+
+      assert {:error, :suite_not_found} =
+               SuiteRunner.execute(Ecto.UUID.generate(), version.id, provider.id)
+
+      assert {:error, :prompt_version_not_found} =
+               SuiteRunner.execute(suite.id, Ecto.UUID.generate(), provider.id)
 
       assert {:error, :provider_not_found} =
                SuiteRunner.execute(suite.id, version.id, Ecto.UUID.generate())

--- a/test/aludel/evals_test.exs
+++ b/test/aludel/evals_test.exs
@@ -764,6 +764,26 @@ defmodule Aludel.EvalsTest do
     end
   end
 
+  describe "launch_suite_execution/4" do
+    test "launches suite execution and sends the completion result" do
+      prompt = prompt_fixture_with_version(%{template: "Hello {{name}}"})
+      suite = suite_fixture(%{prompt_id: prompt.id})
+      provider = provider_fixture()
+      version = List.first(prompt.versions)
+
+      assert {:ok, task_pid} =
+               Evals.launch_suite_execution(self(), suite.id, version.id, provider.id)
+
+      monitor_ref = Process.monitor(task_pid)
+
+      assert_receive {:suite_completed, {:ok, suite_run}}, 1000
+      assert suite_run.suite_id == suite.id
+      assert suite_run.prompt_version_id == version.id
+      assert suite_run.provider_id == provider.id
+      assert_receive {:DOWN, ^monitor_ref, :process, ^task_pid, :normal}, 1000
+    end
+  end
+
   defp build_mock_response(text, input_tokens, output_tokens) do
     %{
       content: text,

--- a/test/aludel/evals_test.exs
+++ b/test/aludel/evals_test.exs
@@ -765,22 +765,32 @@ defmodule Aludel.EvalsTest do
   end
 
   describe "launch_suite_execution/4" do
-    test "launches suite execution and sends the completion result" do
+    test "launches suite execution, monitors it, and sends the completion result" do
       prompt = prompt_fixture_with_version(%{template: "Hello {{name}}"})
       suite = suite_fixture(%{prompt_id: prompt.id})
       provider = provider_fixture()
       version = List.first(prompt.versions)
 
-      assert {:ok, task_pid} =
+      assert {:ok, monitor_ref} =
                Evals.launch_suite_execution(self(), suite.id, version.id, provider.id)
-
-      monitor_ref = Process.monitor(task_pid)
 
       assert_receive {:suite_completed, {:ok, suite_run}}, 1000
       assert suite_run.suite_id == suite.id
       assert suite_run.prompt_version_id == version.id
       assert suite_run.provider_id == provider.id
-      assert_receive {:DOWN, ^monitor_ref, :process, ^task_pid, :normal}, 1000
+      assert_receive {:DOWN, ^monitor_ref, :process, _task_pid, :normal}, 1000
+    end
+
+    test "returns structured failure results through the launched task" do
+      prompt = prompt_fixture_with_version(%{template: "Hello {{name}}"})
+      suite = suite_fixture(%{prompt_id: prompt.id})
+      version = List.first(prompt.versions)
+
+      assert {:ok, monitor_ref} =
+               Evals.launch_suite_execution(self(), suite.id, version.id, Ecto.UUID.generate())
+
+      assert_receive {:suite_completed, {:error, :provider_not_found}}, 1000
+      assert_receive {:DOWN, ^monitor_ref, :process, _task_pid, :normal}, 1000
     end
   end
 

--- a/test/aludel_web/live/suite_live/show_test.exs
+++ b/test/aludel_web/live/suite_live/show_test.exs
@@ -545,6 +545,61 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
       refute has_element?(view, "#run-suite-btn[disabled]")
       assert has_element?(view, "#run-suite-form option[selected][value='#{provider.id}']")
     end
+
+    test "recovers from an abnormal task down message", %{conn: conn} do
+      suite = suite_fixture()
+
+      {:ok, view, _html} = live(conn, "/suites/#{suite.id}")
+
+      monitor_ref = make_ref()
+
+      :sys.replace_state(view.pid, fn state ->
+        put_in(state.socket.assigns, %{
+          state.socket.assigns
+          | running: true,
+            run_task_monitor_ref: monitor_ref
+        })
+      end)
+
+      send(view.pid, {:DOWN, monitor_ref, :process, self(), :boom})
+
+      assert_running_state(view, false)
+      assert has_element?(view, "#flash-error", "Suite execution crashed before completion")
+      refute has_element?(view, "#run-suite-btn[disabled]")
+    end
+
+    test "allows rerunning after a failed attempt", %{conn: conn} do
+      prompt = prompt_fixture_with_version()
+      suite = suite_fixture(%{prompt_id: prompt.id})
+      provider = provider_fixture()
+      version = List.first(prompt.versions)
+
+      {:ok, view, _html} = live(conn, "/suites/#{suite.id}")
+
+      capture_log(fn ->
+        render_submit(view, "run_suite", %{
+          "run_suite" => %{
+            "version_id" => version.id,
+            "provider_id" => Ecto.UUID.generate()
+          }
+        })
+
+        assert_running_state(view, false)
+      end)
+
+      assert has_element?(view, "#flash-error", "Failed to execute suite: provider not found")
+
+      render_submit(view, "run_suite", %{
+        "run_suite" => %{
+          "version_id" => version.id,
+          "provider_id" => provider.id
+        }
+      })
+
+      assert_running_state(view, false)
+      assert has_element?(view, "#flash-info", "Suite executed successfully")
+      refute has_element?(view, "#run-suite-btn[disabled]")
+    end
   end
 
   describe "test case edit cancellation" do

--- a/test/aludel_web/live/suite_live/show_test.exs
+++ b/test/aludel_web/live/suite_live/show_test.exs
@@ -521,7 +521,7 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
   end
 
   describe "suite execution" do
-    test "recovers when the background execution task crashes", %{conn: conn} do
+    test "recovers when the background execution task fails", %{conn: conn} do
       prompt = prompt_fixture_with_version()
       suite = suite_fixture(%{prompt_id: prompt.id})
       provider = provider_fixture()
@@ -541,7 +541,7 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
         assert_running_state(view, false)
       end)
 
-      assert has_element?(view, "#flash-error", "Suite execution crashed before completion")
+      assert has_element?(view, "#flash-error", "Failed to execute suite: provider not found")
       refute has_element?(view, "#run-suite-btn[disabled]")
       assert has_element?(view, "#run-suite-form option[selected][value='#{provider.id}']")
     end

--- a/test/aludel_web/live/suite_live/show_test.exs
+++ b/test/aludel_web/live/suite_live/show_test.exs
@@ -638,11 +638,13 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
     end
   end
 
-  defp assert_eventually(fun, attempts \\ 20)
+  defp assert_eventually(fun, attempts \\ 200)
 
   defp assert_eventually(fun, attempts) when attempts > 0 do
-    if fun.() do
-      assert fun.()
+    result = fun.()
+
+    if result do
+      assert result
     else
       Process.sleep(10)
       assert_eventually(fun, attempts - 1)
@@ -650,6 +652,7 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
   end
 
   defp assert_eventually(fun, 0) do
-    assert fun.()
+    result = fun.()
+    assert result
   end
 end

--- a/test/aludel_web/live/suite_live/show_test.exs
+++ b/test/aludel_web/live/suite_live/show_test.exs
@@ -1,6 +1,7 @@
 defmodule Aludel.Web.SuiteLive.ShowTest do
   use Aludel.Web.ConnCase, async: false
 
+  import ExUnit.CaptureLog
   import Phoenix.LiveViewTest
   import Aludel.EvalsFixtures
   import Aludel.PromptsFixtures
@@ -519,6 +520,33 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
     end
   end
 
+  describe "suite execution" do
+    test "recovers when the background execution task crashes", %{conn: conn} do
+      prompt = prompt_fixture_with_version()
+      suite = suite_fixture(%{prompt_id: prompt.id})
+      provider = provider_fixture()
+      version = List.first(prompt.versions)
+      invalid_provider_id = Ecto.UUID.generate()
+
+      {:ok, view, _html} = live(conn, "/suites/#{suite.id}")
+
+      capture_log(fn ->
+        render_submit(view, "run_suite", %{
+          "run_suite" => %{
+            "version_id" => version.id,
+            "provider_id" => invalid_provider_id
+          }
+        })
+
+        assert_running_state(view, false)
+      end)
+
+      assert has_element?(view, "#flash-error", "Suite execution crashed before completion")
+      refute has_element?(view, "#run-suite-btn[disabled]")
+      assert has_element?(view, "#run-suite-form option[selected][value='#{provider.id}']")
+    end
+  end
+
   describe "test case edit cancellation" do
     test "cancels test case editing", %{conn: conn} do
       suite = suite_fixture()
@@ -535,5 +563,26 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
       # Should return to normal view, not showing edit form
       refute html =~ "Save"
     end
+  end
+
+  defp assert_running_state(view, expected_running, attempts \\ 20)
+
+  defp assert_running_state(view, expected_running, attempts) when attempts > 0 do
+    running = view_running?(view)
+
+    if running == expected_running do
+      assert running == expected_running
+    else
+      Process.sleep(10)
+      assert_running_state(view, expected_running, attempts - 1)
+    end
+  end
+
+  defp assert_running_state(view, expected_running, 0) do
+    assert view_running?(view) == expected_running
+  end
+
+  defp view_running?(view) do
+    :sys.get_state(view.pid).socket.assigns.running
   end
 end

--- a/test/aludel_web/live/suite_live/show_test.exs
+++ b/test/aludel_web/live/suite_live/show_test.exs
@@ -531,18 +531,24 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
       {:ok, view, _html} = live(conn, "/suites/#{suite.id}")
 
       capture_log(fn ->
-        render_submit(view, "run_suite", %{
-          "run_suite" => %{
-            "version_id" => version.id,
-            "provider_id" => invalid_provider_id
+        view
+        |> element("#run-suite-form")
+        |> render_submit(%{
+          run_suite: %{
+            version_id: version.id,
+            provider_id: invalid_provider_id
           }
         })
-
-        assert_running_state(view, false)
       end)
 
-      assert has_element?(view, "#flash-error", "Failed to execute suite: provider not found")
-      refute has_element?(view, "#run-suite-btn[disabled]")
+      assert_eventually(fn ->
+        has_element?(view, "#flash-error", "Failed to execute suite: provider not found")
+      end)
+
+      assert_eventually(fn ->
+        not has_element?(view, "#run-suite-btn[disabled]")
+      end)
+
       assert has_element?(view, "#run-suite-form option[selected][value='#{provider.id}']")
     end
 
@@ -563,9 +569,13 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
 
       send(view.pid, {:DOWN, monitor_ref, :process, self(), :boom})
 
-      assert_running_state(view, false)
-      assert has_element?(view, "#flash-error", "Suite execution crashed before completion")
-      refute has_element?(view, "#run-suite-btn[disabled]")
+      assert_eventually(fn ->
+        has_element?(view, "#flash-error", "Suite execution crashed before completion")
+      end)
+
+      assert_eventually(fn ->
+        not has_element?(view, "#run-suite-btn[disabled]")
+      end)
     end
 
     test "allows rerunning after a failed attempt", %{conn: conn} do
@@ -577,28 +587,36 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
       {:ok, view, _html} = live(conn, "/suites/#{suite.id}")
 
       capture_log(fn ->
-        render_submit(view, "run_suite", %{
-          "run_suite" => %{
-            "version_id" => version.id,
-            "provider_id" => Ecto.UUID.generate()
+        view
+        |> element("#run-suite-form")
+        |> render_submit(%{
+          run_suite: %{
+            version_id: version.id,
+            provider_id: Ecto.UUID.generate()
           }
         })
-
-        assert_running_state(view, false)
       end)
 
-      assert has_element?(view, "#flash-error", "Failed to execute suite: provider not found")
+      assert_eventually(fn ->
+        has_element?(view, "#flash-error", "Failed to execute suite: provider not found")
+      end)
 
-      render_submit(view, "run_suite", %{
-        "run_suite" => %{
-          "version_id" => version.id,
-          "provider_id" => provider.id
+      view
+      |> element("#run-suite-form")
+      |> render_submit(%{
+        run_suite: %{
+          version_id: version.id,
+          provider_id: provider.id
         }
       })
 
-      assert_running_state(view, false)
-      assert has_element?(view, "#flash-info", "Suite executed successfully")
-      refute has_element?(view, "#run-suite-btn[disabled]")
+      assert_eventually(fn ->
+        has_element?(view, "#flash-info", "Suite executed successfully")
+      end)
+
+      assert_eventually(fn ->
+        not has_element?(view, "#run-suite-btn[disabled]")
+      end)
     end
   end
 
@@ -620,24 +638,18 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
     end
   end
 
-  defp assert_running_state(view, expected_running, attempts \\ 20)
+  defp assert_eventually(fun, attempts \\ 20)
 
-  defp assert_running_state(view, expected_running, attempts) when attempts > 0 do
-    running = view_running?(view)
-
-    if running == expected_running do
-      assert running == expected_running
+  defp assert_eventually(fun, attempts) when attempts > 0 do
+    if fun.() do
+      assert fun.()
     else
       Process.sleep(10)
-      assert_running_state(view, expected_running, attempts - 1)
+      assert_eventually(fun, attempts - 1)
     end
   end
 
-  defp assert_running_state(view, expected_running, 0) do
-    assert view_running?(view) == expected_running
-  end
-
-  defp view_running?(view) do
-    :sys.get_state(view.pid).socket.assigns.running
+  defp assert_eventually(fun, 0) do
+    assert fun.()
   end
 end


### PR DESCRIPTION
## Motivation

This fixes issue #89.

`SuiteLive` could get stuck in a permanent running state when its background suite execution task crashed before sending `{:suite_completed, result}` back to the LiveView. That left the run button disabled and gave the user no actionable feedback.

This change keeps the LiveView thin and moves suite execution launch behind the evals boundary. The LiveView now only requests a launch, monitors the returned task pid, and clears its UI state on abnormal task exits.

## Test Plan

Commands run:

```bash
mix test test/aludel_web/live/suite_live/show_test.exs
mix precommit
```

Observed results:

- `mix test test/aludel_web/live/suite_live/show_test.exs` passed
- `mix precommit` passed

Coverage added:

- regression test for the failure path where the background suite execution task crashes before completion

## Next Steps

- confirm GitHub CI passes on the branch
- review whether other LiveViews that launch background work should follow the same boundary and monitoring pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Asynchronous, supervised suite execution that returns a monitor reference to callers and sends completion messages to the UI.

* **Improvements**
  * Clearer run-state tracking in the UI with crash detection, specific error flashes, and reliable run-button recovery.
  * More structured error mapping for missing resources and execution failures; execution errors are reported with clearer details.

* **Tests**
  * Expanded tests covering async launch, execution results, error cases, UI recovery, and monitor behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->