### PR TITLE
chore: prepare v0.1.19 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.19] - 2026-04-19
+
+### Added
+- Provider pricing now supports built-in defaults with per-provider override support
+
+### Changed
+- Refined the provider pricing form and related provider management flow
+
+### Fixed
+- SuiteLive now recovers more safely after task crashes
+- JSON field assertions now compare scalar values with the correct type handling
+- Assertion validation now stays consistent between the visual and JSON editors
+
 ## [0.1.18] - 2026-04-12
 
 ### Fixed

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Aludel.MixProject do
   def project do
     [
       app: :aludel,
-      version: "0.1.18",
+      version: "0.1.19",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Motivation (required)

Prepare the `v0.1.19` release by updating the package version and documenting the net user-facing changes since `v0.1.18`.

This release captures the provider pricing work and the follow-up fixes that landed on `main` after the last tag:

- built-in provider pricing defaults with per-provider overrides
- provider pricing form and provider management refinements
- safer SuiteLive recovery after task crashes
- more consistent assertion validation between the visual and JSON editors
- type-aware scalar comparison support for `json_field` assertions

README content did not require release-specific changes.

## Test Plan (required)

Commands run:

```bash
MIX_DEPS_PATH=/tmp/aludel-release-v0.1.19-deps MIX_BUILD_PATH=/Users/cristiano-carvalho/Projects/aludel/_build mix precommit
```

Observed result:
- `mix precommit` completed successfully
- ExUnit finished with `522 tests, 0 failures`

Notes:
- The run emitted existing third-party dependency warnings during compilation and the known executor test log noise from `executor_test.exs`, but the validation command completed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provider pricing now supports built-in defaults with per-provider customization.

* **Changed**
  * Provider pricing form and management flow improvements.

* **Bug Fixes**
  * Enhanced stability for task error recovery.
  * Corrected assertion scalar type comparisons.
  * Unified assertion validation across visual and JSON editors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->