### PR TITLE
fix: enforce assertion validation consistently across visual and JSON editors

### DIFF
--- a/lib/aludel/evals/assertion_parser.ex
+++ b/lib/aludel/evals/assertion_parser.ex
@@ -37,25 +37,9 @@ defmodule Aludel.Evals.AssertionParser do
     assertions
     |> Enum.with_index(1)
     |> Enum.reduce_while({:ok, assertions}, fn {assertion, idx}, _acc ->
-      type = Map.get(assertion, "type")
-
-      cond do
-        type not in @valid_types ->
-          {:halt,
-           {:error,
-            "Invalid assertion type at index #{idx}: #{inspect(type)}. Must be one of: #{Enum.join(@valid_types, ", ")}"}}
-
-        type == "json_field" and
-            (not Map.has_key?(assertion, "field") or not Map.has_key?(assertion, "expected")) ->
-          {:halt,
-           {:error,
-            "Assertion at index #{idx}: json_field type requires 'field' and 'expected' fields"}}
-
-        type != "json_field" and not Map.has_key?(assertion, "value") ->
-          {:halt, {:error, "Assertion at index #{idx}: #{type} type requires 'value' field"}}
-
-        true ->
-          {:cont, {:ok, assertions}}
+      case validate_assertion(assertion, idx) do
+        :ok -> {:cont, {:ok, assertions}}
+        {:error, message} -> {:halt, {:error, message}}
       end
     end)
   end
@@ -133,4 +117,50 @@ defmodule Aludel.Evals.AssertionParser do
   defp normalize_assertion_params(params) when is_map(params), do: params
   defp normalize_assertion_params(params) when is_list(params), do: Map.new(params)
   defp normalize_assertion_params(_params), do: %{}
+
+  defp validate_assertion(assertion, idx) do
+    type = Map.get(assertion, "type")
+
+    cond do
+      type not in @valid_types ->
+        {:error,
+         "Invalid assertion type at index #{idx}: #{inspect(type)}. Must be one of: #{Enum.join(@valid_types, ", ")}"}
+
+      type == "json_field" ->
+        validate_json_field_assertion(assertion, idx)
+
+      true ->
+        validate_string_assertion(assertion, idx, type)
+    end
+  end
+
+  defp validate_json_field_assertion(assertion, idx) do
+    cond do
+      not Map.has_key?(assertion, "field") or not Map.has_key?(assertion, "expected") ->
+        {:error,
+         "Assertion at index #{idx}: json_field type requires 'field' and 'expected' fields"}
+
+      blank_string?(Map.get(assertion, "field")) ->
+        {:error, "Assertion at index #{idx}: json_field type requires a non-blank 'field' value"}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp validate_string_assertion(assertion, idx, type) do
+    cond do
+      not Map.has_key?(assertion, "value") ->
+        {:error, "Assertion at index #{idx}: #{type} type requires 'value' field"}
+
+      blank_string?(Map.get(assertion, "value")) ->
+        {:error, "Assertion at index #{idx}: #{type} type requires a non-blank 'value' field"}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp blank_string?(value) when is_binary(value), do: String.trim(value) == ""
+  defp blank_string?(_value), do: false
 end

--- a/lib/aludel/evals/assertion_parser.ex
+++ b/lib/aludel/evals/assertion_parser.ex
@@ -143,6 +143,10 @@ defmodule Aludel.Evals.AssertionParser do
       blank_string?(Map.get(assertion, "field")) ->
         {:error, "Assertion at index #{idx}: json_field type requires a non-blank 'field' value"}
 
+      blank_string?(Map.get(assertion, "expected")) ->
+        {:error,
+         "Assertion at index #{idx}: json_field type requires a non-blank 'expected' value"}
+
       true ->
         :ok
     end

--- a/lib/aludel/evals/test_case.ex
+++ b/lib/aludel/evals/test_case.ex
@@ -15,7 +15,7 @@ defmodule Aludel.Evals.TestCase do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Aludel.Evals.{Suite, TestCaseDocument}
+  alias Aludel.Evals.{AssertionParser, Suite, TestCaseDocument}
   alias Ecto.Changeset
 
   @type t :: %__MODULE__{}
