### PR TITLE
fix: make json_field assertions type-aware for scalar comparisons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ assets/.DS_Store
 CLAUDE.md
 
 # Codex configuration
+
+# Dexter local state
+.dexter.db*

--- a/lib/aludel/evals.ex
+++ b/lib/aludel/evals.ex
@@ -544,8 +544,8 @@ defmodule Aludel.Evals do
   end
 
   defp compare_json_values(actual, expected) do
-    # For scalars (string, number, boolean, nil), convert to string
-    to_string(actual) == to_string(expected)
+    # Scalars should preserve JSON semantics instead of coercing types.
+    actual == expected
   end
 
   defp repo, do: Aludel.Repo.get()

--- a/test/aludel/evals_test.exs
+++ b/test/aludel/evals_test.exs
@@ -662,6 +662,46 @@ defmodule Aludel.EvalsTest do
       assert {:ok, suite_run} = Evals.execute_suite(suite, version, provider)
       assert suite_run.failed == 1
     end
+
+    test "json_field passes for exact string scalar matches" do
+      assert {:ok, suite_run} = execute_json_field_suite(~s({"status":"ok"}), "status", "ok")
+
+      assert suite_run.passed == 1
+      assert suite_run.failed == 0
+
+      assert [%{"assertion_results" => [%{"actual_value" => "ok", "passed" => true}]}] =
+               suite_run.results
+    end
+
+    test "json_field fails on number and string scalar mismatches" do
+      assert {:ok, suite_run} = execute_json_field_suite(~s({"count":1}), "count", "1")
+
+      assert suite_run.passed == 0
+      assert suite_run.failed == 1
+
+      assert [%{"assertion_results" => [%{"actual_value" => 1, "passed" => false}]}] =
+               suite_run.results
+    end
+
+    test "json_field fails on boolean and string scalar mismatches" do
+      assert {:ok, suite_run} = execute_json_field_suite(~s({"active":true}), "active", "true")
+
+      assert suite_run.passed == 0
+      assert suite_run.failed == 1
+
+      assert [%{"assertion_results" => [%{"actual_value" => true, "passed" => false}]}] =
+               suite_run.results
+    end
+
+    test "json_field fails on nil and string scalar mismatches" do
+      assert {:ok, suite_run} = execute_json_field_suite(~s({"note":null}), "note", "nil")
+
+      assert suite_run.passed == 0
+      assert suite_run.failed == 1
+
+      assert [%{"assertion_results" => [%{"actual_value" => nil, "passed" => false}]}] =
+               suite_run.results
+    end
   end
 
   describe "test_case_documents" do
@@ -800,5 +840,27 @@ defmodule Aludel.EvalsTest do
       input_tokens: input_tokens,
       output_tokens: output_tokens
     }
+  end
+
+  defp execute_json_field_suite(output, field, expected) do
+    mock_response = build_mock_response(output, 5, 10)
+
+    expect(HttpClientMock, :request, fn _model, _prompt, _opts ->
+      {:ok, mock_response}
+    end)
+
+    suite = suite_fixture()
+    prompt = prompt_fixture()
+    {:ok, version} = Aludel.Prompts.create_prompt_version(prompt, "Return JSON")
+    provider = provider_fixture()
+
+    _test_case =
+      test_case_fixture(%{
+        suite_id: suite.id,
+        variable_values: %{},
+        assertions: [%{"type" => "json_field", "field" => field, "expected" => expected}]
+      })
+
+    Evals.execute_suite(suite, version, provider)
   end
 end


### PR DESCRIPTION
Closes #87

## Motivation (required)

`json_field` assertions were coercing scalar values with `to_string/1`, which allowed semantically different JSON values to pass. In practice this meant values like `1` and `"1"` or `true` and `"true"` could be treated as equal, weakening structured-output validation and inflating suite pass rates.

This change keeps `json_field` strict for scalar comparisons by using direct equality, while preserving the existing explicit handling for map and list comparisons. It also adds regression coverage for exact string matches and scalar type mismatches.

## Test Plan (required)

Commands run:

`mix test test/aludel/evals_test.exs`

Output:

```text
Running ExUnit with seed: 391843, max_cases: 28

.......................................................
Finished in 0.3 seconds (0.00s async, 0.3s sync)
55 tests, 0 failures
```

`mix precommit`

Output:

```text
Checking 140 source files (this might take a while) ...
841 mods/funs, found no issues.
... SCAN COMPLETE ...
Running ExUnit with seed: 108515, max_cases: 28
510 tests, 0 failures
```

Runtime smoke exercise:

`MIX_ENV=test mix run -e '...'`

Output:

```text
json_field_smoke: [
  {"count", false, 1},
  {"active", false, true},
  {"note", true, nil},
  {"status", true, "ok"}
]
```

## Next Steps

If we want string-authored datasets to drive typed `json_field` expectations more ergonomically, the next follow-up should be explicit normalization or a separate coercive assertion mode rather than relaxing the default structured comparison.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * JSON field assertions now use strict equality for scalar values, changing pass/fail outcomes when types differ (e.g., numeric vs string).

* **Tests**
  * Added tests covering JSON field assertions to validate the updated comparison behavior.

* **Chores**
  * Updated ignore rules to exclude local Dexter state files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->