### PR TITLE
feat: add copy actions for run and suite results

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -26,6 +26,7 @@ import topbar from "../vendor/topbar"
 import {EvolutionChart} from "./hooks/evolution_chart"
 // Hook for toggling assertion input fields based on type
 import {AssertionTypeToggle} from "./hooks/assertion_type_toggle"
+import {CopyToClipboard} from "./hooks/copy_to_clipboard"
 import {CustomSelect} from "./hooks/custom_select"
 import {ActivityChart} from "./hooks/activity_chart"
 import {TagInput} from "./hooks/tag_input"
@@ -92,7 +93,7 @@ const livePath = document.querySelector("meta[name='live-path']").getAttribute("
 const liveSocket = new LiveSocket(livePath, Socket, {
   transport: liveTran === "longpoll" ? LongPoll : WebSocket,
   params: {_csrf_token: csrfToken},
-  hooks: {AutoDismissFlash, EvolutionChart, AssertionTypeToggle, CustomSelect, ActivityChart, TagInput, StepperInput},
+  hooks: {AutoDismissFlash, EvolutionChart, AssertionTypeToggle, CopyToClipboard, CustomSelect, ActivityChart, TagInput, StepperInput},
 })
 
 // Show progress bar on live navigation and form submits

--- a/assets/js/hooks/copy_to_clipboard.js
+++ b/assets/js/hooks/copy_to_clipboard.js
@@ -10,9 +10,16 @@ async function writeClipboard(text) {
   textarea.style.position = "absolute"
   textarea.style.left = "-9999px"
   document.body.appendChild(textarea)
-  textarea.select()
-  document.execCommand("copy")
-  document.body.removeChild(textarea)
+
+  try {
+    textarea.select()
+
+    if (!document.execCommand("copy")) {
+      throw new Error("Fallback clipboard copy failed")
+    }
+  } finally {
+    document.body.removeChild(textarea)
+  }
 }
 
 export const CopyToClipboard = {

--- a/assets/js/hooks/copy_to_clipboard.js
+++ b/assets/js/hooks/copy_to_clipboard.js
@@ -1,0 +1,62 @@
+async function writeClipboard(text) {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text)
+    return
+  }
+
+  const textarea = document.createElement("textarea")
+  textarea.value = text
+  textarea.setAttribute("readonly", "")
+  textarea.style.position = "absolute"
+  textarea.style.left = "-9999px"
+  document.body.appendChild(textarea)
+  textarea.select()
+  document.execCommand("copy")
+  document.body.removeChild(textarea)
+}
+
+export const CopyToClipboard = {
+  mounted() {
+    this.defaultLabel = this.el.dataset.copyLabel || this.el.textContent.trim()
+    this.handleClick = async event => {
+      event.preventDefault()
+
+      const targetId = this.el.dataset.copyTarget
+      const target = targetId ? document.getElementById(targetId) : null
+
+      if (!target) {
+        this.showFeedback("Copy failed")
+        return
+      }
+
+      try {
+        await writeClipboard(target.textContent || "")
+        this.showFeedback("Copied")
+      } catch (_error) {
+        this.showFeedback("Copy failed")
+      }
+    }
+
+    this.el.addEventListener("click", this.handleClick)
+  },
+
+  destroyed() {
+    if (this.feedbackTimer) {
+      clearTimeout(this.feedbackTimer)
+    }
+
+    this.el.removeEventListener("click", this.handleClick)
+  },
+
+  showFeedback(label) {
+    this.el.textContent = label
+
+    if (this.feedbackTimer) {
+      clearTimeout(this.feedbackTimer)
+    }
+
+    this.feedbackTimer = setTimeout(() => {
+      this.el.textContent = this.defaultLabel
+    }, 1500)
+  },
+}

--- a/lib/aludel/web/live/run_live/show.html.heex
+++ b/lib/aludel/web/live/run_live/show.html.heex
@@ -79,7 +79,7 @@
                   phx-hook="CopyToClipboard"
                   data-copy-target={"run-result-error-#{result.id}"}
                   data-copy-label="Copy error"
-                  style="border: 1px solid var(--border); background: var(--bg-tertiary); color: var(--text-secondary); border-radius: 999px; padding: 4px 10px; font-size: 11px; font-weight: 600; cursor: pointer; transition: background-color 0.2s ease, color 0.2s ease;"
+                  style="border: 1px solid var(--border); background: var(--bg-tertiary); color: var(--text-secondary); border-radius: 8px; padding: 4px 10px; font-size: 11px; font-weight: 600; cursor: pointer; transition: background-color 0.2s ease, color 0.2s ease;"
                 >
                   Copy error
                 </button>
