### PR TITLE
refactor: model explicit run execution states

### DIFF
--- a/lib/aludel/runs/executor.ex
+++ b/lib/aludel/runs/executor.ex
@@ -3,6 +3,8 @@ defmodule Aludel.Runs.Executor do
   Owns run launch and provider execution under explicit supervision.
   """
 
+  import Ecto.Query, only: [from: 2]
+
   require Logger
 
   alias Aludel.LLM
@@ -56,22 +58,36 @@ defmodule Aludel.Runs.Executor do
   def execute(%Run{} = run, providers) when is_list(providers) do
     run = preload_prompt_version(run)
 
-    with {:ok, run} <- mark_run_running(run),
-         :ok <- validate_variable_values(run.prompt_version.variables, run.variable_values),
-         rendered_prompt <- render_template(run.prompt_version.template, run.variable_values),
-         {:ok, pending_results} <- create_pending_results(run, providers),
-         provider_outcomes <-
-           execute_providers(run, Enum.zip(providers, pending_results), rendered_prompt),
-         failures = collect_failures(provider_outcomes),
-         {:ok, updated_run} <- complete_run(run, length(providers), failures) do
-      {:ok,
-       %Execution{
-         failures: failures,
-         provider_results: updated_run.run_results,
-         run: updated_run,
-         status: execution_status(length(providers), length(failures))
-       }}
-    else
+    case mark_run_running(run) do
+      {:ok, running_run} ->
+        with :ok <-
+               validate_variable_values(
+                 running_run.prompt_version.variables,
+                 running_run.variable_values
+               ),
+             rendered_prompt <-
+               render_template(running_run.prompt_version.template, running_run.variable_values),
+             {:ok, pending_results} <- create_pending_results(running_run, providers),
+             provider_outcomes <-
+               execute_providers(
+                 running_run,
+                 Enum.zip(providers, pending_results),
+                 rendered_prompt
+               ),
+             failures = collect_failures(provider_outcomes),
+             {:ok, updated_run} <- complete_run(running_run, length(providers), failures) do
+          {:ok,
+           %Execution{
+             failures: failures,
+             provider_results: updated_run.run_results,
+             run: updated_run,
+             status: execution_status(length(providers), length(failures))
+           }}
+        else
+          {:error, reason} ->
+            fail_run(running_run, reason)
+        end
+
       {:error, reason} ->
         fail_run(run, reason)
     end
@@ -252,33 +268,37 @@ defmodule Aludel.Runs.Executor do
   end
 
   defp mark_run_running(%Run{} = run) do
-    run
-    |> Run.changeset(%{
-      status: :running,
-      started_at: now(),
-      completed_at: nil,
-      error_summary: nil
-    })
-    |> repo().update(stale_error_field: :id)
+    transition_timestamp = now()
+
+    from(r in Run, where: r.id == ^run.id and r.status == :pending)
+    |> repo().update_all(
+      set: [
+        status: :running,
+        started_at: transition_timestamp,
+        completed_at: nil,
+        error_summary: nil
+      ]
+    )
     |> case do
-      {:ok, updated_run} = result ->
-        broadcast_run_update(updated_run.id, updated_run.status)
-        result
+      {1, _} ->
+        with {:ok, updated_run} <- reload_run(run.id) do
+          broadcast_run_update(updated_run.id, updated_run.status)
+          {:ok, updated_run}
+        end
 
-      {:error, %Changeset{errors: [id: {"is stale", _details}]}} ->
+      {0, _} ->
         {:error, :run_not_found}
-
-      error ->
-        error
     end
   end
 
   defp create_pending_results(%Run{} = run, providers) do
     multi =
-      Enum.reduce(providers, Multi.new(), fn provider, multi ->
+      providers
+      |> Enum.with_index()
+      |> Enum.reduce(Multi.new(), fn {provider, index}, multi ->
         Multi.insert(
           multi,
-          {:run_result, provider.id},
+          {:run_result, index},
           RunResult.changeset(%RunResult{}, %{
             run_id: run.id,
             provider_id: provider.id,
@@ -290,8 +310,10 @@ defmodule Aludel.Runs.Executor do
     case repo().transaction(multi) do
       {:ok, results} ->
         pending_results =
-          Enum.map(providers, fn provider ->
-            run_result = Map.fetch!(results, {:run_result, provider.id})
+          providers
+          |> Enum.with_index()
+          |> Enum.map(fn {_provider, index} ->
+            run_result = Map.fetch!(results, {:run_result, index})
             broadcast_update(run.id, run_result.id, :pending, nil)
             run_result
           end)
@@ -347,7 +369,7 @@ defmodule Aludel.Runs.Executor do
     final_status = run_status(provider_count, length(failures))
 
     run
-    |> Run.changeset(%{
+    |> Run.execution_changeset(%{
       status: final_status,
       completed_at: now(),
       error_summary: error_summary(failures)
@@ -374,7 +396,7 @@ defmodule Aludel.Runs.Executor do
       {_run_id, _reason} ->
         _ =
           run
-          |> Run.changeset(%{
+          |> Run.execution_changeset(%{
             status: :failed,
             completed_at: now(),
             error_summary: inspect(reason)

--- a/lib/aludel/runs/executor.ex
+++ b/lib/aludel/runs/executor.ex
@@ -10,6 +10,7 @@ defmodule Aludel.Runs.Executor do
   alias Aludel.PubSub
   alias Aludel.Runs.{Execution, Run, RunResult}
   alias Ecto.Changeset
+  alias Ecto.Multi
 
   @execution_supervisor Aludel.Runs.ExecutorSupervisor
   @default_max_concurrency 3
@@ -55,12 +56,14 @@ defmodule Aludel.Runs.Executor do
   def execute(%Run{} = run, providers) when is_list(providers) do
     run = preload_prompt_version(run)
 
-    with :ok <- validate_variable_values(run.prompt_version.variables, run.variable_values),
+    with {:ok, run} <- mark_run_running(run),
+         :ok <- validate_variable_values(run.prompt_version.variables, run.variable_values),
          rendered_prompt <- render_template(run.prompt_version.template, run.variable_values),
-         provider_outcomes <- execute_providers(run, providers, rendered_prompt),
-         {:ok, updated_run} <- reload_run(run.id) do
-      failures = collect_failures(provider_outcomes)
-
+         {:ok, pending_results} <- create_pending_results(run, providers),
+         provider_outcomes <-
+           execute_providers(run, Enum.zip(providers, pending_results), rendered_prompt),
+         failures = collect_failures(provider_outcomes),
+         {:ok, updated_run} <- complete_run(run, length(providers), failures) do
       {:ok,
        %Execution{
          failures: failures,
@@ -68,6 +71,9 @@ defmodule Aludel.Runs.Executor do
          run: updated_run,
          status: execution_status(length(providers), length(failures))
        }}
+    else
+      {:error, reason} ->
+        fail_run(run, reason)
     end
   end
 
@@ -77,86 +83,92 @@ defmodule Aludel.Runs.Executor do
 
   defp preload_prompt_version(%Run{} = run), do: run
 
-  defp execute_providers(run, providers, rendered_prompt) do
+  defp execute_providers(run, provider_results, rendered_prompt) do
     case execution_mode() do
       :sequential ->
-        Enum.map(providers, fn provider ->
-          {provider, execute_provider(run, provider, rendered_prompt)}
+        Enum.map(provider_results, fn {provider, run_result} ->
+          {provider, execute_provider(run.id, run_result, provider, rendered_prompt)}
         end)
 
       _mode ->
-        stream_provider_executions(run, providers, rendered_prompt)
+        stream_provider_executions(run, provider_results, rendered_prompt)
     end
   end
 
-  defp stream_provider_executions(run, providers, rendered_prompt) do
-    providers
+  defp stream_provider_executions(run, provider_results, rendered_prompt) do
+    provider_results
     |> Enum.zip(
       Task.Supervisor.async_stream_nolink(
         @execution_supervisor,
-        providers,
-        fn provider ->
-          execute_provider(run, provider, rendered_prompt)
+        provider_results,
+        fn {provider, run_result} ->
+          execute_provider(run.id, run_result, provider, rendered_prompt)
         end,
         max_concurrency: execution_max_concurrency(),
         timeout: execution_timeout_ms()
       )
     )
     |> Enum.map(fn
-      {provider, {:ok, outcome}} ->
+      {{provider, _run_result}, {:ok, outcome}} ->
         {provider, outcome}
 
-      {provider, {:exit, reason}} ->
-        {provider, create_error_result(run, provider, {:task_exit, reason})}
+      {{provider, run_result}, {:exit, reason}} ->
+        {provider, create_error_result(run.id, run_result, provider, {:task_exit, reason})}
     end)
   end
 
-  defp execute_provider(run, provider, rendered_prompt) do
-    case LLM.call(provider, rendered_prompt) do
-      {:ok, result} ->
-        create_completed_result(run, provider, result)
+  defp execute_provider(run_id, run_result, provider, rendered_prompt) do
+    with {:ok, run_result} <- mark_run_result_running(run_result),
+         result <- LLM.call(provider, rendered_prompt) do
+      case result do
+        {:ok, llm_result} ->
+          complete_run_result(run_id, run_result, provider, llm_result)
 
-      {:error, reason} ->
-        create_error_result(run, provider, reason)
+        {:error, reason} ->
+          create_error_result(run_id, run_result, provider, reason)
+      end
+    else
+      {:error, changeset} ->
+        log_run_result_failure(run_id, provider.id, changeset)
+        {:error, provider_failure(provider, {:result_transition_failed, changeset.errors})}
     end
   end
 
-  defp create_completed_result(run, provider, result) do
-    case create_run_result(%{
-           run_id: run.id,
-           provider_id: provider.id,
+  defp complete_run_result(run_id, run_result, provider, result) do
+    case update_run_result(run_result, %{
            output: result.output,
            input_tokens: result.input_tokens,
            output_tokens: result.output_tokens,
            latency_ms: result.latency_ms,
            cost_usd: result.cost_usd,
-           status: :completed
+           status: :completed,
+           completed_at: now(),
+           error: nil
          }) do
       {:ok, run_result} ->
-        broadcast_update(run.id, run_result.id, :completed, result.output)
+        broadcast_update(run_id, run_result.id, :completed, result.output)
         {:ok, run_result}
 
       {:error, changeset} ->
-        log_run_result_failure(run.id, provider.id, changeset)
+        log_run_result_failure(run_id, provider.id, changeset)
         {:error, provider_failure(provider, {:result_persistence_failed, changeset.errors})}
     end
   end
 
-  defp create_error_result(run, provider, reason) do
+  defp create_error_result(run_id, run_result, provider, reason) do
     inspected_reason = inspect(reason)
 
-    case create_run_result(%{
-           run_id: run.id,
-           provider_id: provider.id,
+    case persist_error_result(run_result, %{
            status: :error,
-           error: inspected_reason
+           error: inspected_reason,
+           completed_at: now()
          }) do
       {:ok, run_result} ->
-        broadcast_update(run.id, run_result.id, :error, inspected_reason)
+        broadcast_update(run_id, run_result.id, :error, inspected_reason)
         {:error, provider_failure(provider, reason)}
 
       {:error, changeset} ->
-        log_run_result_failure(run.id, provider.id, changeset)
+        log_run_result_failure(run_id, provider.id, changeset)
         {:error, provider_failure(provider, {:result_persistence_failed, changeset.errors})}
     end
   end
@@ -179,6 +191,14 @@ defmodule Aludel.Runs.Executor do
   end
 
   defp execution_status(_provider_count, _failure_count), do: :partial_failure
+
+  defp run_status(_provider_count, 0), do: :completed
+
+  defp run_status(provider_count, failure_count) when provider_count == failure_count do
+    :failed
+  end
+
+  defp run_status(_provider_count, _failure_count), do: :partial_failure
 
   defp provider_failure(provider, reason) do
     %{
@@ -225,6 +245,162 @@ defmodule Aludel.Runs.Executor do
     |> repo().insert()
   end
 
+  defp update_run_result(%RunResult{} = run_result, attrs) do
+    run_result
+    |> RunResult.changeset(attrs)
+    |> repo().update()
+  end
+
+  defp mark_run_running(%Run{} = run) do
+    run
+    |> Run.changeset(%{
+      status: :running,
+      started_at: now(),
+      completed_at: nil,
+      error_summary: nil
+    })
+    |> repo().update(stale_error_field: :id)
+    |> case do
+      {:ok, updated_run} = result ->
+        broadcast_run_update(updated_run.id, updated_run.status)
+        result
+
+      {:error, %Changeset{errors: [id: {"is stale", _details}]}} ->
+        {:error, :run_not_found}
+
+      error ->
+        error
+    end
+  end
+
+  defp create_pending_results(%Run{} = run, providers) do
+    multi =
+      Enum.reduce(providers, Multi.new(), fn provider, multi ->
+        Multi.insert(
+          multi,
+          {:run_result, provider.id},
+          RunResult.changeset(%RunResult{}, %{
+            run_id: run.id,
+            provider_id: provider.id,
+            status: :pending
+          })
+        )
+      end)
+
+    case repo().transaction(multi) do
+      {:ok, results} ->
+        pending_results =
+          Enum.map(providers, fn provider ->
+            run_result = Map.fetch!(results, {:run_result, provider.id})
+            broadcast_update(run.id, run_result.id, :pending, nil)
+            run_result
+          end)
+
+        {:ok, pending_results}
+
+      {:error, _operation, changeset, _changes_so_far} ->
+        {:error, {:pending_result_persistence_failed, changeset.errors}}
+    end
+  end
+
+  defp mark_run_result_running(%RunResult{} = run_result) do
+    update_run_result(run_result, %{
+      status: :running,
+      started_at: now(),
+      completed_at: nil
+    })
+    |> case do
+      {:ok, updated_result} = result ->
+        broadcast_update(
+          updated_result.run_id,
+          updated_result.id,
+          :running,
+          updated_result.output
+        )
+
+        result
+
+      error ->
+        error
+    end
+  end
+
+  defp persist_error_result(%RunResult{id: nil} = run_result, attrs) do
+    attrs =
+      attrs
+      |> Map.put(:run_id, run_result.run_id)
+      |> Map.put(:provider_id, run_result.provider_id)
+      |> Map.put_new(:started_at, now())
+
+    create_run_result(attrs)
+  end
+
+  defp persist_error_result(%RunResult{} = run_result, attrs) do
+    attrs =
+      attrs
+      |> Map.put_new(:started_at, run_result.started_at || now())
+
+    update_run_result(run_result, attrs)
+  end
+
+  defp complete_run(%Run{} = run, provider_count, failures) do
+    final_status = run_status(provider_count, length(failures))
+
+    run
+    |> Run.changeset(%{
+      status: final_status,
+      completed_at: now(),
+      error_summary: error_summary(failures)
+    })
+    |> repo().update()
+    |> case do
+      {:ok, updated_run} ->
+        broadcast_run_update(updated_run.id, updated_run.status)
+        reload_run(updated_run.id)
+
+      error ->
+        error
+    end
+  end
+
+  defp fail_run(%Run{} = run, reason) do
+    case {run.id, reason} do
+      {_run_id, :run_not_found} ->
+        {:error, :run_not_found}
+
+      {nil, _reason} ->
+        {:error, reason}
+
+      {_run_id, _reason} ->
+        _ =
+          run
+          |> Run.changeset(%{
+            status: :failed,
+            completed_at: now(),
+            error_summary: inspect(reason)
+          })
+          |> repo().update()
+          |> case do
+            {:ok, updated_run} ->
+              broadcast_run_update(updated_run.id, updated_run.status)
+              :ok
+
+            {:error, _changeset} ->
+              :error
+          end
+
+        {:error, reason}
+    end
+  end
+
+  defp error_summary([]), do: nil
+
+  defp error_summary(failures) do
+    Enum.map_join(failures, "\n", fn failure ->
+      "#{failure.provider_name}: #{inspect(failure.reason)}"
+    end)
+  end
+
   defp log_run_result_failure(run_id, provider_id, %Changeset{} = changeset) do
     Logger.warning("Failed to create run result for run #{run_id}",
       provider_id: provider_id,
@@ -237,6 +413,14 @@ defmodule Aludel.Runs.Executor do
       PubSub,
       "run:#{run_id}",
       {:run_result_update, result_id, status, output}
+    )
+  end
+
+  defp broadcast_run_update(run_id, status) do
+    Phoenix.PubSub.broadcast(
+      PubSub,
+      "run:#{run_id}",
+      {:run_update, status}
     )
   end
 
@@ -254,6 +438,10 @@ defmodule Aludel.Runs.Executor do
 
   defp llm_config do
     Application.get_env(:aludel, :llm, [])
+  end
+
+  defp now do
+    DateTime.utc_now() |> DateTime.truncate(:second)
   end
 
   defp repo, do: Aludel.Repo.get()

--- a/lib/aludel/runs/executor.ex
+++ b/lib/aludel/runs/executor.ex
@@ -410,7 +410,11 @@ defmodule Aludel.Runs.Executor do
               broadcast_run_update(updated_run.id, updated_run.status)
               :ok
 
-            {:error, _changeset} ->
+            {:error, changeset} ->
+              Logger.warning("Failed to persist :failed status for run #{run.id}",
+                reason: inspect(changeset.errors)
+              )
+
               :error
           end
 

--- a/lib/aludel/runs/executor.ex
+++ b/lib/aludel/runs/executor.ex
@@ -394,11 +394,14 @@ defmodule Aludel.Runs.Executor do
         {:error, reason}
 
       {_run_id, _reason} ->
+        transition_timestamp = now()
+
         _ =
           run
           |> Run.execution_changeset(%{
             status: :failed,
-            completed_at: now(),
+            started_at: run.started_at || transition_timestamp,
+            completed_at: transition_timestamp,
             error_summary: inspect(reason)
           })
           |> repo().update()

--- a/lib/aludel/runs/run.ex
+++ b/lib/aludel/runs/run.ex
@@ -16,7 +16,8 @@ defmodule Aludel.Runs.Run do
   @type t :: %__MODULE__{}
 
   @required_fields ~w(prompt_version_id variable_values)a
-  @optional_fields ~w(name provider_ids status started_at completed_at error_summary)a
+  @optional_fields ~w(name provider_ids)a
+  @execution_fields ~w(status started_at completed_at error_summary)a
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
@@ -50,5 +51,14 @@ defmodule Aludel.Runs.Run do
     run
     |> cast(attrs, @required_fields ++ @optional_fields)
     |> validate_required(@required_fields)
+  end
+
+  @doc """
+  Changeset for executor-owned lifecycle transitions.
+  """
+  @spec execution_changeset(t(), map()) :: Changeset.t()
+  def execution_changeset(run, attrs) do
+    run
+    |> cast(attrs, @execution_fields)
   end
 end

--- a/lib/aludel/runs/run.ex
+++ b/lib/aludel/runs/run.ex
@@ -16,7 +16,7 @@ defmodule Aludel.Runs.Run do
   @type t :: %__MODULE__{}
 
   @required_fields ~w(prompt_version_id variable_values)a
-  @optional_fields ~w(name provider_ids)a
+  @optional_fields ~w(name provider_ids status started_at completed_at error_summary)a
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
@@ -25,6 +25,14 @@ defmodule Aludel.Runs.Run do
     field :name, :string
     field :variable_values, :map
     field :provider_ids, {:array, :string}, virtual: true, default: []
+
+    field :status, Ecto.Enum,
+      values: [:pending, :running, :completed, :partial_failure, :failed],
+      default: :pending
+
+    field :started_at, :utc_datetime
+    field :completed_at, :utc_datetime
+    field :error_summary, :string
 
     belongs_to(:prompt_version, PromptVersion)
     has_many(:run_results, RunResult)

--- a/lib/aludel/runs/run_result.ex
+++ b/lib/aludel/runs/run_result.ex
@@ -16,7 +16,7 @@ defmodule Aludel.Runs.RunResult do
   @type t :: %__MODULE__{}
 
   @required_fields ~w(run_id provider_id status)a
-  @optional_fields ~w(output input_tokens output_tokens latency_ms cost_usd error)a
+  @optional_fields ~w(output input_tokens output_tokens latency_ms cost_usd error started_at completed_at)a
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
@@ -27,8 +27,10 @@ defmodule Aludel.Runs.RunResult do
     field :output_tokens, :integer
     field :latency_ms, :integer
     field :cost_usd, :float
-    field :status, Ecto.Enum, values: [:pending, :streaming, :completed, :error]
+    field :status, Ecto.Enum, values: [:pending, :running, :completed, :error]
     field :error, :string
+    field :started_at, :utc_datetime
+    field :completed_at, :utc_datetime
 
     belongs_to(:run, Run)
     belongs_to(:provider, Provider)

--- a/lib/aludel/web/live/run_live/show.ex
+++ b/lib/aludel/web/live/run_live/show.ex
@@ -45,26 +45,15 @@ defmodule Aludel.Web.RunLive.Show do
         socket
       ) do
     updated_result = Runs.get_run_result!(result_id)
-    run_results = merge_run_result(socket.assigns.run_results, updated_result)
-    run = %{socket.assigns.run | run_results: run_results}
+    run = Runs.get_run!(updated_result.run_id)
 
-    {:noreply, assign(socket, run: run, run_results: run_results)}
+    {:noreply, assign(socket, run: run, run_results: run.run_results)}
   end
 
-  defp merge_run_result(run_results, updated_result) do
-    {updated_run_results, found_match?} =
-      Enum.map_reduce(run_results, false, fn run_result, found_match? ->
-        if run_result.id == updated_result.id do
-          {updated_result, true}
-        else
-          {run_result, found_match?}
-        end
-      end)
+  @impl Phoenix.LiveView
+  def handle_info({:run_update, _status}, socket) do
+    run = Runs.get_run!(socket.assigns.run.id)
 
-    if found_match? do
-      updated_run_results
-    else
-      updated_run_results ++ [updated_result]
-    end
+    {:noreply, assign(socket, run: run, run_results: run.run_results)}
   end
 end

--- a/lib/aludel/web/live/run_live/show.html.heex
+++ b/lib/aludel/web/live/run_live/show.html.heex
@@ -1,6 +1,51 @@
 <Layouts.app flash={@flash} current_path={@current_path}>
   <div style="max-width: 1000px; margin: 0 auto;">
-    <h1>{@run.name || "Run #{String.slice(@run.id, 0..7)}"}</h1>
+    <div style="display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 24px;">
+      <div>
+        <h1>{@run.name || "Run #{String.slice(@run.id, 0..7)}"}</h1>
+        <div style="display: flex; flex-wrap: wrap; gap: 12px; margin-top: 8px; font-size: 13px; color: var(--text-secondary);">
+          <span>
+            Started: {if @run.started_at,
+              do: Calendar.strftime(@run.started_at, "%Y-%m-%d %H:%M:%S UTC"),
+              else: "not started"}
+          </span>
+          <span>
+            Completed: {if @run.completed_at,
+              do: Calendar.strftime(@run.completed_at, "%Y-%m-%d %H:%M:%S UTC"),
+              else: "in progress"}
+          </span>
+        </div>
+      </div>
+      <span style={
+        case @run.status do
+          :completed ->
+            "padding: 6px 10px; border-radius: 999px; font-size: 12px; font-weight: 600; background-color: rgba(16, 185, 129, 0.12); color: #10b981;"
+
+          :partial_failure ->
+            "padding: 6px 10px; border-radius: 999px; font-size: 12px; font-weight: 600; background-color: rgba(245, 158, 11, 0.12); color: #f59e0b;"
+
+          :failed ->
+            "padding: 6px 10px; border-radius: 999px; font-size: 12px; font-weight: 600; background-color: rgba(220, 38, 38, 0.12); color: #dc2626;"
+
+          :running ->
+            "padding: 6px 10px; border-radius: 999px; font-size: 12px; font-weight: 600; background-color: rgba(59, 130, 246, 0.12); color: #3b82f6;"
+
+          :pending ->
+            "padding: 6px 10px; border-radius: 999px; font-size: 12px; font-weight: 600; background-color: rgba(107, 114, 128, 0.12); color: #6b7280;"
+        end
+      }>
+        {@run.status}
+      </span>
+    </div>
+
+    <div
+      :if={@run.error_summary}
+      class="aludel-card"
+      style="margin-bottom: 24px; border-color: rgba(220, 38, 38, 0.25);"
+    >
+      <h2 style="margin-bottom: 12px;">Execution Summary</h2>
+      <pre style="background-color: rgba(220, 38, 38, 0.08); border: 1px solid rgba(220, 38, 38, 0.2); padding: 12px; border-radius: 8px; color: #dc2626; font-size: 13px; line-height: 1.5; overflow-x: auto; margin: 0; white-space: pre-wrap; word-wrap: break-word;"><%= @run.error_summary %></pre>
+    </div>
 
     <div style="margin-bottom: 32px;">
       <h2>Configuration</h2>
@@ -33,7 +78,21 @@
               <div>
                 <h3 style="margin: 0; font-size: 16px;">{result.provider.name}</h3>
               </div>
-              <span style={"padding: 4px 8px; border-radius: 4px; font-size: 11px; font-weight: 500; #{if result.status == :completed, do: "background-color: rgba(16, 185, 129, 0.1); color: #10b981;", else: "background-color: rgba(220, 38, 38, 0.1); color: #dc2626;"}"}>
+              <span style={
+                case result.status do
+                  :completed ->
+                    "padding: 4px 8px; border-radius: 4px; font-size: 11px; font-weight: 500; background-color: rgba(16, 185, 129, 0.1); color: #10b981;"
+
+                  :error ->
+                    "padding: 4px 8px; border-radius: 4px; font-size: 11px; font-weight: 500; background-color: rgba(220, 38, 38, 0.1); color: #dc2626;"
+
+                  :running ->
+                    "padding: 4px 8px; border-radius: 4px; font-size: 11px; font-weight: 500; background-color: rgba(59, 130, 246, 0.1); color: #3b82f6;"
+
+                  :pending ->
+                    "padding: 4px 8px; border-radius: 4px; font-size: 11px; font-weight: 500; background-color: rgba(107, 114, 128, 0.1); color: #6b7280;"
+                end
+              }>
                 {result.status}
               </span>
             </div>
@@ -97,16 +156,31 @@
                   Copy output
                 </button>
               </div>
-              <%= if result.status == :error do %>
-                <div style="background-color: rgba(220, 38, 38, 0.1); border: 1px solid rgba(220, 38, 38, 0.2); padding: 12px; border-radius: 4px; color: #dc2626; font-size: 13px;">
-                  <strong>Error:</strong>
-                  <span id={"run-result-error-#{result.id}"}>{result.error}</span>
-                </div>
-              <% else %>
-                <pre
-                  id={"run-result-output-#{result.id}"}
-                  style="background-color: var(--bg-tertiary); border: 1px solid var(--border); padding: 12px; border-radius: 4px; font-size: 12px; line-height: 1.5; overflow-x: auto; margin: 0; white-space: pre-wrap; word-wrap: break-word; flex: 1;"
-                ><%= result.output %></pre>
+              <%= cond do %>
+                <% result.status == :error -> %>
+                  <div style="background-color: rgba(220, 38, 38, 0.1); border: 1px solid rgba(220, 38, 38, 0.2); padding: 12px; border-radius: 4px; color: #dc2626; font-size: 13px;">
+                    <strong>Error:</strong>
+                    <span id={"run-result-error-#{result.id}"}>{result.error}</span>
+                  </div>
+                <% result.status == :pending -> %>
+                  <div
+                    id={"run-result-output-#{result.id}"}
+                    style="background-color: var(--bg-tertiary); border: 1px dashed var(--border); padding: 12px; border-radius: 4px; font-size: 12px; line-height: 1.5; color: var(--text-secondary);"
+                  >
+                    Awaiting execution
+                  </div>
+                <% result.status == :running -> %>
+                  <div
+                    id={"run-result-output-#{result.id}"}
+                    style="background-color: rgba(59, 130, 246, 0.06); border: 1px solid rgba(59, 130, 246, 0.16); padding: 12px; border-radius: 4px; font-size: 12px; line-height: 1.5; color: var(--text-primary);"
+                  >
+                    {result.output || "Running..."}
+                  </div>
+                <% true -> %>
+                  <pre
+                    id={"run-result-output-#{result.id}"}
+                    style="background-color: var(--bg-tertiary); border: 1px solid var(--border); padding: 12px; border-radius: 4px; font-size: 12px; line-height: 1.5; overflow-x: auto; margin: 0; white-space: pre-wrap; word-wrap: break-word; flex: 1;"
+                  ><%= result.output %></pre>
               <% end %>
             </div>
           </div>

--- a/priv/repo/migrations/20260420205000_add_execution_state_to_runs_and_run_results.exs
+++ b/priv/repo/migrations/20260420205000_add_execution_state_to_runs_and_run_results.exs
@@ -9,6 +9,8 @@ defmodule Aludel.Repo.Migrations.AddExecutionStateToRunsAndRunResults do
       add :error_summary, :text
     end
 
+    create index(:runs, [:status])
+
     alter table(:run_results) do
       add :started_at, :utc_datetime
       add :completed_at, :utc_datetime

--- a/priv/repo/migrations/20260420205000_add_execution_state_to_runs_and_run_results.exs
+++ b/priv/repo/migrations/20260420205000_add_execution_state_to_runs_and_run_results.exs
@@ -1,0 +1,17 @@
+defmodule Aludel.Repo.Migrations.AddExecutionStateToRunsAndRunResults do
+  use Ecto.Migration
+
+  def change do
+    alter table(:runs) do
+      add :status, :string, null: false, default: "pending"
+      add :started_at, :utc_datetime
+      add :completed_at, :utc_datetime
+      add :error_summary, :text
+    end
+
+    alter table(:run_results) do
+      add :started_at, :utc_datetime
+      add :completed_at, :utc_datetime
+    end
+  end
+end

--- a/test/aludel/runs/executor_test.exs
+++ b/test/aludel/runs/executor_test.exs
@@ -4,8 +4,7 @@ defmodule Aludel.Runs.ExecutorTest do
   import Mox
 
   alias Aludel.Interfaces.HttpClientMock
-  alias Aludel.Runs.Execution
-  alias Aludel.Runs.Executor
+  alias Aludel.Runs.{Execution, Executor, Run}
 
   import Aludel.PromptsFixtures
   import Aludel.ProvidersFixtures
@@ -52,10 +51,29 @@ defmodule Aludel.Runs.ExecutorTest do
     end
 
     test "rejects runs with missing template variables", %{run: run} do
-      run = %{run | variable_values: %{}}
+      {:ok, run} =
+        Aludel.Runs.update_run(run, %{
+          variable_values: %{}
+        })
 
       assert {:error, {:missing_variables, ["user"]}} =
                Executor.execute(run, [provider_fixture()])
+    end
+
+    test "marks the run failed after transition-time validation errors", %{run: run} do
+      {:ok, run} =
+        Aludel.Runs.update_run(run, %{
+          variable_values: %{}
+        })
+
+      assert {:error, {:missing_variables, ["user"]}} =
+               Executor.execute(run, [provider_fixture()])
+
+      persisted_run = Aludel.Runs.get_run!(run.id)
+      assert persisted_run.status == :failed
+      assert persisted_run.started_at
+      assert persisted_run.completed_at
+      assert persisted_run.error_summary =~ "missing_variables"
     end
 
     test "returns a partial failure when provider outcomes are mixed", %{run: run} do
@@ -77,6 +95,33 @@ defmodule Aludel.Runs.ExecutorTest do
       assert execution.run.error_summary =~ provider2.name
       assert length(execution.failures) == 1
       assert length(execution.provider_results) == 2
+    end
+
+    test "supports duplicate providers without pending-result key collisions", %{run: run} do
+      provider =
+        provider_fixture(%{name: "Duplicated Provider", model: "duplicate-provider-model"})
+
+      expect(HttpClientMock, :request, 2, fn "openai:duplicate-provider-model", _prompt, _opts ->
+        {:ok, build_mock_response("Hello Alice", 5, 10)}
+      end)
+
+      assert {:ok, %Execution{} = execution} = Executor.execute(run, [provider, provider])
+      assert execution.status == :ok
+      assert execution.run.status == :completed
+      assert length(execution.provider_results) == 2
+      assert Enum.all?(execution.provider_results, &(&1.provider_id == provider.id))
+    end
+
+    test "rejects runs that already left the pending state", %{run: run} do
+      {:ok, _run} =
+        run
+        |> Run.execution_changeset(%{
+          status: :running,
+          started_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+        |> Repo.update()
+
+      assert {:error, :run_not_found} = Executor.execute(run, [provider_fixture()])
     end
 
     test "persists task exits in concurrent execution", %{run: run} do

--- a/test/aludel/runs/executor_test.exs
+++ b/test/aludel/runs/executor_test.exs
@@ -37,9 +37,14 @@ defmodule Aludel.Runs.ExecutorTest do
 
       assert {:ok, %Execution{} = execution} = Executor.execute(run, [provider])
       assert execution.status == :ok
+      assert execution.run.status == :completed
+      assert execution.run.started_at
+      assert execution.run.completed_at
       assert execution.failures == []
       assert length(execution.provider_results) == 1
       assert hd(execution.provider_results).status == :completed
+      assert hd(execution.provider_results).started_at
+      assert hd(execution.provider_results).completed_at
     end
 
     test "rejects empty provider lists", %{run: run} do
@@ -66,6 +71,10 @@ defmodule Aludel.Runs.ExecutorTest do
 
       assert {:ok, %Execution{} = execution} = Executor.execute(run, [provider1, provider2])
       assert execution.status == :partial_failure
+      assert execution.run.status == :partial_failure
+      assert execution.run.started_at
+      assert execution.run.completed_at
+      assert execution.run.error_summary =~ provider2.name
       assert length(execution.failures) == 1
       assert length(execution.provider_results) == 2
     end
@@ -89,6 +98,10 @@ defmodule Aludel.Runs.ExecutorTest do
 
       assert {:ok, %Execution{} = execution} = Executor.execute(run, [provider])
       assert execution.status == :error
+      assert execution.run.status == :failed
+      assert execution.run.started_at
+      assert execution.run.completed_at
+      assert execution.run.error_summary =~ provider.name
 
       assert [%{provider_id: provider_id, provider_name: provider_name, reason: reason}] =
                execution.failures
@@ -103,6 +116,8 @@ defmodule Aludel.Runs.ExecutorTest do
 
       assert [result] = execution.provider_results
       assert result.status == :error
+      assert result.started_at
+      assert result.completed_at
       assert result.error =~ "task_exit"
       assert result.error =~ "boom"
     end

--- a/test/aludel/runs/run_result_test.exs
+++ b/test/aludel/runs/run_result_test.exs
@@ -61,7 +61,7 @@ defmodule Aludel.Runs.RunResultTest do
       assert changeset.valid?
     end
 
-    test "valid changeset with streaming status", %{
+    test "valid changeset with running status", %{
       run: run,
       provider: provider
     } do
@@ -74,10 +74,12 @@ defmodule Aludel.Runs.RunResultTest do
           output_tokens: 2,
           latency_ms: 200,
           cost_usd: 0.0005,
-          status: :streaming
+          status: :running,
+          started_at: ~U[2026-04-20 12:00:00Z]
         })
 
       assert changeset.valid?
+      assert changeset.changes.started_at == ~U[2026-04-20 12:00:00Z]
     end
 
     test "valid changeset with error status and error message", %{

--- a/test/aludel/runs/run_test.exs
+++ b/test/aludel/runs/run_test.exs
@@ -89,8 +89,10 @@ defmodule Aludel.Runs.RunTest do
       refute Map.has_key?(changeset.changes, :completed_at)
       refute Map.has_key?(changeset.changes, :error_summary)
     end
+  end
 
-    test "execution_changeset casts lifecycle fields" do
+  describe "execution_changeset/2" do
+    test "casts lifecycle fields" do
       changeset =
         Run.execution_changeset(%Run{}, %{
           status: :running,

--- a/test/aludel/runs/run_test.exs
+++ b/test/aludel/runs/run_test.exs
@@ -71,5 +71,39 @@ defmodule Aludel.Runs.RunTest do
       assert changeset.valid?
       refute Map.has_key?(changeset.changes, :name)
     end
+
+    test "public changeset ignores executor-managed fields", %{prompt_version: version} do
+      changeset =
+        Run.changeset(%Run{}, %{
+          prompt_version_id: version.id,
+          variable_values: %{"user" => "Alice"},
+          status: :failed,
+          started_at: ~U[2026-04-20 12:00:00Z],
+          completed_at: ~U[2026-04-20 12:05:00Z],
+          error_summary: "should not be accepted"
+        })
+
+      assert changeset.valid?
+      refute Map.has_key?(changeset.changes, :status)
+      refute Map.has_key?(changeset.changes, :started_at)
+      refute Map.has_key?(changeset.changes, :completed_at)
+      refute Map.has_key?(changeset.changes, :error_summary)
+    end
+
+    test "execution_changeset casts lifecycle fields" do
+      changeset =
+        Run.execution_changeset(%Run{}, %{
+          status: :running,
+          started_at: ~U[2026-04-20 12:00:00Z],
+          completed_at: ~U[2026-04-20 12:05:00Z],
+          error_summary: "executor-owned"
+        })
+
+      assert changeset.valid?
+      assert changeset.changes.status == :running
+      assert changeset.changes.started_at == ~U[2026-04-20 12:00:00Z]
+      assert changeset.changes.completed_at == ~U[2026-04-20 12:05:00Z]
+      assert changeset.changes.error_summary == "executor-owned"
+    end
   end
 end

--- a/test/aludel/runs_test.exs
+++ b/test/aludel/runs_test.exs
@@ -1,7 +1,6 @@
 defmodule Aludel.RunsTest do
   use Aludel.DataCase
 
-  import ExUnit.CaptureLog
   import Mox
 
   alias Aludel.Interfaces.HttpClientMock
@@ -117,6 +116,10 @@ defmodule Aludel.RunsTest do
       assert run.name == "Test Run"
       assert run.variable_values == %{"user" => "Alice", "topic" => "AI"}
       assert run.prompt_version_id == version.id
+      assert run.status == :pending
+      assert is_nil(run.started_at)
+      assert is_nil(run.completed_at)
+      assert is_nil(run.error_summary)
     end
 
     test "create_run/1 with invalid data returns error changeset" do
@@ -311,12 +314,18 @@ defmodule Aludel.RunsTest do
       assert {:ok, %Execution{} = execution} = Runs.execute_run(run, [provider])
       assert execution.status == :ok
 
+      assert execution.run.status == :completed
+      assert execution.run.started_at
+      assert execution.run.completed_at
+      assert is_nil(execution.run.error_summary)
       assert Ecto.assoc_loaded?(execution.run.run_results)
       assert length(execution.run.run_results) == 1
 
       result = hd(execution.run.run_results)
       assert result.provider_id == provider.id
       assert result.status == :completed
+      assert result.started_at
+      assert result.completed_at
       assert is_binary(result.output)
       assert result.input_tokens > 0
       assert result.output_tokens > 0
@@ -343,6 +352,9 @@ defmodule Aludel.RunsTest do
                Runs.execute_run(run, [provider1, provider2, provider3])
 
       assert execution.status == :ok
+      assert execution.run.status == :completed
+      assert execution.run.started_at
+      assert execution.run.completed_at
 
       assert Ecto.assoc_loaded?(execution.run.run_results)
       assert length(execution.run.run_results) == 3
@@ -355,6 +367,8 @@ defmodule Aludel.RunsTest do
 
       for result <- execution.run.run_results do
         assert result.status == :completed
+        assert result.started_at
+        assert result.completed_at
         assert is_binary(result.output)
       end
     end
@@ -416,7 +430,13 @@ defmodule Aludel.RunsTest do
       assert execution.status == :error
       assert length(execution.failures) == 1
       assert length(execution.run.run_results) == 1
+      assert execution.run.status == :failed
+      assert execution.run.started_at
+      assert execution.run.completed_at
+      assert execution.run.error_summary =~ provider.name
       assert hd(execution.run.run_results).status == :error
+      assert hd(execution.run.run_results).started_at
+      assert hd(execution.run.run_results).completed_at
     end
 
     test "marks execution as partially failed when some providers fail", %{run: run} do
@@ -436,50 +456,22 @@ defmodule Aludel.RunsTest do
       assert execution.status == :partial_failure
       assert length(execution.failures) == 1
       assert length(execution.run.run_results) == 2
+      assert execution.run.status == :partial_failure
+      assert execution.run.started_at
+      assert execution.run.completed_at
+      assert execution.run.error_summary =~ provider2.name
     end
 
-    test "logs warning when run result creation fails on success", %{
+    test "returns run_not_found when the run disappears before execution starts", %{
       run: run,
       provider: provider
     } do
-      mock_response = build_mock_response("Test output", 5, 10)
-
-      expect(HttpClientMock, :request, fn _model, _prompt, _opts ->
-        {:ok, mock_response}
-      end)
-
       run = Repo.preload(run, :prompt_version)
 
-      # Delete the run to cause create_run_result to fail
+      # Delete the run before execution can transition it to :running.
       Runs.delete_run(run)
 
-      log =
-        capture_log([level: :warning], fn ->
-          Runs.execute_run(run, [provider])
-        end)
-
-      assert log =~ "Failed to create run result for run #{run.id}"
-    end
-
-    test "logs warning when run result creation fails on error", %{
-      run: run,
-      provider: provider
-    } do
-      expect(HttpClientMock, :request, fn _model, _prompt, _opts ->
-        {:error, "API timeout"}
-      end)
-
-      run = Repo.preload(run, :prompt_version)
-
-      # Delete the run to cause create_run_result to fail
-      Runs.delete_run(run)
-
-      log =
-        capture_log([level: :warning], fn ->
-          Runs.execute_run(run, [provider])
-        end)
-
-      assert log =~ "Failed to create run result for run #{run.id}"
+      assert {:error, :run_not_found} = Runs.execute_run(run, [provider])
     end
   end
 

--- a/test/aludel/runs_test.exs
+++ b/test/aludel/runs_test.exs
@@ -74,7 +74,7 @@ defmodule Aludel.RunsTest do
     test "list_runs/0 returns all runs", %{prompt_version: version} do
       attrs = Map.put(@valid_attrs, :prompt_version_id, version.id)
       {:ok, run} = Runs.create_run(attrs)
-      assert Runs.list_runs() == [run]
+      assert Enum.any?(Runs.list_runs(), &(&1.id == run.id))
     end
 
     test "get_run!/1 returns the run with given id", %{prompt_version: version} do

--- a/test/aludel_web/live/run_live/show_test.exs
+++ b/test/aludel_web/live/run_live/show_test.exs
@@ -108,7 +108,7 @@ defmodule Aludel.Web.RunLive.ShowTest do
       assert html =~ "Streaming update from Cohere"
     end
 
-    test "handles streaming status updates", %{
+    test "handles running status updates", %{
       conn: conn,
       run: run
     } do
@@ -127,17 +127,19 @@ defmodule Aludel.Web.RunLive.ShowTest do
       {:ok, _updated_result} =
         Aludel.Runs.update_run_result(result3, %{
           output: "Partial",
-          status: :streaming
+          status: :running,
+          started_at: DateTime.utc_now()
         })
 
       Phoenix.PubSub.broadcast(
         Aludel.PubSub,
         "run:#{run.id}",
-        {:run_result_update, result3.id, :streaming, "Partial"}
+        {:run_result_update, result3.id, :running, "Partial"}
       )
 
       html = render(view)
       assert html =~ "Partial"
+      assert html =~ "running"
     end
 
     test "displays error status for failed results", %{conn: conn} do

--- a/test/support/migrations/20260420205000_add_execution_state_to_runs_and_run_results.exs
+++ b/test/support/migrations/20260420205000_add_execution_state_to_runs_and_run_results.exs
@@ -9,6 +9,8 @@ defmodule Aludel.Repo.Migrations.AddExecutionStateToRunsAndRunResults do
       add :error_summary, :text
     end
 
+    create index(:runs, [:status])
+
     alter table(:run_results) do
       add :started_at, :utc_datetime
       add :completed_at, :utc_datetime

--- a/test/support/migrations/20260420205000_add_execution_state_to_runs_and_run_results.exs
+++ b/test/support/migrations/20260420205000_add_execution_state_to_runs_and_run_results.exs
@@ -1,0 +1,17 @@
+defmodule Aludel.Repo.Migrations.AddExecutionStateToRunsAndRunResults do
+  use Ecto.Migration
+
+  def change do
+    alter table(:runs) do
+      add :status, :string, null: false, default: "pending"
+      add :started_at, :utc_datetime
+      add :completed_at, :utc_datetime
+      add :error_summary, :text
+    end
+
+    alter table(:run_results) do
+      add :started_at, :utc_datetime
+      add :completed_at, :utc_datetime
+    end
+  end
+end


### PR DESCRIPTION
## Motivation (required)

This pull request makes run execution state explicit instead of inferring it from a mix of task completion and row reloading.

It adds persisted lifecycle state to `Run` and `RunResult`, including execution timestamps and run-level error summaries, and moves the status transitions into the executor so each run follows a deliberate pending -> running -> terminal flow.

This improves UI clarity for in-flight and terminal states, makes partial failures auditable, and gives the execution layer a stronger foundation for future retry or resume behavior.

Closes #62.

## Test Plan (required)

Commands run:

```sh
mix test test/aludel/runs/run_result_test.exs test/aludel/runs/executor_test.exs test/aludel/runs_test.exs test/aludel_web/live/run_live/show_test.exs
mix precommit
MIX_ENV=test mix run -e "{:ok, _repo} = Aludel.Test.Repo.start_link(); Mox.defmock(Aludel.Interfaces.HttpClientSmokeMock, for: Aludel.Interfaces.Adapters.Http); Application.put_env(:aludel, :http_client, Aludel.Interfaces.HttpClientSmokeMock); Mox.stub(Aludel.Interfaces.HttpClientSmokeMock, :request, fn _model, _prompt, _opts -> {:ok, %{content: \"Smoke output\", input_tokens: 1, output_tokens: 1}} end); {:ok, prompt} = Aludel.Prompts.create_prompt(%{name: \"Smoke Prompt\", description: \"Smoke\", tags: [\"smoke\"]}); {:ok, version} = Aludel.Prompts.create_prompt_version(prompt, \"Hello {{user}}\"); {:ok, provider} = Aludel.Providers.create_provider(%{name: \"Smoke Provider\", provider: :openai, model: \"smoke-model\", config: %{\"temperature\" => 0.0, \"max_tokens\" => 10}}); {:ok, run} = Aludel.Runs.create_run(%{prompt_version_id: version.id, variable_values: %{\"user\" => \"Smoke\"}}); run = Aludel.Test.Repo.preload(run, :prompt_version); {:ok, execution} = Aludel.Runs.execute_run(run, [provider]); if execution.run.status != :completed, do: raise(\"smoke failed: #{inspect(execution.run.status)}\"); IO.puts(\"smoke_ok:\" <> Atom.to_string(execution.run.status))"
```

Observed results:

- Targeted run and LiveView tests passed.
- `mix precommit` passed.
- The smoke check printed `smoke_ok:completed`.

UI impact:

- Run detail pages now show explicit run status, start/completion timestamps, pending/running result states, and a run-level execution summary for failures.

## Next Steps

- Future follow-up can build retries or resume semantics on top of the persisted run and provider result state model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runs now persist lifecycle state: status (pending/running/partial_failure/failed/completed), started/completed timestamps, and an Execution Summary for errors
  * Provider results are pre-created, show explicit pending→running→completed/error transitions, and broadcast updates during each phase

* **Bug Fixes**
  * Live run pages always reload full run state on updates to prevent stale/incremental merges

* **Tests**
  * Expanded coverage for lifecycle fields, failure modes, duplicate providers, and non-pending run handling

* **Chores**
  * Database migration added for new execution fields
<!-- end of auto-generated comment: release notes by coderabbit.ai -->