### PR TITLE
docs: add copy actions to v0.1.19 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.19] - 2026-04-19
 
 ### Added
+- Copy actions for run and suite results
 - Provider pricing now supports built-in defaults with per-provider override support
 
 ### Changed


### PR DESCRIPTION
## Motivation (required)

`main` advanced after the v0.1.19 release-prep PR merged. The release changelog entry should include the already-merged copy-action feature so the tagged release notes match the actual contents of `main`.

This PR only updates the `0.1.19` changelog entry to mention copy actions for run and suite results.

## Test Plan (required)

Commands run:

```bash
git diff -- CHANGELOG.md
```

Observed result:
- the diff is a single added changelog bullet under `0.1.19`

No code paths changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added copy actions for run and suite results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->