@@ -47,5 +47,15 @@ defmodule Aludel.Evals.TestCase do
     test_case
     |> cast(attrs, @required_fields ++ @optional_fields)
     |> validate_required(@required_fields)
+    |> validate_assertions()
+  end
+
+  defp validate_assertions(%Changeset{} = changeset) do
+    validate_change(changeset, :assertions, fn :assertions, assertions ->
+      case AssertionParser.validate(assertions) do
+        {:ok, _assertions} -> []
+        {:error, message} -> [assertions: message]
+      end
+    end)
   end
 end

--- a/lib/aludel/evals/test_case_editor.ex
+++ b/lib/aludel/evals/test_case_editor.ex
@@ -9,7 +9,7 @@ defmodule Aludel.Evals.TestCaseEditor do
   alias Aludel.Evals.AssertionParser
   alias Aludel.Evals.TestCase
 
-  @default_assertions [%{"type" => "contains", "value" => ""}]
+  @default_assertions []
   @form_fields ~w(id variable_values assertions_json)a
   @form_types %{id: :string, variable_values: :map, assertions_json: :string}
 

--- a/lib/aludel/web/live/suite_live/new.ex
+++ b/lib/aludel/web/live/suite_live/new.ex
@@ -6,6 +6,7 @@ defmodule Aludel.Web.SuiteLive.New do
   use Aludel.Web, :live_view
 
   alias Aludel.Evals
+  alias Aludel.Evals.AssertionParser
   alias Aludel.Evals.Suite
   alias Aludel.Projects
   alias Aludel.Prompts
@@ -170,7 +171,7 @@ defmodule Aludel.Web.SuiteLive.New do
   end
 
   defp save_suite(socket, :new, suite_params) do
-    case validate_test_cases_json(suite_params) do
+    case validate_test_cases(suite_params) do
       :ok ->
         case create_suite_with_test_cases(suite_params) do
           {:ok, suite} ->
@@ -199,7 +200,7 @@ defmodule Aludel.Web.SuiteLive.New do
   end
 
   defp save_suite(socket, :edit, suite_params) do
-    case validate_test_cases_json(suite_params) do
+    case validate_test_cases(suite_params) do
       :ok ->
         case update_suite_with_test_cases(socket.assigns.suite, suite_params) do
           {:ok, suite} ->
@@ -227,31 +228,24 @@ defmodule Aludel.Web.SuiteLive.New do
     end
   end
 
-  defp validate_test_cases_json(params) do
+  defp validate_test_cases(params) do
     test_cases = params["test_cases"] || %{}
 
     test_cases
     |> Enum.reduce_while(:ok, fn {_id, test_case_params}, _acc ->
-      case validate_assertions_json(test_case_params["assertions_json"]) do
-        :ok -> {:cont, :ok}
-        {:error, _} = error -> {:halt, error}
+      case parse_test_case_assertions(test_case_params) do
+        {:ok, _assertions} -> {:cont, :ok}
+        {:error, _message} = error -> {:halt, error}
       end
     end)
   end
 
-  defp validate_assertions_json(nil), do: :ok
+  defp parse_test_case_assertions(%{"assertions_json" => assertions_json}) do
+    AssertionParser.parse(:json, %{"assertions_json" => assertions_json})
+  end
 
-  defp validate_assertions_json(assertions_json) do
-    case Jason.decode(assertions_json) do
-      {:ok, json_assertions} when is_list(json_assertions) ->
-        validate_assertion_structure(json_assertions)
-
-      {:ok, _} ->
-        {:error, "Invalid JSON: assertions must be a list"}
-
-      {:error, %Jason.DecodeError{}} ->
-        {:error, "Invalid JSON syntax in assertions"}
-    end
+  defp parse_test_case_assertions(test_case_params) do
+    AssertionParser.parse(:visual, test_case_params)
   end
 
   defp create_suite_with_test_cases(params) do
@@ -275,10 +269,9 @@ defmodule Aludel.Web.SuiteLive.New do
       variable_values = Map.get(test_case_params, "variable_values", %{})
 
       assertions =