@@ -90,7 +90,7 @@
                   phx-hook="CopyToClipboard"
                   data-copy-target={"run-result-output-#{result.id}"}
                   data-copy-label="Copy output"
-                  style="border: 1px solid var(--border); background: var(--bg-tertiary); color: var(--text-secondary); border-radius: 999px; padding: 4px 10px; font-size: 11px; font-weight: 600; cursor: pointer; transition: background-color 0.2s ease, color 0.2s ease;"
+                  style="border: 1px solid var(--border); background: var(--bg-tertiary); color: var(--text-secondary); border-radius: 8px; padding: 4px 10px; font-size: 11px; font-weight: 600; cursor: pointer; transition: background-color 0.2s ease, color 0.2s ease;"
                 >
                   Copy output
                 </button>

--- a/lib/aludel/web/live/run_live/show.html.heex
+++ b/lib/aludel/web/live/run_live/show.html.heex
@@ -68,15 +68,43 @@
             <% end %>
 
             <div style="flex: 1; display: flex; flex-direction: column;">
-              <div style="font-size: 11px; font-weight: 500; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 8px;">
-                Output
+              <div style="display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 8px;">
+                <div style="font-size: 11px; font-weight: 500; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.05em;">
+                  Output
+                </div>
+                <button
+                  :if={result.status == :error}
+                  id={"copy-run-error-#{result.id}"}
+                  type="button"
+                  phx-hook="CopyToClipboard"
+                  data-copy-target={"run-result-error-#{result.id}"}
+                  data-copy-label="Copy error"
+                  style="border: 1px solid var(--border); background: var(--bg-tertiary); color: var(--text-secondary); border-radius: 999px; padding: 4px 10px; font-size: 11px; font-weight: 600; cursor: pointer; transition: background-color 0.2s ease, color 0.2s ease;"
+                >
+                  Copy error
+                </button>
+                <button
+                  :if={result.status != :error}
+                  id={"copy-run-output-#{result.id}"}
+                  type="button"
+                  phx-hook="CopyToClipboard"
+                  data-copy-target={"run-result-output-#{result.id}"}
+                  data-copy-label="Copy output"
+                  style="border: 1px solid var(--border); background: var(--bg-tertiary); color: var(--text-secondary); border-radius: 999px; padding: 4px 10px; font-size: 11px; font-weight: 600; cursor: pointer; transition: background-color 0.2s ease, color 0.2s ease;"
+                >
+                  Copy output
+                </button>
               </div>
               <%= if result.status == :error do %>
                 <div style="background-color: rgba(220, 38, 38, 0.1); border: 1px solid rgba(220, 38, 38, 0.2); padding: 12px; border-radius: 4px; color: #dc2626; font-size: 13px;">
-                  <strong>Error:</strong> {result.error}
+                  <strong>Error:</strong>
+                  <span id={"run-result-error-#{result.id}"}>{result.error}</span>
                 </div>
               <% else %>
-                <pre style="background-color: var(--bg-tertiary); border: 1px solid var(--border); padding: 12px; border-radius: 4px; font-size: 12px; line-height: 1.5; overflow-x: auto; margin: 0; white-space: pre-wrap; word-wrap: break-word; flex: 1;"><%= result.output %></pre>
+                <pre
+                  id={"run-result-output-#{result.id}"}
+                  style="background-color: var(--bg-tertiary); border: 1px solid var(--border); padding: 12px; border-radius: 4px; font-size: 12px; line-height: 1.5; overflow-x: auto; margin: 0; white-space: pre-wrap; word-wrap: break-word; flex: 1;"
+                ><%= result.output %></pre>
               <% end %>
             </div>
           </div>

--- a/lib/aludel/web/live/run_live/show.html.heex
+++ b/lib/aludel/web/live/run_live/show.html.heex
@@ -77,6 +77,7 @@
                   id={"copy-run-error-#{result.id}"}
                   type="button"
                   phx-hook="CopyToClipboard"
+                  phx-update="ignore"
                   data-copy-target={"run-result-error-#{result.id}"}
                   data-copy-label="Copy error"
                   style="border: 1px solid var(--border); background: var(--bg-tertiary); color: var(--text-secondary); border-radius: 8px; padding: 4px 10px; font-size: 11px; font-weight: 600; cursor: pointer; transition: background-color 0.2s ease, color 0.2s ease;"
