### PR TITLE
Refine provider pricing form

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -429,6 +429,311 @@ textarea {
   resize: vertical;
 }
 
+.pricing-panel {
+  margin-bottom: 16px;
+  padding: 20px;
+  border: 1px solid color-mix(in srgb, var(--border) 96%, transparent);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--bg-secondary) 98%, transparent);
+  box-shadow:
+    0 1px 2px rgba(15, 23, 42, 0.08),
+    0 8px 24px rgba(15, 23, 42, 0.06);
+}
+
+.pricing-panel-header {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.pricing-panel-copy-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.pricing-panel-title-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.pricing-panel-title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--text-heading);
+}
+
+.pricing-panel-copy {
+  max-width: 620px;
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.pricing-panel-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 100%;
+  min-width: 0;
+}
+
+.pricing-panel-meta-label {
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.pricing-panel-meta-value {
+  color: var(--text-heading);
+  font-size: 13px;
+  font-weight: 550;
+  line-height: 1.5;
+  letter-spacing: -0.01em;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+}
+
+.pricing-panel-meta.is-empty .pricing-panel-meta-value {
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.pricing-panel-toggle {
+  margin-top: 18px;
+  padding: 16px;
+  border: 1px solid color-mix(in srgb, var(--border) 92%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--bg-primary) 94%, transparent);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.04),
+    0 1px 2px rgba(15, 23, 42, 0.06);
+}
+
+.pricing-panel-toggle .label {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 0;
+  color: var(--text-heading);
+  font-size: 14px;
+  font-weight: 650;
+}
+
+.pricing-toggle-checkbox {
+  width: 18px;
+  height: 18px;
+  border: 1px solid color-mix(in srgb, var(--border) 96%, transparent);
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--bg-secondary) 100%, transparent);
+  box-shadow:
+    0 1px 2px rgba(15, 23, 42, 0.14),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.pricing-toggle-checkbox:hover {
+  border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
+  background: color-mix(in srgb, var(--bg-secondary) 100%, transparent);
+}
+
+.pricing-toggle-checkbox:checked,
+.pricing-toggle-checkbox[aria-checked="true"] {
+  border-color: color-mix(in srgb, var(--accent) 72%, white);
+  background-color: var(--accent);
+  color: white;
+}
+
+.pricing-toggle-checkbox:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 3px rgba(139, 92, 246, 0.14),
+    0 2px 8px rgba(15, 23, 42, 0.12);
+}
+
+.pricing-panel-toggle-copy {
+  margin: 8px 0 0 28px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.pricing-grid {
+  display: grid;
+  gap: 16px;
+  margin-top: 18px;
+}
+
+.pricing-rate-card {
+  padding: 18px;
+  border: 1px solid color-mix(in srgb, var(--border) 92%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--bg-primary) 96%, transparent);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.03),
+    0 1px 2px rgba(15, 23, 42, 0.05);
+}
+
+.pricing-rate-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.pricing-rate-title {
+  color: var(--text-heading);
+  font-size: 15px;
+  font-weight: 650;
+  letter-spacing: -0.02em;
+}
+
+.pricing-rate-badge {
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.pricing-stepper {
+  display: grid;
+  grid-template-columns: 36px minmax(0, 1fr) 36px;
+  align-items: stretch;
+  min-height: 46px;
+  border: 1px solid color-mix(in srgb, var(--border) 96%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--bg-secondary) 100%, transparent);
+  overflow: hidden;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.pricing-stepper:hover {
+  border-color: color-mix(in srgb, var(--accent) 44%, var(--border));
+}
+
+.pricing-stepper:focus-within {
+  border-color: color-mix(in srgb, var(--accent) 72%, white);
+  box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.12);
+}
+
+.pricing-stepper-input {
+  width: 100%;
+  min-width: 0;
+  height: 100%;
+  padding: 10px 12px;
+  border: 0;
+  border-left: 1px solid color-mix(in srgb, var(--border) 94%, transparent);
+  border-right: 1px solid color-mix(in srgb, var(--border) 94%, transparent);
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-heading);
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  font-variant-numeric: tabular-nums;
+  box-shadow: none;
+  text-align: center;
+}
+
+.pricing-stepper-input:hover,
+.pricing-stepper-input:focus {
+  border-left-color: color-mix(in srgb, var(--border) 94%, transparent);
+  border-right-color: color-mix(in srgb, var(--border) 94%, transparent);
+  box-shadow: none;
+}
+
+.aludel-stepper-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  border-radius: 0;
+  background: color-mix(in srgb, var(--bg-primary) 98%, transparent);
+  color: var(--text-heading);
+  box-shadow: none;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.aludel-stepper-button:hover {
+  background: color-mix(in srgb, var(--bg-primary) 90%, transparent);
+  color: var(--text-heading);
+  box-shadow: none;
+}
+
+.aludel-stepper-button:active {
+  transform: none;
+  background: color-mix(in srgb, var(--bg-primary) 88%, transparent);
+}
+
+.aludel-stepper-button:focus-visible {
+  outline: none;
+  position: relative;
+  z-index: 1;
+  color: var(--text-heading);
+}
+
+.aludel-stepper-glyph {
+  display: inline-block;
+  min-width: 1ch;
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: -0.04em;
+}
+
+.pricing-rate-copy {
+  margin: 10px 0 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.pricing-default-indicator {
+  margin-top: 18px;
+  padding: 14px 16px;
+  border: 1px dashed color-mix(in srgb, var(--border) 82%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--bg-primary) 92%, transparent);
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+@media (min-width: 768px) {
+  .pricing-panel-header {
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: space-between;
+  }
+
+  .pricing-panel-meta {
+    width: auto;
+    max-width: 320px;
+    flex: 0 1 320px;
+    align-items: flex-end;
+    text-align: right;
+  }
+
+  .pricing-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
 label {
   display: block;
   font-size: 13px;

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -712,6 +712,15 @@ textarea {
   color: var(--text-secondary);
   font-size: 13px;
   line-height: 1.6;
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.pricing-default-indicator-icon {
+  color: var(--text-secondary);
+  flex-shrink: 0;
+  margin-top: 1px;
 }
 
 @media (min-width: 768px) {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -29,6 +29,7 @@ import {AssertionTypeToggle} from "./hooks/assertion_type_toggle"
 import {CustomSelect} from "./hooks/custom_select"
 import {ActivityChart} from "./hooks/activity_chart"
 import {TagInput} from "./hooks/tag_input"
+import {StepperInput} from "./hooks/stepper_input"
 
 // Auto-dismiss flash messages after 5 seconds
 const AutoDismissFlash = {
@@ -91,7 +92,7 @@ const livePath = document.querySelector("meta[name='live-path']").getAttribute("
 const liveSocket = new LiveSocket(livePath, Socket, {
   transport: liveTran === "longpoll" ? LongPoll : WebSocket,
   params: {_csrf_token: csrfToken},
-  hooks: {AutoDismissFlash, EvolutionChart, AssertionTypeToggle, CustomSelect, ActivityChart, TagInput},
+  hooks: {AutoDismissFlash, EvolutionChart, AssertionTypeToggle, CustomSelect, ActivityChart, TagInput, StepperInput},
 })
 
 // Show progress bar on live navigation and form submits

--- a/assets/js/hooks/stepper_input.js
+++ b/assets/js/hooks/stepper_input.js
@@ -1,0 +1,70 @@
+export const StepperInput = {
+  mounted() {
+    this.input = this.el.querySelector("[data-stepper-input]")
+    this.buttons = Array.from(this.el.querySelectorAll("[data-stepper-direction]"))
+    this.step = parseFloat(this.el.dataset.step || "1") || 1
+    this.min = this.parseMin(this.el.dataset.min)
+    this.precision = this.decimalPlaces(this.el.dataset.step || "1")
+
+    this.handleClick = (event) => {
+      const button = event.currentTarget
+      const direction = button.dataset.stepperDirection
+
+      if (!this.input || this.input.disabled) {
+        return
+      }
+
+      const current = this.parseCurrentValue()
+      const delta = direction === "increment" ? this.step : -this.step
+      let nextValue = current + delta
+
+      if (this.min !== null) {
+        nextValue = Math.max(this.min, nextValue)
+      }
+
+      this.input.value = this.formatValue(nextValue)
+      this.input.dispatchEvent(new Event("input", {bubbles: true}))
+      this.input.dispatchEvent(new Event("change", {bubbles: true}))
+      this.input.focus()
+    }
+
+    this.buttons.forEach((button) => button.addEventListener("click", this.handleClick))
+  },
+
+  destroyed() {
+    this.buttons?.forEach((button) => button.removeEventListener("click", this.handleClick))
+  },
+
+  parseCurrentValue() {
+    const parsed = parseFloat(this.input.value)
+
+    if (!Number.isNaN(parsed)) {
+      return parsed
+    }
+
+    return this.min !== null ? this.min : 0
+  },
+
+  parseMin(value) {
+    if (value === undefined || value === null || value === "") {
+      return null
+    }
+
+    const parsed = parseFloat(value)
+    return Number.isNaN(parsed) ? null : parsed
+  },
+
+  decimalPlaces(step) {
+    const normalized = String(step)
+    const decimals = normalized.split(".")[1]
+    return decimals ? decimals.length : 0
+  },
+
+  formatValue(value) {
+    if (this.precision === 0) {
+      return `${Math.round(value)}`
+    }
+
+    return value.toFixed(this.precision)
+  }
+}

--- a/lib/aludel/web/components/core_components.ex
+++ b/lib/aludel/web/components/core_components.ex
@@ -397,6 +397,7 @@ defmodule Aludel.Web.CoreComponents do
   attr :errors, :list, default: []
   attr :step, :string, default: "1"
   attr :min, :string, default: nil
+  attr :aria_label, :string, default: nil
   attr :wrapper_class, :string, default: "aludel-stepper"
   attr :input_class, :string, default: "aludel-stepper-input"
 
@@ -418,7 +419,9 @@ defmodule Aludel.Web.CoreComponents do
   def stepper_input(assigns) do
     ~H"""
     <div class="fieldset mb-2">
-      <span :if={@label} class="label mb-1 block">{@label}</span>
+      <label :if={@label} id={"#{@id}-label"} for={@id} class="label mb-1 block">
+        {@label}
+      </label>
       <div
         id={"#{@id}-stepper"}
         class={[
@@ -434,6 +437,8 @@ defmodule Aludel.Web.CoreComponents do
           class="aludel-stepper-button"
           data-stepper-direction="decrement"
           aria-label={"Decrease #{@label || @name}"}
+          aria-disabled={to_string(!!@rest[:disabled])}
+          disabled={@rest[:disabled]}
         >
           <span class="aludel-stepper-glyph" aria-hidden="true">-</span>
         </button>
@@ -443,6 +448,8 @@ defmodule Aludel.Web.CoreComponents do
           name={@name}
           value={Phoenix.HTML.Form.normalize_value("text", @value)}
           class={@input_class}
+          aria-labelledby={@label && "#{@id}-label"}
+          aria-label={if @label, do: nil, else: @aria_label || to_string(@name)}
           data-stepper-input
           {@rest}
         />
@@ -451,6 +458,8 @@ defmodule Aludel.Web.CoreComponents do
           class="aludel-stepper-button"
           data-stepper-direction="increment"
           aria-label={"Increase #{@label || @name}"}
+          aria-disabled={to_string(!!@rest[:disabled])}
+          disabled={@rest[:disabled]}
         >
           <span class="aludel-stepper-glyph" aria-hidden="true">+</span>
         </button>

--- a/lib/aludel/web/components/core_components.ex
+++ b/lib/aludel/web/components/core_components.ex
@@ -386,6 +386,80 @@ defmodule Aludel.Web.CoreComponents do
     """
   end
 
+  @doc """
+  Renders a custom text-based numeric input with increment and decrement controls.
+  """
+  attr :id, :any, default: nil
+  attr :name, :any
+  attr :label, :string, default: nil
+  attr :value, :any
+  attr :field, Phoenix.HTML.FormField
+  attr :errors, :list, default: []
+  attr :step, :string, default: "1"
+  attr :min, :string, default: nil
+  attr :wrapper_class, :string, default: "aludel-stepper"
+  attr :input_class, :string, default: "aludel-stepper-input"
+
+  attr :rest, :global,
+    include: ~w(autocomplete disabled form inputmode max maxlength min minlength pattern
+                placeholder readonly required)
+
+  def stepper_input(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
+    errors = if Phoenix.Component.used_input?(field), do: field.errors, else: []
+
+    assigns
+    |> assign(field: nil, id: assigns.id || field.id)
+    |> assign(:errors, Enum.map(errors, &translate_error(&1)))
+    |> assign_new(:name, fn -> field.name end)
+    |> assign_new(:value, fn -> field.value end)
+    |> stepper_input()
+  end
+
+  def stepper_input(assigns) do
+    ~H"""
+    <div class="fieldset mb-2">
+      <span :if={@label} class="label mb-1 block">{@label}</span>
+      <div
+        id={"#{@id}-stepper"}
+        class={[
+          @wrapper_class,
+          @errors != [] && "aludel-stepper-error"
+        ]}
+        phx-hook="StepperInput"
+        data-step={@step}
+        data-min={@min || ""}
+      >
+        <button
+          type="button"
+          class="aludel-stepper-button"
+          data-stepper-direction="decrement"
+          aria-label={"Decrease #{@label || @name}"}
+        >
+          <span class="aludel-stepper-glyph" aria-hidden="true">-</span>
+        </button>
+        <input
+          type="text"
+          id={@id}
+          name={@name}
+          value={Phoenix.HTML.Form.normalize_value("text", @value)}
+          class={@input_class}
+          data-stepper-input
+          {@rest}
+        />
+        <button
+          type="button"
+          class="aludel-stepper-button"
+          data-stepper-direction="increment"
+          aria-label={"Increase #{@label || @name}"}
+        >
+          <span class="aludel-stepper-glyph" aria-hidden="true">+</span>
+        </button>
+      </div>
+      <.error :for={msg <- @errors}>{msg}</.error>
+    </div>
+    """
+  end
+
   defp normalize_select_options(options) do
     Enum.flat_map(options, fn
       {group_label, group_options} when is_list(group_options) ->

--- a/lib/aludel/web/live/provider_live/new.ex
+++ b/lib/aludel/web/live/provider_live/new.ex
@@ -302,6 +302,21 @@ defmodule Aludel.Web.ProviderLive.New do
   defp resolve_pricing_inputs(
          pricing_input,
          pricing_output,
+         true,
+         nil,
+         previous_default_pricing
+       ) do
+    if (blank_string?(pricing_input) and blank_string?(pricing_output)) or
+         matches_default_pricing?(pricing_input, pricing_output, previous_default_pricing) do
+      {"", ""}
+    else
+      {pricing_input || "", pricing_output || ""}
+    end
+  end
+
+  defp resolve_pricing_inputs(
+         pricing_input,
+         pricing_output,
          _custom_pricing_enabled,
          _default_pricing,
          _previous_default_pricing

--- a/lib/aludel/web/live/provider_live/new.ex
+++ b/lib/aludel/web/live/provider_live/new.ex
@@ -31,9 +31,17 @@ defmodule Aludel.Web.ProviderLive.New do
     model_groups = Providers.fetch_model_groups(provider_type)
 
     custom_pricing_enabled = provider_params["custom_pricing_enabled"] == "true"
+    model = resolve_model(provider_params, model_groups)
+    default_pricing = Providers.default_pricing(provider_type, model)
 
-    pricing_input = provider_params["pricing_input"] || ""
-    pricing_output = provider_params["pricing_output"] || ""
+    {pricing_input, pricing_output} =
+      resolve_pricing_inputs(
+        provider_params["pricing_input"],
+        provider_params["pricing_output"],
+        custom_pricing_enabled,
+        default_pricing,
+        socket.assigns.default_pricing
+      )
 
     changeset =
       socket.assigns.provider
@@ -47,9 +55,6 @@ defmodule Aludel.Web.ProviderLive.New do
       |> ensure_model_selection(model_groups)
       |> validate_model_selection()
       |> Map.put(:action, :validate)
-
-    model = resolve_model(provider_params, model_groups)
-    default_pricing = Providers.default_pricing(provider_type, model)
 
     {:noreply,
      socket
@@ -277,5 +282,42 @@ defmodule Aludel.Web.ProviderLive.New do
       value when is_binary(value) and value != "" -> value
       _ -> nil
     end
+  end
+
+  defp resolve_pricing_inputs(
+         pricing_input,
+         pricing_output,
+         true,
+         %{input: input, output: output},
+         previous_default_pricing
+       ) do
+    if (blank_string?(pricing_input) and blank_string?(pricing_output)) or
+         matches_default_pricing?(pricing_input, pricing_output, previous_default_pricing) do
+      {format_price(input), format_price(output)}
+    else
+      {pricing_input || "", pricing_output || ""}
+    end
+  end
+
+  defp resolve_pricing_inputs(
+         pricing_input,
+         pricing_output,
+         _custom_pricing_enabled,
+         _default_pricing,
+         _previous_default_pricing
+       ) do
+    {pricing_input || "", pricing_output || ""}
+  end
+
+  defp blank_string?(value), do: value in [nil, ""]
+
+  defp matches_default_pricing?(_pricing_input, _pricing_output, nil), do: false
+
+  defp matches_default_pricing?(pricing_input, pricing_output, %{input: input, output: output}) do
+    pricing_input == format_price(input) and pricing_output == format_price(output)
+  end
+
+  defp format_price(value) when is_number(value) do
+    :erlang.float_to_binary(value / 1, decimals: 2)
   end
 end

--- a/lib/aludel/web/live/provider_live/new.html.heex
+++ b/lib/aludel/web/live/provider_live/new.html.heex
@@ -125,6 +125,7 @@
                 </div>
                 <.stepper_input
                   field={@form[:pricing_input]}
+                  aria_label="Input price"
                   wrapper_class="pricing-stepper"
                   input_class="pricing-stepper-input"
                   step="0.01"
@@ -144,6 +145,7 @@
                 </div>
                 <.stepper_input
                   field={@form[:pricing_output]}
+                  aria_label="Output price"
                   wrapper_class="pricing-stepper"
                   input_class="pricing-stepper-input"
                   step="0.01"
@@ -162,7 +164,13 @@
               id="pricing-default-indicator"
               class="pricing-default-indicator"
             >
-              Using the selected model&apos;s default pricing from the model database.
+              <.icon
+                name="hero-information-circle"
+                class="pricing-default-indicator-icon"
+              />
+              <span>
+                Using the selected model&apos;s default pricing from the model database.
+              </span>
             </div>
           <% end %>
         </section>

--- a/lib/aludel/web/live/provider_live/new.html.heex
+++ b/lib/aludel/web/live/provider_live/new.html.heex
@@ -63,64 +63,109 @@
           </div>
         <% end %>
 
-        <div
-          id="pricing-section"
-          style="margin-bottom: 16px; padding: 16px; border: 1px solid var(--border); border-radius: 8px; background: var(--bg-secondary);"
-        >
-          <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px;">
-            <span style="font-weight: 600; font-size: 14px;">Pricing</span>
-            <span
-              id="default-pricing-display"
-              style="font-size: 13px; color: var(--text-secondary);"
-            >
-              <%= if @default_pricing do %>
-                Default: {Aludel.Providers.Pricing.format_pricing(@default_pricing)}
-              <% else %>
-                No default pricing available
-              <% end %>
-            </span>
+        <section id="pricing-section" class="pricing-panel">
+          <div class="pricing-panel-header">
+            <div class="pricing-panel-copy-wrap">
+              <div class="pricing-panel-title-row">
+                <h2 id="pricing-section-heading" class="pricing-panel-title">
+                  Pricing
+                </h2>
+              </div>
+              <p id="pricing-section-copy" class="pricing-panel-copy">
+                Default model pricing is applied automatically. Add an override only when this provider uses different token rates.
+              </p>
+            </div>
+
+            <%= if !@custom_pricing_enabled do %>
+              <div
+                id="default-pricing-display"
+                class={[
+                  "pricing-panel-meta",
+                  @default_pricing && "is-default",
+                  !@default_pricing && "is-empty"
+                ]}
+              >
+                <%= if @default_pricing do %>
+                  <div class="pricing-panel-meta-label">
+                    <span>Default</span>
+                  </div>
+                  <div class="pricing-panel-meta-value">
+                    {Aludel.Providers.Pricing.format_pricing(@default_pricing)}
+                  </div>
+                <% else %>
+                  <div class="pricing-panel-meta-label">
+                    <span>Pricing unavailable</span>
+                  </div>
+                  <div class="pricing-panel-meta-value">
+                    No default pricing is available for the selected model yet.
+                  </div>
+                <% end %>
+              </div>
+            <% end %>
           </div>
 
-          <div style="margin-bottom: 12px;">
+          <div class="pricing-panel-toggle">
             <.input
               field={@form[:custom_pricing_enabled]}
               type="checkbox"
+              class="checkbox checkbox-sm pricing-toggle-checkbox"
               label="Use custom pricing"
             />
+            <p class="pricing-panel-toggle-copy">
+              Enable this when you need provider-specific rates instead of the shared model catalog.
+            </p>
           </div>
 
           <%= if @custom_pricing_enabled do %>
-            <div id="custom-pricing-fields" style="display: flex; gap: 16px;">
-              <div style="flex: 1;">
-                <.input
+            <div id="custom-pricing-fields" class="pricing-grid">
+              <div class="pricing-rate-card">
+                <div class="pricing-rate-header">
+                  <div class="pricing-rate-title">Input price</div>
+                  <span class="pricing-rate-badge">Prompt tokens</span>
+                </div>
+                <.stepper_input
                   field={@form[:pricing_input]}
-                  type="number"
-                  label="Input price (per 1M tokens)"
+                  wrapper_class="pricing-stepper"
+                  input_class="pricing-stepper-input"
                   step="0.01"
                   min="0"
+                  inputmode="decimal"
+                  pattern="^[0-9]*[.]?[0-9]+$"
                   placeholder="3.00"
                 />
+                <p class="pricing-rate-copy">
+                  Price per 1M prompt and input tokens.
+                </p>
               </div>
-              <div style="flex: 1;">
-                <.input
+              <div class="pricing-rate-card">
+                <div class="pricing-rate-header">
+                  <div class="pricing-rate-title">Output price</div>
+                  <span class="pricing-rate-badge">Completion tokens</span>
+                </div>
+                <.stepper_input
                   field={@form[:pricing_output]}
-                  type="number"
-                  label="Output price (per 1M tokens)"
+                  wrapper_class="pricing-stepper"
+                  input_class="pricing-stepper-input"
                   step="0.01"
                   min="0"
+                  inputmode="decimal"
+                  pattern="^[0-9]*[.]?[0-9]+$"
                   placeholder="15.00"
                 />
+                <p class="pricing-rate-copy">
+                  Price per 1M generated and completion tokens.
+                </p>
               </div>
             </div>
           <% else %>
             <div
               id="pricing-default-indicator"
-              style="font-size: 13px; color: var(--text-secondary);"
+              class="pricing-default-indicator"
             >
-              Using default pricing from model database
+              Using the selected model&apos;s default pricing from the model database.
             </div>
           <% end %>
-        </div>
+        </section>
 
         <div>
           <div class="fieldset mb-2">

--- a/priv/static/app.css
+++ b/priv/static/app.css
@@ -2530,6 +2530,334 @@ textarea {
   min-height: 100px;
   resize: vertical;
 }
+.pricing-panel {
+  margin-bottom: 16px;
+  padding: 20px;
+  border: 1px solid var(--border);
+  @supports (color: color-mix(in lab, red, red)) {
+    border: 1px solid color-mix(in srgb, var(--border) 96%, transparent);
+  }
+  border-radius: 10px;
+  background: var(--bg-secondary);
+  @supports (color: color-mix(in lab, red, red)) {
+    background: color-mix(in srgb, var(--bg-secondary) 98%, transparent);
+  }
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08), 0 8px 24px rgba(15, 23, 42, 0.06);
+}
+.pricing-panel-header {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.pricing-panel-copy-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.pricing-panel-title-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.pricing-panel-title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--text-heading);
+}
+.pricing-panel-copy {
+  max-width: 620px;
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.6;
+}
+.pricing-panel-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 100%;
+  min-width: 0;
+}
+.pricing-panel-meta-label {
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.pricing-panel-meta-value {
+  color: var(--text-heading);
+  font-size: 13px;
+  font-weight: 550;
+  line-height: 1.5;
+  letter-spacing: -0.01em;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+}
+.pricing-panel-meta.is-empty .pricing-panel-meta-value {
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+.pricing-panel-toggle {
+  margin-top: 18px;
+  padding: 16px;
+  border: 1px solid var(--border);
+  @supports (color: color-mix(in lab, red, red)) {
+    border: 1px solid color-mix(in srgb, var(--border) 92%, transparent);
+  }
+  border-radius: 8px;
+  background: var(--bg-primary);
+  @supports (color: color-mix(in lab, red, red)) {
+    background: color-mix(in srgb, var(--bg-primary) 94%, transparent);
+  }
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 1px 2px rgba(15, 23, 42, 0.06);
+}
+.pricing-panel-toggle .label {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 0;
+  color: var(--text-heading);
+  font-size: 14px;
+  font-weight: 650;
+}
+.pricing-toggle-checkbox {
+  width: 18px;
+  height: 18px;
+  border: 1px solid var(--border);
+  @supports (color: color-mix(in lab, red, red)) {
+    border: 1px solid color-mix(in srgb, var(--border) 96%, transparent);
+  }
+  border-radius: 4px;
+  background: var(--bg-secondary);
+  @supports (color: color-mix(in lab, red, red)) {
+    background: color-mix(in srgb, var(--bg-secondary) 100%, transparent);
+  }
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.14), inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+.pricing-toggle-checkbox:hover {
+  border-color: var(--accent);
+  @supports (color: color-mix(in lab, red, red)) {
+    border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
+  }
+  background: var(--bg-secondary);
+  @supports (color: color-mix(in lab, red, red)) {
+    background: color-mix(in srgb, var(--bg-secondary) 100%, transparent);
+  }
+}
+.pricing-toggle-checkbox:checked, .pricing-toggle-checkbox[aria-checked="true"] {
+  border-color: var(--accent);
+  @supports (color: color-mix(in lab, red, red)) {
+    border-color: color-mix(in srgb, var(--accent) 72%, white);
+  }
+  background-color: var(--accent);
+  color: white;
+}
+.pricing-toggle-checkbox:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.14), 0 2px 8px rgba(15, 23, 42, 0.12);
+}
+.pricing-panel-toggle-copy {
+  margin: 8px 0 0 28px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.6;
+}
+.pricing-grid {
+  display: grid;
+  gap: 16px;
+  margin-top: 18px;
+}
+.pricing-rate-card {
+  padding: 18px;
+  border: 1px solid var(--border);
+  @supports (color: color-mix(in lab, red, red)) {
+    border: 1px solid color-mix(in srgb, var(--border) 92%, transparent);
+  }
+  border-radius: 8px;
+  background: var(--bg-primary);
+  @supports (color: color-mix(in lab, red, red)) {
+    background: color-mix(in srgb, var(--bg-primary) 96%, transparent);
+  }
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03), 0 1px 2px rgba(15, 23, 42, 0.05);
+}
+.pricing-rate-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+.pricing-rate-title {
+  color: var(--text-heading);
+  font-size: 15px;
+  font-weight: 650;
+  letter-spacing: -0.02em;
+}
+.pricing-rate-badge {
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.pricing-stepper {
+  display: grid;
+  grid-template-columns: 36px minmax(0, 1fr) 36px;
+  align-items: stretch;
+  min-height: 46px;
+  border: 1px solid var(--border);
+  @supports (color: color-mix(in lab, red, red)) {
+    border: 1px solid color-mix(in srgb, var(--border) 96%, transparent);
+  }
+  border-radius: 8px;
+  background: var(--bg-secondary);
+  @supports (color: color-mix(in lab, red, red)) {
+    background: color-mix(in srgb, var(--bg-secondary) 100%, transparent);
+  }
+  overflow: hidden;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.pricing-stepper:hover {
+  border-color: var(--accent);
+  @supports (color: color-mix(in lab, red, red)) {
+    border-color: color-mix(in srgb, var(--accent) 44%, var(--border));
+  }
+}
+.pricing-stepper:focus-within {
+  border-color: var(--accent);
+  @supports (color: color-mix(in lab, red, red)) {
+    border-color: color-mix(in srgb, var(--accent) 72%, white);
+  }
+  box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.12);
+}
+.pricing-stepper-input {
+  width: 100%;
+  min-width: 0;
+  height: 100%;
+  padding: 10px 12px;
+  border: 0;
+  border-left: 1px solid var(--border);
+  @supports (color: color-mix(in lab, red, red)) {
+    border-left: 1px solid color-mix(in srgb, var(--border) 94%, transparent);
+  }
+  border-right: 1px solid var(--border);
+  @supports (color: color-mix(in lab, red, red)) {
+    border-right: 1px solid color-mix(in srgb, var(--border) 94%, transparent);
+  }
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-heading);
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  font-variant-numeric: tabular-nums;
+  box-shadow: none;
+  text-align: center;
+}
+.pricing-stepper-input:hover, .pricing-stepper-input:focus {
+  border-left-color: var(--border);
+  @supports (color: color-mix(in lab, red, red)) {
+    border-left-color: color-mix(in srgb, var(--border) 94%, transparent);
+  }
+  border-right-color: var(--border);
+  @supports (color: color-mix(in lab, red, red)) {
+    border-right-color: color-mix(in srgb, var(--border) 94%, transparent);
+  }
+  box-shadow: none;
+}
+.aludel-stepper-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  border-radius: 0;
+  background: var(--bg-primary);
+  @supports (color: color-mix(in lab, red, red)) {
+    background: color-mix(in srgb, var(--bg-primary) 98%, transparent);
+  }
+  color: var(--text-heading);
+  box-shadow: none;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+.aludel-stepper-button:hover {
+  background: var(--bg-primary);
+  @supports (color: color-mix(in lab, red, red)) {
+    background: color-mix(in srgb, var(--bg-primary) 90%, transparent);
+  }
+  color: var(--text-heading);
+  box-shadow: none;
+}
+.aludel-stepper-button:active {
+  transform: none;
+  background: var(--bg-primary);
+  @supports (color: color-mix(in lab, red, red)) {
+    background: color-mix(in srgb, var(--bg-primary) 88%, transparent);
+  }
+}
+.aludel-stepper-button:focus-visible {
+  outline: none;
+  position: relative;
+  z-index: 1;
+  color: var(--text-heading);
+}
+.aludel-stepper-glyph {
+  display: inline-block;
+  min-width: 1ch;
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: -0.04em;
+}
+.pricing-rate-copy {
+  margin: 10px 0 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.55;
+}
+.pricing-default-indicator {
+  margin-top: 18px;
+  padding: 14px 16px;
+  border: 1px dashed var(--border);
+  @supports (color: color-mix(in lab, red, red)) {
+    border: 1px dashed color-mix(in srgb, var(--border) 82%, transparent);
+  }
+  border-radius: 8px;
+  background: var(--bg-primary);
+  @supports (color: color-mix(in lab, red, red)) {
+    background: color-mix(in srgb, var(--bg-primary) 92%, transparent);
+  }
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.6;
+}
+@media (min-width: 768px) {
+  .pricing-panel-header {
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: space-between;
+  }
+  .pricing-panel-meta {
+    width: auto;
+    max-width: 320px;
+    flex: 0 1 320px;
+    align-items: flex-end;
+    text-align: right;
+  }
+  .pricing-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
 label {
   display: block;
   font-size: 13px;

--- a/priv/static/app.css
+++ b/priv/static/app.css
@@ -2840,6 +2840,14 @@ textarea {
   color: var(--text-secondary);
   font-size: 13px;
   line-height: 1.6;
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+.pricing-default-indicator-icon {
+  color: var(--text-secondary);
+  flex-shrink: 0;
+  margin-top: 1px;
 }
 @media (min-width: 768px) {
   .pricing-panel-header {

--- a/priv/static/app.js
+++ b/priv/static/app.js
@@ -20904,6 +20904,63 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
     }
   };
 
+  // assets/js/hooks/stepper_input.js
+  var StepperInput = {
+    mounted() {
+      this.input = this.el.querySelector("[data-stepper-input]");
+      this.buttons = Array.from(this.el.querySelectorAll("[data-stepper-direction]"));
+      this.step = parseFloat(this.el.dataset.step || "1") || 1;
+      this.min = this.parseMin(this.el.dataset.min);
+      this.precision = this.decimalPlaces(this.el.dataset.step || "1");
+      this.handleClick = (event) => {
+        const button = event.currentTarget;
+        const direction = button.dataset.stepperDirection;
+        if (!this.input || this.input.disabled) {
+          return;
+        }
+        const current = this.parseCurrentValue();
+        const delta = direction === "increment" ? this.step : -this.step;
+        let nextValue = current + delta;
+        if (this.min !== null) {
+          nextValue = Math.max(this.min, nextValue);
+        }
+        this.input.value = this.formatValue(nextValue);
+        this.input.dispatchEvent(new Event("input", { bubbles: true }));
+        this.input.dispatchEvent(new Event("change", { bubbles: true }));
+        this.input.focus();
+      };
+      this.buttons.forEach((button) => button.addEventListener("click", this.handleClick));
+    },
+    destroyed() {
+      this.buttons?.forEach((button) => button.removeEventListener("click", this.handleClick));
+    },
+    parseCurrentValue() {
+      const parsed = parseFloat(this.input.value);
+      if (!Number.isNaN(parsed)) {
+        return parsed;
+      }
+      return this.min !== null ? this.min : 0;
+    },
+    parseMin(value) {
+      if (value === void 0 || value === null || value === "") {
+        return null;
+      }
+      const parsed = parseFloat(value);
+      return Number.isNaN(parsed) ? null : parsed;
+    },
+    decimalPlaces(step) {
+      const normalized = String(step);
+      const decimals = normalized.split(".")[1];
+      return decimals ? decimals.length : 0;
+    },
+    formatValue(value) {
+      if (this.precision === 0) {
+        return `${Math.round(value)}`;
+      }
+      return value.toFixed(this.precision);
+    }
+  };
+
   // assets/js/app.js
   var AutoDismissFlash = {
     mounted() {
@@ -20952,7 +21009,7 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
   var liveSocket = new LiveSocket2(livePath, Socket, {
     transport: liveTran === "longpoll" ? LongPoll : WebSocket,
     params: { _csrf_token: csrfToken },
-    hooks: { AutoDismissFlash, EvolutionChart, AssertionTypeToggle, CustomSelect, ActivityChart, TagInput }
+    hooks: { AutoDismissFlash, EvolutionChart, AssertionTypeToggle, CustomSelect, ActivityChart, TagInput, StepperInput }
   });
   import_topbar.default.config({ barColors: { 0: "#29d" }, shadowColor: "rgba(0, 0, 0, .3)" });
   window.addEventListener("phx:page-loading-start", (_info) => import_topbar.default.show(300));

--- a/test/aludel_web/live/provider_live/new_test.exs
+++ b/test/aludel_web/live/provider_live/new_test.exs
@@ -15,6 +15,92 @@ defmodule Aludel.Web.ProviderLive.NewTest do
       assert has_element?(view, "#provider-form select[name='provider[model_selection]']")
       assert has_element?(view, "#provider_provider-select[phx-hook='CustomSelect']")
       assert has_element?(view, "#provider_provider[data-select-input]")
+      assert has_element?(view, "#pricing-section.pricing-panel")
+      assert has_element?(view, "#pricing-section-heading", "Pricing")
+      assert has_element?(view, "#default-pricing-display.pricing-panel-meta")
+
+      assert has_element?(
+               view,
+               "#pricing-section-copy",
+               "Default model pricing is applied automatically"
+             )
+    end
+
+    test "renders custom pricing steppers when pricing override is enabled", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/providers/new")
+
+      html =
+        view
+        |> form("#provider-form", provider: %{custom_pricing_enabled: "true"})
+        |> render_change()
+
+      assert html =~ "data-stepper-direction=\"decrement\""
+      assert has_element?(view, "#provider_pricing_input-stepper")
+      assert has_element?(view, "#provider_pricing_output-stepper")
+      refute has_element?(view, "#default-pricing-display")
+    end
+
+    test "prefills custom pricing inputs from default pricing when enabled", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/providers/new")
+
+      default_pricing = Providers.default_pricing("openai", "gpt-4o")
+      assert default_pricing
+
+      render_change(view, :validate, %{
+        "provider" => %{
+          "provider" => "openai",
+          "model_selection" => "gpt-4o",
+          "custom_pricing_enabled" => "true",
+          "pricing_input" => "",
+          "pricing_output" => ""
+        }
+      })
+
+      assert has_element?(
+               view,
+               "#provider_pricing_input[value='#{format_price(default_pricing.input)}']"
+             )
+
+      assert has_element?(
+               view,
+               "#provider_pricing_output[value='#{format_price(default_pricing.output)}']"
+             )
+    end
+
+    test "refreshes auto-filled custom pricing when the selected model changes", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/providers/new")
+
+      {first_model, second_model, first_pricing, second_pricing} = distinct_openai_pricing_pair()
+
+      render_change(view, :validate, %{
+        "provider" => %{
+          "provider" => "openai",
+          "model_selection" => first_model,
+          "custom_pricing_enabled" => "true",
+          "pricing_input" => "",
+          "pricing_output" => ""
+        }
+      })
+
+      render_change(view, :validate, %{
+        "provider" => %{
+          "provider" => "openai",
+          "model_selection" => second_model,
+          "custom_pricing_enabled" => "true",
+          "pricing_input" => format_price(first_pricing.input),
+          "pricing_output" => format_price(first_pricing.output)
+        }
+      })
+
+      assert has_element?(
+               view,
+               "#provider_pricing_input[value='#{format_price(second_pricing.input)}']"
+             )
+
+      assert has_element?(
+               view,
+               "#provider_pricing_output[value='#{format_price(second_pricing.output)}']"
+             )
     end
 
     test "shows custom input when custom model is selected", %{conn: conn} do
@@ -231,6 +317,34 @@ defmodule Aludel.Web.ProviderLive.NewTest do
       reloaded_provider = Providers.get_provider!(provider.id)
       assert reloaded_provider.name == "Existing Provider"
       assert reloaded_provider.model == "gpt-4o"
+    end
+  end
+
+  defp format_price(value) when is_number(value) do
+    :erlang.float_to_binary(value / 1, decimals: 2)
+  end
+
+  defp distinct_openai_pricing_pair do
+    models = Providers.fetch_model_groups("openai").active
+
+    models
+    |> Enum.flat_map(fn first ->
+      first_pricing = Providers.default_pricing("openai", first.id)
+
+      Enum.map(models, fn second ->
+        {first, second, first_pricing, Providers.default_pricing("openai", second.id)}
+      end)
+    end)
+    |> Enum.find(fn {first, second, first_pricing, second_pricing} ->
+      first.id != second.id and is_map(first_pricing) and is_map(second_pricing) and
+        first_pricing != second_pricing
+    end)
+    |> case do
+      {first, second, first_pricing, second_pricing} ->
+        {first.id, second.id, first_pricing, second_pricing}
+
+      nil ->
+        raise "expected at least two OpenAI models with distinct default pricing"
     end
   end
 end

--- a/test/aludel_web/live/provider_live/new_test.exs
+++ b/test/aludel_web/live/provider_live/new_test.exs
@@ -18,6 +18,7 @@ defmodule Aludel.Web.ProviderLive.NewTest do
       assert has_element?(view, "#pricing-section.pricing-panel")
       assert has_element?(view, "#pricing-section-heading", "Pricing")
       assert has_element?(view, "#default-pricing-display.pricing-panel-meta")
+      assert has_element?(view, "#pricing-default-indicator .pricing-default-indicator-icon")
 
       assert has_element?(
                view,
@@ -101,6 +102,39 @@ defmodule Aludel.Web.ProviderLive.NewTest do
                view,
                "#provider_pricing_output[value='#{format_price(second_pricing.output)}']"
              )
+    end
+
+    test "clears auto-filled custom pricing when the next model has no default pricing", %{
+      conn: conn
+    } do
+      {:ok, view, _html} = live(conn, "/providers/new")
+
+      default_pricing = Providers.default_pricing("openai", "gpt-4o")
+      assert default_pricing
+
+      render_change(view, :validate, %{
+        "provider" => %{
+          "provider" => "openai",
+          "model_selection" => "gpt-4o",
+          "custom_pricing_enabled" => "true",
+          "pricing_input" => "",
+          "pricing_output" => ""
+        }
+      })
+
+      render_change(view, :validate, %{
+        "provider" => %{
+          "provider" => "openai",
+          "model_selection" => "custom",
+          "model_custom" => "my-unpriced-model",
+          "custom_pricing_enabled" => "true",
+          "pricing_input" => format_price(default_pricing.input),
+          "pricing_output" => format_price(default_pricing.output)
+        }
+      })
+
+      assert has_element?(view, "#provider_pricing_input[value='']")
+      assert has_element?(view, "#provider_pricing_output[value='']")
     end
 
     test "shows custom input when custom model is selected", %{conn: conn} do


### PR DESCRIPTION
## Motivation (required)

The provider pricing section had a few UX issues that made configuring overrides harder than it needed to be:

- the pricing UI did not match the rest of the form
- custom pricing required manual entry even when model defaults were already known
- the native number widget did not fit the desired UI, so the stepper controls needed a more intentional interaction

This change refines the pricing section into a cleaner control surface, adds a custom stepper input, seeds custom pricing from model defaults, and refreshes those seeded values when the selected model changes unless the user has already edited them.

## Test Plan (required)

Ran the following commands locally:

```bash
mix test test/aludel_web/live/provider_live/new_test.exs
mix compile --warnings-as-errors
mix precommit
mix assets.build
```
## Screenshots

<img width="640" height="433" alt="Screenshot 2026-04-14 at 22 07 53" src="https://github.com/user-attachments/assets/b1aae4fc-2584-4540-bfa5-a9c8c5272b7a" />
<img width="640" height="509" alt="Screenshot 2026-04-14 at 22 08 03" src="https://github.com/user-attachments/assets/a22363c5-8a34-4c0b-a635-d7b62ca49963" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stepper numeric controls and improved styling added to the pricing inputs and toggle, plus responsive pricing panel layout.

* **Behavior Fixes**
  * Pricing inputs now correctly preserve, autofill, or clear values when toggling custom pricing and switching models.

* **Tests**
  * Added UI tests covering pricing panel rendering, steppers, autofill behavior, and model-driven pricing updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->