### PR TITLE
chore: add CodeRabbit review configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -26,7 +26,7 @@ reviews:
       instructions: |
         Focus on migration safety and reversibility.
         Flag destructive or tightly coupled schema changes, missing indexes or constraints, and changes that look unsafe for existing PostgreSQL data.
-    - path: ".github/workflows/**/*.yml"
+    - path: ".github/workflows/**/*.{yml,yaml}"
       instructions: |
         Review GitHub Actions changes for correctness, least-privilege permissions, safe caching, and maintainability.
   tools:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+language: "en-US"
+early_access: false
+
+reviews:
+  profile: "assertive"
+  request_changes_workflow: false
+  high_level_summary: true
+  review_status: true
+  auto_review:
+    enabled: true
+    drafts: false
+  path_instructions:
+    - path: "lib/**/*.ex"
+      instructions: |
+        Review these Elixir and Phoenix changes against the repo's AGENTS.md guidance.
+        Focus on correctness, explicit data flow, and hidden coupling first.
+        Flag LiveView lifecycle issues, deprecated navigation APIs, incorrect stream usage, Ecto preload mistakes, changeset bugs, and logging of secrets or noisy duplicate logs.
+    - path: "test/**/*.exs"
+      instructions: |
+        Review tests as behavior-focused regression coverage.
+        Prefer stable assertions with LiveView test helpers and explicit DOM ids over brittle raw HTML checks.
+        Flag missing edge-case coverage and tests that mix multiple failure reasons.
+    - path: "priv/repo/migrations/**/*.exs"
+      instructions: |
+        Focus on migration safety and reversibility.
+        Flag destructive or tightly coupled schema changes, missing indexes or constraints, and changes that look unsafe for existing PostgreSQL data.
+    - path: ".github/workflows/**/*.yml"
+      instructions: |
+        Review GitHub Actions changes for correctness, least-privilege permissions, safe caching, and maintainability.
+  tools:
+    actionlint:
+      enabled: true
+    gitleaks:
+      enabled: true
+
+knowledge_base:
+  code_guidelines:
+    enabled: true


### PR DESCRIPTION
## Motivation (required)

This pull request adds a repository-level `.coderabbit.yaml` so CodeRabbit reviews can follow Aludel's existing standards with less per-repo UI setup.

The configuration keeps the scope narrow:
- enables assertive CodeRabbit reviews for PRs that are ready for review
- relies on the existing `AGENTS.md` guidance via CodeRabbit's code-guidelines support
- adds path-specific review instructions for Elixir application code, tests, Ecto migrations, and GitHub Actions workflows
- enables `actionlint` and `gitleaks` inside CodeRabbit for workflow and secret scanning coverage

## Test Plan (required)

Commands run:

```bash
ruby -e 'require "yaml"; YAML.load_file(".coderabbit.yaml")'
MIX_DEPS_PATH=/tmp/aludel-coderabbit-config-deps MIX_BUILD_PATH=/Users/cristiano-carvalho/Projects/aludel/_build mix precommit
```

Observed result:
- `.coderabbit.yaml` parsed successfully
- `mix precommit` completed successfully
- ExUnit finished with `522 tests, 0 failures`

No UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added CodeRabbit integration to enable automated, high-level code reviews in English with assertive review behavior and auto-review enabled.
  * Enabled targeted review guidance for backend source, tests, migrations, and CI workflows.
  * Turned on automated linting and security checks and activated project code-guideline knowledge base for consistent reviews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->