@@ -88,6 +89,7 @@
                   id={"copy-run-output-#{result.id}"}
                   type="button"
                   phx-hook="CopyToClipboard"
+                  phx-update="ignore"
                   data-copy-target={"run-result-output-#{result.id}"}
                   data-copy-label="Copy output"
                   style="border: 1px solid var(--border); background: var(--bg-tertiary); color: var(--text-secondary); border-radius: 8px; padding: 4px 10px; font-size: 11px; font-weight: 600; cursor: pointer; transition: background-color 0.2s ease, color 0.2s ease;"

--- a/lib/aludel/web/live/suite_live/show.html.heex
+++ b/lib/aludel/web/live/suite_live/show.html.heex
@@ -630,12 +630,27 @@
                       </div>
                     <% end %>
                     <div style={"padding: 14px; background: #{if result["passed"], do: "rgba(16, 185, 129, 0.05)", else: "rgba(248, 81, 73, 0.05)"}"}>
-                      <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">
-                        <span style={"font-weight: 600; font-size: 13px; color: #{if result["passed"], do: "#10b981", else: "#f85149"}"}>
-                          {if result["passed"], do: "✓ Output", else: "✗ Output"}
-                        </span>
+                      <div style="display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 8px;">
+                        <div style="display: flex; align-items: center; gap: 8px;">
+                          <span style={"font-weight: 600; font-size: 13px; color: #{if result["passed"], do: "#10b981", else: "#f85149"}"}>
+                            {if result["passed"], do: "✓ Output", else: "✗ Output"}
+                          </span>
+                        </div>
+                        <button
+                          id={"copy-suite-result-#{result["test_case_id"]}"}
+                          type="button"
+                          phx-hook="CopyToClipboard"
+                          data-copy-target={"suite-result-output-#{result["test_case_id"]}"}
+                          data-copy-label="Copy output"
+                          style="border: 1px solid var(--border); background: var(--bg-tertiary); color: var(--text-secondary); border-radius: 999px; padding: 4px 10px; font-size: 11px; font-weight: 600; cursor: pointer; transition: background-color 0.2s ease, color 0.2s ease;"
+                        >
+                          Copy output
+                        </button>
                       </div>
-                      <pre style="font-size: 12px; margin: 0; white-space: pre-wrap; color: var(--text-primary); line-height: 1.5;">{result["output"]}</pre>
+                      <pre
+                        id={"suite-result-output-#{result["test_case_id"]}"}
+                        style="font-size: 12px; margin: 0; white-space: pre-wrap; color: var(--text-primary); line-height: 1.5;"
+                      >{result["output"]}</pre>
                     </div>
                   </div>
                 <% end %>

--- a/lib/aludel/web/live/suite_live/show.html.heex
+++ b/lib/aludel/web/live/suite_live/show.html.heex
@@ -642,7 +642,7 @@
                           phx-hook="CopyToClipboard"
                           data-copy-target={"suite-result-output-#{result["test_case_id"]}"}
                           data-copy-label="Copy output"
-                          style="border: 1px solid var(--border); background: var(--bg-tertiary); color: var(--text-secondary); border-radius: 999px; padding: 4px 10px; font-size: 11px; font-weight: 600; cursor: pointer; transition: background-color 0.2s ease, color 0.2s ease;"
+                          style="border: 1px solid var(--border); background: var(--bg-tertiary); color: var(--text-secondary); border-radius: 8px; padding: 4px 10px; font-size: 11px; font-weight: 600; cursor: pointer; transition: background-color 0.2s ease, color 0.2s ease;"
                         >
                           Copy output
                         </button>

--- a/lib/aludel/web/live/suite_live/show.html.heex
+++ b/lib/aludel/web/live/suite_live/show.html.heex
@@ -637,10 +637,11 @@
                           </span>
                         </div>
                         <button
-                          id={"copy-suite-result-#{result["test_case_id"]}"}
+                          id={"copy-suite-result-#{suite_run.id}-#{result["test_case_id"]}"}
                           type="button"
                           phx-hook="CopyToClipboard"
-                          data-copy-target={"suite-result-output-#{result["test_case_id"]}"}
+                          phx-update="ignore"
+                          data-copy-target={"suite-result-output-#{suite_run.id}-#{result["test_case_id"]}"}
                           data-copy-label="Copy output"
                           style="border: 1px solid var(--border); background: var(--bg-tertiary); color: var(--text-secondary); border-radius: 8px; padding: 4px 10px; font-size: 11px; font-weight: 600; cursor: pointer; transition: background-color 0.2s ease, color 0.2s ease;"
                         >
@@ -648,7 +649,7 @@
                         </button>
                       </div>
                       <pre
-                        id={"suite-result-output-#{result["test_case_id"]}"}
+                        id={"suite-result-output-#{suite_run.id}-#{result["test_case_id"]}"}
                         style="font-size: 12px; margin: 0; white-space: pre-wrap; color: var(--text-primary); line-height: 1.5;"
                       >{result["output"]}</pre>
                     </div>

--- a/priv/static/app.css
+++ b/priv/static/app.css
@@ -1216,6 +1216,9 @@
       }
     }
   }