-        if test_case_params["assertions_json"] do
-          parse_assertions(test_case_params["assertions_json"])
-        else
-          parse_visual_assertions(Map.get(test_case_params, "assertions", %{}))
+        case parse_test_case_assertions(test_case_params) do
+          {:ok, assertions} -> assertions
+          {:error, _message} -> []
         end
 
       %{
@@ -310,42 +303,11 @@ defmodule Aludel.Web.SuiteLive.New do
     end
   end
 
-  defp parse_assertions(nil), do: []
-  defp parse_assertions(""), do: []
-
-  defp parse_assertions(str) do
-    case Jason.decode(str) do
-      {:ok, assertions} when is_list(assertions) -> assertions
-      _ -> []
+  defp merge_test_case_assertions(test_case_params) do
+    case parse_test_case_assertions(test_case_params) do
+      {:ok, assertions} -> assertions
+      {:error, _message} -> []
     end
-  end
-
-  defp parse_visual_assertions(assertion_params) do
-    assertion_params = normalize_assertion_params(assertion_params)
-
-    assertion_indices =
-      assertion_params
-      |> Map.keys()
-      |> Enum.filter(&String.starts_with?(&1, "assertion_type_"))
-      |> Enum.map(fn "assertion_type_" <> idx -> String.to_integer(idx) end)
-      |> Enum.sort()
-
-    Enum.map(assertion_indices, fn idx ->
-      type = assertion_params["assertion_type_#{idx}"]
-
-      if type == "json_field" do
-        %{
-          "type" => type,
-          "field" => assertion_params["assertion_field_#{idx}"] || "",
-          "expected" => assertion_params["assertion_expected_#{idx}"] || ""
-        }
-      else
-        %{
-          "type" => type,
-          "value" => assertion_params["assertion_value_#{idx}"] || ""
-        }
-      end
-    end)
   end
 
   defp extract_variables(template) do
@@ -391,17 +353,10 @@ defmodule Aludel.Web.SuiteLive.New do
         end)
         |> Map.new()
 
-      assertions =
-        if test_case_params["assertions_json"] do
-          parse_assertions(test_case_params["assertions_json"])
-        else
-          parse_visual_assertions(Map.get(test_case_params, "assertions", %{}))
-        end
-
       %{
         id: id,
         variable_values: variable_values,
-        assertions: assertions
+        assertions: merge_test_case_assertions(test_case_params)
       }
     end)
   end
@@ -420,37 +375,4 @@ defmodule Aludel.Web.SuiteLive.New do
 
   defp prompt_variables(%{versions: [%{template: template} | _]}), do: extract_variables(template)
   defp prompt_variables(_selected_prompt), do: []
-
-  defp normalize_assertion_params(params) when is_map(params), do: params
-  defp normalize_assertion_params(params) when is_list(params), do: Map.new(params)
-  defp normalize_assertion_params(_params), do: %{}
-
-  defp validate_assertion_structure(assertions) do
-    valid_types = ["contains", "not_contains", "regex", "exact_match", "json_field"]
-
-    assertions
-    |> Enum.with_index(1)
-    |> Enum.reduce_while(:ok, fn {assertion, idx}, _acc ->
-      type = Map.get(assertion, "type")
-
-      cond do
-        type not in valid_types ->
-          {:halt,
-           {:error,
-            "Invalid assertion type at index #{idx}: #{inspect(type)}. Must be one of: #{Enum.join(valid_types, ", ")}"}}
-
-        type == "json_field" and
-            (not Map.has_key?(assertion, "field") or not Map.has_key?(assertion, "expected")) ->
-          {:halt,
-           {:error,
-            "Assertion at index #{idx}: json_field type requires 'field' and 'expected' fields"}}
-
-        type != "json_field" and not Map.has_key?(assertion, "value") ->
-          {:halt, {:error, "Assertion at index #{idx}: #{type} type requires 'value' field"}}
-
-        true ->
-          {:cont, :ok}
-      end
-    end)
-  end
 end