+  .absolute {
+    position: absolute;
+  }
   .fixed {
     position: fixed;
   }

--- a/priv/static/app.js
+++ b/priv/static/app.js
@@ -20539,6 +20539,59 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
     }
   };
 
+  // assets/js/hooks/copy_to_clipboard.js
+  async function writeClipboard(text) {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return;
+    }
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "absolute";
+    textarea.style.left = "-9999px";
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand("copy");
+    document.body.removeChild(textarea);
+  }
+  var CopyToClipboard = {
+    mounted() {
+      this.defaultLabel = this.el.dataset.copyLabel || this.el.textContent.trim();
+      this.handleClick = async (event) => {
+        event.preventDefault();
+        const targetId = this.el.dataset.copyTarget;
+        const target = targetId ? document.getElementById(targetId) : null;
+        if (!target) {
+          this.showFeedback("Copy failed");
+          return;
+        }
+        try {
+          await writeClipboard(target.textContent || "");
+          this.showFeedback("Copied");
+        } catch (_error) {
+          this.showFeedback("Copy failed");
+        }
+      };
+      this.el.addEventListener("click", this.handleClick);
+    },
+    destroyed() {
+      if (this.feedbackTimer) {
+        clearTimeout(this.feedbackTimer);
+      }
+      this.el.removeEventListener("click", this.handleClick);
+    },
+    showFeedback(label) {
+      this.el.textContent = label;
+      if (this.feedbackTimer) {
+        clearTimeout(this.feedbackTimer);
+      }
+      this.feedbackTimer = setTimeout(() => {
+        this.el.textContent = this.defaultLabel;
+      }, 1500);
+    }
+  };
+
   // assets/js/hooks/custom_select.js
   var customSelectState = /* @__PURE__ */ new Map();
   var CustomSelect = {
@@ -21009,7 +21062,7 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
   var liveSocket = new LiveSocket2(livePath, Socket, {
     transport: liveTran === "longpoll" ? LongPoll : WebSocket,
     params: { _csrf_token: csrfToken },
-    hooks: { AutoDismissFlash, EvolutionChart, AssertionTypeToggle, CustomSelect, ActivityChart, TagInput, StepperInput }
+    hooks: { AutoDismissFlash, EvolutionChart, AssertionTypeToggle, CopyToClipboard, CustomSelect, ActivityChart, TagInput, StepperInput }
   });
   import_topbar.default.config({ barColors: { 0: "#29d" }, shadowColor: "rgba(0, 0, 0, .3)" });
   window.addEventListener("phx:page-loading-start", (_info) => import_topbar.default.show(300));

--- a/priv/static/app.js
+++ b/priv/static/app.js
@@ -20551,9 +20551,14 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
     textarea.style.position = "absolute";
     textarea.style.left = "-9999px";
     document.body.appendChild(textarea);
-    textarea.select();
-    document.execCommand("copy");
-    document.body.removeChild(textarea);
+    try {
+      textarea.select();
+      if (!document.execCommand("copy")) {
+        throw new Error("Fallback clipboard copy failed");
+      }
+    } finally {
+      document.body.removeChild(textarea);
+    }
   }
   var CopyToClipboard = {
     mounted() {

--- a/test/aludel_web/live/run_live/show_test.exs
+++ b/test/aludel_web/live/run_live/show_test.exs
@@ -158,6 +158,31 @@ defmodule Aludel.Web.RunLive.ShowTest do
       assert html =~ "API call failed"
     end
 
+    test "shows copy actions for successful outputs", %{conn: conn, run: run, result1: result1} do
+      {:ok, view, _html} = live(conn, "/runs/#{run.id}")
+
+      assert has_element?(view, "#run-result-output-#{result1.id}", "Hello from OpenAI")
+      assert has_element?(view, "#copy-run-output-#{result1.id}", "Copy output")
+    end
+
+    test "shows copy actions for failed errors", %{conn: conn} do
+      run = run_fixture(%{name: "Copy Error Run"})
+      provider = provider_fixture(%{name: "FailProvider"})
+
+      result =
+        run_result_fixture(%{
+          run_id: run.id,
+          provider_id: provider.id,
+          status: :error,
+          error: "API call failed"
+        })
+
+      {:ok, view, _html} = live(conn, "/runs/#{run.id}")
+
+      assert has_element?(view, "#run-result-error-#{result.id}", "API call failed")
+      assert has_element?(view, "#copy-run-error-#{result.id}", "Copy error")
+    end
+
     test "raises 404 for non-existent run", %{conn: conn} do
       fake_id = Ecto.UUID.generate()
 

--- a/test/aludel_web/live/suite_live/show_test.exs
+++ b/test/aludel_web/live/suite_live/show_test.exs
@@ -655,4 +655,46 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
     result = fun.()
     assert result
   end
+
+  describe "result copy actions" do
+    test "shows copy action for suite result outputs", %{conn: conn} do
+      prompt = prompt_fixture_with_version()
+      suite = suite_fixture(%{prompt_id: prompt.id})
+      prompt = Aludel.Prompts.get_prompt_with_versions!(prompt.id)
+      version = hd(prompt.versions)
+      provider = provider_fixture(%{name: "OpenAI"})
+      test_case = test_case_fixture(%{suite_id: suite.id})
+
+      _suite_run =
+        suite_run_fixture(%{
+          suite_id: suite.id,
+          prompt_version_id: version.id,
+          provider_id: provider.id,
+          passed: 1,
+          failed: 0,
+          results: [
+            %{
+              "test_case_id" => test_case.id,
+              "passed" => true,
+              "output" => "Structured output for copying",
+              "assertion_results" => [
+                %{"type" => "contains", "passed" => true, "value" => "Structured"}
+              ],
+              "cost_usd" => 0.001,
+              "latency_ms" => 250
+            }
+          ]
+        })
+
+      {:ok, view, _html} = live(conn, "/suites/#{suite.id}")
+
+      assert has_element?(
+               view,
+               "#suite-result-output-#{test_case.id}",
+               "Structured output for copying"
+             )
+
+      assert has_element?(view, "#copy-suite-result-#{test_case.id}", "Copy output")
+    end
+  end
 end

--- a/test/aludel_web/live/suite_live/show_test.exs
+++ b/test/aludel_web/live/suite_live/show_test.exs
@@ -665,7 +665,7 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
       provider = provider_fixture(%{name: "OpenAI"})
       test_case = test_case_fixture(%{suite_id: suite.id})
 
-      _suite_run =
+      suite_run =
         suite_run_fixture(%{
           suite_id: suite.id,
           prompt_version_id: version.id,
@@ -690,11 +690,15 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
 
       assert has_element?(
                view,
-               "#suite-result-output-#{test_case.id}",
+               "#suite-result-output-#{suite_run.id}-#{test_case.id}",
                "Structured output for copying"
              )
 
-      assert has_element?(view, "#copy-suite-result-#{test_case.id}", "Copy output")
+      assert has_element?(
+               view,
+               "#copy-suite-result-#{suite_run.id}-#{test_case.id}",
+               "Copy output"
+             )
     end
   end
 end


### PR DESCRIPTION
Closes #73

## Motivation (required)

Run and suite result screens rendered outputs and errors, but they did not provide a fast way to copy that content for debugging or reuse. This adds inline copy actions to both result views so users can copy successful outputs and failed errors without leaving the page.

## Test Plan (required)

1. `mix test test/aludel_web/live/run_live/show_test.exs test/aludel_web/live/suite_live/show_test.exs`
   - `44 tests, 0 failures`
2. `mix precommit`
   - `525 tests, 0 failures`

The focused LiveView tests cover copy controls for successful run outputs, failed run errors, and suite result entries. The clipboard interaction itself is handled by a small client-side hook with inline `Copied` feedback.

## Next Steps

This PR is intentionally limited to the existing result views and a reusable clipboard hook. It does not change result payloads or export formats.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added copy-to-clipboard buttons for run outputs and error messages; per-test result displays now include copy controls with temporary success/failure feedback.
* **Style**
  * Added an absolute-positioning utility to support the new copy-control layout.
* **Tests**
  * Added LiveView tests confirming copy control presence and rendered output/error targets for runs and suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->