--- a/test/aludel/evals/assertion_parser_test.exs
+++ b/test/aludel/evals/assertion_parser_test.exs
@@ -36,6 +36,15 @@ defmodule Aludel.Evals.AssertionParserTest do
       assert message =~ "Invalid assertion type at index 1"
     end
 
+    test "rejects JSON string assertions with blank values" do
+      params = %{
+        "assertions_json" => ~s([{"type":"contains","value":"   "}])
+      }
+
+      assert {:error, message} = AssertionParser.parse(:json, params)
+      assert message =~ "contains type requires a non-blank 'value' field"
+    end
+
     test "parses visual assertions" do
       params = %{
         "assertions" => %{
@@ -70,6 +79,18 @@ defmodule Aludel.Evals.AssertionParserTest do
                AssertionParser.parse(:visual, params)
     end
 
+    test "rejects visual string assertions with blank values" do
+      params = %{
+        "assertions" => %{
+          "assertion_type_0" => "contains",
+          "assertion_value_0" => "  "
+        }
+      }
+
+      assert {:error, message} = AssertionParser.parse(:visual, params)
+      assert message =~ "contains type requires a non-blank 'value' field"
+    end
+
     test "rejects json_field assertions missing expected keys" do
       params = %{
         "assertions_json" => ~s([{"type":"json_field"}])
@@ -77,6 +98,15 @@ defmodule Aludel.Evals.AssertionParserTest do
 
       assert {:error, message} = AssertionParser.parse(:json, params)
       assert message =~ "json_field type requires 'field' and 'expected' fields"
+    end
+
+    test "rejects json_field assertions with blank field values" do
+      params = %{
+        "assertions_json" => ~s([{"type":"json_field","field":"   ","expected":"positive"}])
+      }
+
+      assert {:error, message} = AssertionParser.parse(:json, params)
+      assert message =~ "json_field type requires a non-blank 'field' value"
     end
   end
 

--- a/test/aludel/evals/assertion_parser_test.exs
+++ b/test/aludel/evals/assertion_parser_test.exs
@@ -108,6 +108,28 @@ defmodule Aludel.Evals.AssertionParserTest do
       assert {:error, message} = AssertionParser.parse(:json, params)
       assert message =~ "json_field type requires a non-blank 'field' value"
     end
+
+    test "rejects json_field assertions with blank expected values in JSON mode" do
+      params = %{
+        "assertions_json" => ~s([{"type":"json_field","field":"sentiment","expected":"   "}])
+      }
+
+      assert {:error, message} = AssertionParser.parse(:json, params)
+      assert message =~ "json_field type requires a non-blank 'expected' value"
+    end
+
+    test "rejects json_field assertions with blank expected values in visual mode" do
+      params = %{
+        "assertions" => %{
+          "assertion_type_0" => "json_field",
+          "assertion_field_0" => "sentiment",
+          "assertion_expected_0" => "  "
+        }
+      }
+
+      assert {:error, message} = AssertionParser.parse(:visual, params)
+      assert message =~ "json_field type requires a non-blank 'expected' value"
+    end
   end
 
   describe "build_form_params/1" do

--- a/test/aludel/evals/test_case_editor_test.exs
+++ b/test/aludel/evals/test_case_editor_test.exs
@@ -4,22 +4,22 @@ defmodule Aludel.Evals.TestCaseEditorTest do
   alias Aludel.Evals.TestCaseEditor
 
   describe "create_test_case/2" do
-    test "creates a test case with prompt variables and default assertions" do
+    test "creates a test case with prompt variables and no persisted assertions" do
       suite = suite_fixture()
       prompt = prompt_fixture_with_version(%{template: "Hello {{ name }} from {{city}}"})
 
       assert {:ok, test_case} = TestCaseEditor.create_test_case(suite.id, prompt)
       assert test_case.variable_values == %{"name" => "", "city" => ""}
-      assert test_case.assertions == [%{"type" => "contains", "value" => ""}]
+      assert test_case.assertions == []
     end
 
-    test "creates a test case with empty variables when the prompt has no versions" do
+    test "creates a test case with empty variables and no persisted assertions when the prompt has no versions" do
       suite = suite_fixture()
       prompt = prompt_fixture()
 
       assert {:ok, test_case} = TestCaseEditor.create_test_case(suite.id, prompt)
       assert test_case.variable_values == %{}
-      assert test_case.assertions == [%{"type" => "contains", "value" => ""}]
+      assert test_case.assertions == []
     end
   end
 

--- a/test/aludel/evals/test_case_test.exs
+++ b/test/aludel/evals/test_case_test.exs
@@ -59,6 +59,23 @@ defmodule Aludel.Evals.TestCaseTest do
       refute changeset.valid?
       assert "can't be blank" in errors_on(changeset).assertions
     end
+
+    test "rejects assertions with unsupported types" do
+      suite = suite_fixture()
+
+      changeset =
+        TestCase.changeset(%TestCase{}, %{
+          suite_id: suite.id,
+          variable_values: %{"name" => "John"},
+          assertions: [%{"type" => "invalid_type", "value" => "Hello"}]
+        })
+
+      refute changeset.valid?
+
+      assert {"Invalid assertion type at index 1: \"invalid_type\". Must be one of: contains, not_contains, regex, exact_match, json_field",
+              []} =
+               changeset.errors[:assertions]
+    end
   end
 
   describe "associations" do

--- a/test/aludel/evals/test_case_test.exs
+++ b/test/aludel/evals/test_case_test.exs
@@ -76,6 +76,22 @@ defmodule Aludel.Evals.TestCaseTest do
               []} =
                changeset.errors[:assertions]
     end
+
+    test "rejects assertions with blank string values" do
+      suite = suite_fixture()
+
+      changeset =
+        TestCase.changeset(%TestCase{}, %{
+          suite_id: suite.id,
+          variable_values: %{"name" => "John"},
+          assertions: [%{"type" => "contains", "value" => "   "}]
+        })
+
+      refute changeset.valid?
+
+      assert {"Assertion at index 1: contains type requires a non-blank 'value' field", []} =
+               changeset.errors[:assertions]
+    end
   end
 
   describe "associations" do

--- a/test/aludel_web/live/suite_live/new_test.exs
+++ b/test/aludel_web/live/suite_live/new_test.exs
@@ -274,6 +274,43 @@ defmodule Aludel.Web.SuiteLive.NewTest do
       assert has_element?(view, "#flash-error", "Invalid assertion type")
     end
 
+    test "rejects invalid assertion types in visual mode", %{conn: conn} do
+      prompt = prompt_fixture_with_version(%{template: "Hello {{name}}"})
+
+      {:ok, view, _html} = live(conn, "/suites/new")
+
+      view
+      |> form("#suite-form", suite: %{name: "", prompt_id: prompt.id})
+      |> render_change()
+
+      view
+      |> element("[phx-click='add_test_case']")
+      |> render_click()
+
+      test_case_id = List.first(:sys.get_state(view.pid).socket.assigns.test_cases).id
+
+      view
+      |> render_click("add_assertion", %{"id" => test_case_id})
+
+      render_submit(view, "save", %{
+        "suite" => %{
+          "name" => "Test Suite",
+          "prompt_id" => prompt.id,
+          "test_cases" => %{
+            test_case_id => %{
+              "variable_values" => %{"name" => "Alice"},
+              "assertions" => %{
+                "assertion_type_0" => "invalid_type",
+                "assertion_value_0" => "test"
+              }
+            }
+          }
+        }
+      })
+
+      assert has_element?(view, "#flash-error", "Invalid assertion type")
+    end
+
     test "uses nested variable inputs after prompt selection", %{conn: conn} do
       prompt = prompt_fixture_with_version(%{template: "Hello {{name}}"})
 

--- a/test/aludel_web/live/suite_live/new_test.exs
+++ b/test/aludel_web/live/suite_live/new_test.exs
@@ -274,7 +274,7 @@ defmodule Aludel.Web.SuiteLive.NewTest do
       assert has_element?(view, "#flash-error", "Invalid assertion type")
     end
 
-    test "rejects invalid assertion types in visual mode", %{conn: conn} do
+    test "rejects blank assertion values in visual mode", %{conn: conn} do
       prompt = prompt_fixture_with_version(%{template: "Hello {{name}}"})
 
       {:ok, view, _html} = live(conn, "/suites/new")
@@ -292,23 +292,25 @@ defmodule Aludel.Web.SuiteLive.NewTest do
       view
       |> render_click("add_assertion", %{"id" => test_case_id})
 
-      render_submit(view, "save", %{
-        "suite" => %{
+      view
+      |> form("#suite-form",
+        suite: %{
           "name" => "Test Suite",
           "prompt_id" => prompt.id,
           "test_cases" => %{
             test_case_id => %{
               "variable_values" => %{"name" => "Alice"},
               "assertions" => %{
-                "assertion_type_0" => "invalid_type",
-                "assertion_value_0" => "test"
+                "assertion_type_0" => "contains",
+                "assertion_value_0" => "   "
               }
             }
           }
         }
-      })
+      )
+      |> render_submit()
 
-      assert has_element?(view, "#flash-error", "Invalid assertion type")
+      assert has_element?(view, "#flash-error", "non-blank 'value' field")
     end
 
     test "uses nested variable inputs after prompt selection", %{conn: conn} do


### PR DESCRIPTION
Closes #88

## Motivation (required)

Assertion payload validation was inconsistent across suite editing paths. The shared `AssertionParser` already knew how to validate both JSON and visual assertion payloads, but the new-suite LiveView still carried its own assertion parsing and validation logic, and `Aludel.Evals.TestCase.changeset/2` did not validate assertion structure at all.

That left two real problems:

- visual editor payloads on the new-suite path could drift from the JSON editor contract
- invalid assertion payloads could still be persisted by direct callers because the schema only checked presence, not shape

This change makes the new-suite flow use the shared `AssertionParser` contract and adds schema-level assertion validation so unsupported assertion types and other malformed payloads are rejected before persistence.

## Test Plan (required)

Commands run:

`mix test test/aludel/evals/test_case_test.exs test/aludel_web/live/suite_live/new_test.exs`

Output:

```text
Running ExUnit with seed: 661992, max_cases: 28

......................
Finished in 0.2 seconds (0.1s async, 0.1s sync)
22 tests, 0 failures
```

`mix test test/aludel/evals/assertion_parser_test.exs test/aludel/evals/test_case_editor_test.exs test/aludel/evals/test_case_test.exs test/aludel_web/live/suite_live/new_test.exs test/aludel_web/live/suite_live/show_test.exs`

Output:

```text
Running ExUnit with seed: 472505, max_cases: 28

.......................................................................
Finished in 0.5 seconds (0.1s async, 0.4s sync)
71 tests, 0 failures
```

`mix precommit`

Output:

```text
Checking 140 source files (this might take a while) ...
846 mods/funs, found no issues.
... SCAN COMPLETE ...
Running ExUnit with seed: 163870, max_cases: 28
516 tests, 0 failures
```

Runtime smoke exercise:

`MIX_ENV=test mix run -e '...'`

Output:

```text
schema_assertion_errors: [
  assertions: {"Invalid assertion type at index 1: \"invalid_type\". Must be one of: contains, not_contains, regex, exact_match, json_field",
   []}
]
visual_assertion_error: "Invalid assertion type at index 1: \"invalid_type\". Must be one of: contains, not_contains, regex, exact_match, json_field"
```

## Next Steps

Blank default assertions are still allowed during test-case creation so the current editor workflow remains intact. If we want to tighten that later, it should be a deliberate UX change rather than part of this structural validation fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stronger assertion validation with clear errors for invalid types and blank/whitespace values/fields; visual-mode submission surfaces errors (flash) on invalid assertions.
  * Unified validation so JSON and visual inputs are validated consistently.

* **Refactor**
  * Consolidated assertion parsing/validation into a single flow.
  * New test cases now start with no default assertions (initial assertions list is empty).

* **Tests**
  * Added/updated tests covering invalid types, blank values, visual-mode submission, and editor defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->