### PR TITLE
Add retry for individual suite test results

### DIFF
--- a/lib/aludel/evals.ex
+++ b/lib/aludel/evals.ex
@@ -268,6 +268,41 @@ defmodule Aludel.Evals do
   end
 
   @doc """
+  Retries a single test case result within an existing suite run.
+
+  The existing embedded result is replaced in-place and the suite run
+  aggregates are recalculated from the updated result set.
+  """
+  @spec retry_suite_run_test_case(SuiteRun.t(), binary()) ::
+          {:ok, SuiteRun.t()} | {:error, term()}
+  def retry_suite_run_test_case(%SuiteRun{} = suite_run, test_case_id)
+      when is_binary(test_case_id) do
+    with {:ok, existing_result} <- fetch_suite_run_result(suite_run, test_case_id),
+         {:ok, test_case} <- fetch_suite_test_case(suite_run.suite_id, test_case_id),
+         {:ok, version} <- fetch_prompt_version(suite_run.prompt_version_id),
+         {:ok, provider} <- fetch_provider(suite_run.provider_id) do
+      retried_result =
+        test_case
+        |> execute_test_case(version, provider)
+        |> merge_retry_metadata(existing_result)
+
+      updated_results = replace_suite_run_result(suite_run.results, test_case_id, retried_result)
+
+      suite_run
+      |> SuiteRun.changeset(
+        Map.put(summarize_suite_results(updated_results), :results, updated_results)
+      )
+      |> repo().update()
+    end
+  rescue
+    error ->
+      {:error, {:retry_failed, Exception.message(error)}}
+  catch
+    kind, reason ->
+      {:error, {:retry_failed, {kind, reason}}}
+  end
+
+  @doc """
   Executes a test suite against a prompt version and provider.
 
   Runs all test cases for the suite, evaluating their assertions
@@ -287,58 +322,15 @@ defmodule Aludel.Evals do
   def execute_suite(%Suite{} = suite, %PromptVersion{} = version, %Provider{} = provider) do
     suite = repo().preload(suite, test_cases: :documents)
 
-    {results, metrics} =
-      Enum.map_reduce(
-        suite.test_cases,
-        %{total_cost: Decimal.new("0"), total_latency: 0, successful: 0},
-        fn test_case, acc ->
-          result = execute_test_case(test_case, version, provider)
-
-          new_acc =
-            case result do
-              %{"cost_usd" => cost, "latency_ms" => latency}
-              when not is_nil(cost) and not is_nil(latency) ->
-                %{
-                  total_cost: Decimal.add(acc.total_cost, Decimal.from_float(cost)),
-                  total_latency: acc.total_latency + latency,
-                  successful: acc.successful + 1
-                }
-
-              _ ->
-                acc
-            end
-
-          {result, new_acc}
-        end
-      )
-
-    passed = Enum.count(results, & &1["passed"])
-    failed = Enum.count(results, &(!&1["passed"]))
-
-    avg_cost_usd =
-      if metrics.successful > 0 do
-        Decimal.div(metrics.total_cost, metrics.successful)
-      else
-        nil
-      end
-
-    avg_latency_ms =
-      if metrics.successful > 0 do
-        round(metrics.total_latency / metrics.successful)
-      else
-        nil
-      end
+    results = Enum.map(suite.test_cases, &execute_test_case(&1, version, provider))
 
     create_suite_run(%{
       suite_id: suite.id,
       prompt_version_id: version.id,
       provider_id: provider.id,
-      results: results,
-      passed: passed,
-      failed: failed,
-      avg_cost_usd: avg_cost_usd,
-      avg_latency_ms: avg_latency_ms
+      results: results
     })
+    |> merge_suite_run_summary(results)
   end
 
   @doc """
@@ -472,6 +464,113 @@ defmodule Aludel.Evals do
   defp error_message({:invalid_request, msg}), do: "Invalid request: #{msg}"
   defp error_message({:api_error, status, msg}), do: "API error (#{status}): #{msg}"
   defp error_message({:network_error, err}), do: "Network error: #{inspect(err)}"
+
+  defp fetch_suite_run_result(%SuiteRun{results: results}, test_case_id) do
+    case Enum.find(results, &(&1["test_case_id"] == test_case_id)) do
+      nil -> {:error, :test_case_result_not_found}
+      result -> {:ok, result}
+    end
+  end
+
+  defp fetch_suite_test_case(suite_id, test_case_id) do
+    query =
+      from tc in TestCase,
+        where: tc.id == ^test_case_id and tc.suite_id == ^suite_id
+
+    case repo().one(query) do
+      nil -> {:error, :test_case_not_found}
+      test_case -> {:ok, repo().preload(test_case, :documents)}
+    end
+  end
+
+  defp fetch_prompt_version(version_id) do
+    case repo().get(PromptVersion, version_id) do
+      nil -> {:error, :prompt_version_not_found}
+      version -> {:ok, version}
+    end
+  end
+
+  defp fetch_provider(provider_id) do
+    case repo().get(Provider, provider_id) do
+      nil -> {:error, :provider_not_found}
+      provider -> {:ok, provider}
+    end
+  end
+
+  defp merge_retry_metadata(result, existing_result) do
+    retry_count = parse_retry_count(existing_result["retry_count"])
+
+    Map.merge(result, %{
+      "retry_count" => retry_count + 1,
+      "retried_at" => DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
+    })
+  end
+
+  defp parse_retry_count(count) when is_integer(count), do: count
+
+  defp parse_retry_count(count) when is_binary(count) do
+    case Integer.parse(count) do
+      {parsed, ""} -> parsed
+      _ -> 0
+    end
+  end
+
+  defp parse_retry_count(_count), do: 0
+
+  defp replace_suite_run_result(results, test_case_id, replacement) do
+    Enum.map(results, fn result ->
+      if result["test_case_id"] == test_case_id, do: replacement, else: result
+    end)
+  end
+
+  defp merge_suite_run_summary({:ok, suite_run}, results) do
+    suite_run
+    |> SuiteRun.changeset(Map.put(summarize_suite_results(results), :results, results))
+    |> repo().update()
+  end
+
+  defp merge_suite_run_summary(error, _results), do: error
+
+  defp summarize_suite_results(results) do
+    metrics =
+      Enum.reduce(results, %{total_cost: Decimal.new("0"), total_latency: 0, successful: 0}, fn
+        %{"cost_usd" => cost, "latency_ms" => latency}, acc
+        when is_number(cost) and is_integer(latency) ->
+          %{
+            total_cost: Decimal.add(acc.total_cost, decimal_from_number(cost)),
+            total_latency: acc.total_latency + latency,
+            successful: acc.successful + 1
+          }
+
+        _, acc ->
+          acc
+      end)
+
+    passed = Enum.count(results, &(&1["passed"] == true))
+    failed = length(results) - passed
+
+    %{
+      passed: passed,
+      failed: failed,
+      avg_cost_usd: average_cost(metrics),
+      avg_latency_ms: average_latency(metrics)
+    }
+  end
+
+  defp decimal_from_number(number) when is_float(number), do: Decimal.from_float(number)
+  defp decimal_from_number(number) when is_integer(number), do: Decimal.new(number)
+
+  defp average_cost(%{successful: successful}) when successful < 1, do: nil
+
+  defp average_cost(%{total_cost: total_cost, successful: successful}) do
+    Decimal.div(total_cost, successful)
+  end
+
+  defp average_latency(%{successful: successful}) when successful < 1, do: nil
+
+  defp average_latency(%{total_latency: total_latency, successful: successful}) do
+    round(total_latency / successful)
+  end
 
   defp ensure_documents_loaded(%TestCase{documents: %NotLoaded{}} = test_case) do
     repo().preload(test_case, :documents)

--- a/lib/aludel/evals.ex
+++ b/lib/aludel/evals.ex
@@ -323,14 +323,16 @@ defmodule Aludel.Evals do
     suite = repo().preload(suite, test_cases: :documents)
 
     results = Enum.map(suite.test_cases, &execute_test_case(&1, version, provider))
+    summary = summarize_suite_results(results)
 
-    create_suite_run(%{
-      suite_id: suite.id,
-      prompt_version_id: version.id,
-      provider_id: provider.id,
-      results: results
-    })
-    |> merge_suite_run_summary(results)
+    create_suite_run(
+      Map.merge(summary, %{
+        suite_id: suite.id,
+        prompt_version_id: version.id,
+        provider_id: provider.id,
+        results: results
+      })
+    )
   end
 
   @doc """
@@ -523,22 +525,14 @@ defmodule Aludel.Evals do
     end)
   end
 
-  defp merge_suite_run_summary({:ok, suite_run}, results) do
-    suite_run
-    |> SuiteRun.changeset(Map.put(summarize_suite_results(results), :results, results))
-    |> repo().update()
-  end
-
-  defp merge_suite_run_summary(error, _results), do: error
-
   defp summarize_suite_results(results) do
     metrics =
       Enum.reduce(results, %{total_cost: Decimal.new("0"), total_latency: 0, successful: 0}, fn
         %{"cost_usd" => cost, "latency_ms" => latency}, acc
-        when is_number(cost) and is_integer(latency) ->
+        when is_number(cost) and is_number(latency) ->
           %{
             total_cost: Decimal.add(acc.total_cost, decimal_from_number(cost)),
-            total_latency: acc.total_latency + latency,
+            total_latency: acc.total_latency + round(latency),
             successful: acc.successful + 1
           }
 

--- a/lib/aludel/web/live/suite_live/show.ex
+++ b/lib/aludel/web/live/suite_live/show.ex
@@ -366,6 +366,22 @@ defmodule Aludel.Web.SuiteLive.Show do
     end
   end
 
+  @impl Phoenix.LiveView
+  def handle_event(
+        "retry_suite_result",
+        %{"suite-run-id" => suite_run_id, "test-case-id" => test_case_id},
+        socket
+      ) do
+    socket =
+      if socket.assigns.running do
+        put_flash(socket, :error, "Suite is already running")
+      else
+        retry_suite_result(socket, suite_run_id, test_case_id)
+      end
+
+    {:noreply, socket}
+  end
+
   defp handle_test_case_uploads(socket, test_case) do
     socket
     |> consume_uploaded_entries(:documents, fn %{path: path}, entry ->
@@ -492,6 +508,53 @@ defmodule Aludel.Web.SuiteLive.Show do
     end)
   end
 
+  defp retry_count(%{"retry_count" => count}) when is_integer(count), do: count
+
+  defp retry_count(%{"retry_count" => count}) when is_binary(count) do
+    case Integer.parse(count) do
+      {parsed, ""} -> parsed
+      _ -> 0
+    end
+  end
+
+  defp retry_count(_result), do: 0
+
+  defp retried_at(%{"retried_at" => retried_at}) when is_binary(retried_at) do
+    case DateTime.from_iso8601(retried_at) do
+      {:ok, datetime, _offset} -> datetime
+      _ -> nil
+    end
+  end
+
+  defp retried_at(_result), do: nil
+
+  defp retry_suite_result(socket, suite_run_id, test_case_id) do
+    with {:ok, suite_run} <- fetch_loaded_suite_run(socket.assigns.suite_runs, suite_run_id),
+         {:ok, updated_suite_run} <- Evals.retry_suite_run_test_case(suite_run, test_case_id) do
+      updated_suite_run = Evals.reload_suite_run_with_associations(updated_suite_run)
+
+      socket
+      |> assign(:suite_runs, replace_suite_run(socket.assigns.suite_runs, updated_suite_run))
+      |> put_flash(:info, "Test case retried successfully")
+    else
+      {:error, reason} ->
+        put_flash(socket, :error, retry_result_error_message(reason))
+    end
+  end
+
+  defp fetch_loaded_suite_run(suite_runs, suite_run_id) do
+    case Enum.find(suite_runs, &(&1.id == suite_run_id)) do
+      nil -> {:error, :suite_run_not_found}
+      suite_run -> {:ok, suite_run}
+    end
+  end
+
+  defp replace_suite_run(suite_runs, updated_suite_run) do
+    Enum.map(suite_runs, fn suite_run ->
+      if suite_run.id == updated_suite_run.id, do: updated_suite_run, else: suite_run
+    end)
+  end
+
   defp clear_run_task_state(socket) do
     case socket.assigns.run_task_monitor_ref do
       nil ->
@@ -536,6 +599,26 @@ defmodule Aludel.Web.SuiteLive.Show do
     do: "Failed to execute suite: #{format_execution_error_detail(detail)}"
 
   defp suite_execution_error_message(_reason), do: "Failed to execute suite"
+
+  defp retry_result_error_message(:test_case_result_not_found),
+    do: "Failed to retry test case: existing result not found"
+
+  defp retry_result_error_message(:suite_run_not_found),
+    do: "Failed to retry test case: suite run not found"
+
+  defp retry_result_error_message(:test_case_not_found),
+    do: "Failed to retry test case: test case not found"
+
+  defp retry_result_error_message(:prompt_version_not_found),
+    do: "Failed to retry test case: prompt version not found"
+
+  defp retry_result_error_message(:provider_not_found),
+    do: "Failed to retry test case: provider not found"
+
+  defp retry_result_error_message({:retry_failed, detail}),
+    do: "Failed to retry test case: #{format_execution_error_detail(detail)}"
+
+  defp retry_result_error_message(_reason), do: "Failed to retry test case"
 
   defp format_execution_error_detail(detail) when is_binary(detail), do: detail
   defp format_execution_error_detail(detail), do: inspect(detail)

--- a/lib/aludel/web/live/suite_live/show.html.heex
+++ b/lib/aludel/web/live/suite_live/show.html.heex
@@ -631,22 +631,49 @@
                     <% end %>
                     <div style={"padding: 14px; background: #{if result["passed"], do: "rgba(16, 185, 129, 0.05)", else: "rgba(248, 81, 73, 0.05)"}"}>
                       <div style="display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 8px;">
-                        <div style="display: flex; align-items: center; gap: 8px;">
-                          <span style={"font-weight: 600; font-size: 13px; color: #{if result["passed"], do: "#10b981", else: "#f85149"}"}>
-                            {if result["passed"], do: "✓ Output", else: "✗ Output"}
-                          </span>
+                        <div style="display: flex; flex-direction: column; align-items: start; gap: 4px;">
+                          <div style="display: flex; align-items: center; gap: 8px;">
+                            <span style={"font-weight: 600; font-size: 13px; color: #{if result["passed"], do: "#10b981", else: "#f85149"}"}>
+                              {if result["passed"], do: "✓ Output", else: "✗ Output"}
+                            </span>
+                          </div>
+                          <%= if retry_count(result) > 0 do %>
+                            <div
+                              id={"suite-result-retry-meta-#{suite_run.id}-#{result["test_case_id"]}"}
+                              style="font-size: 11px; color: var(--text-muted);"
+                            >
+                              {"Retry ##{retry_count(result)}"}
+                              <%= if retried_at = retried_at(result) do %>
+                                <span>{" • #{relative_time(retried_at)}"}</span>
+                              <% end %>
+                            </div>
+                          <% end %>
                         </div>
-                        <button
-                          id={"copy-suite-result-#{suite_run.id}-#{result["test_case_id"]}"}
-                          type="button"
-                          phx-hook="CopyToClipboard"
-                          phx-update="ignore"
-                          data-copy-target={"suite-result-output-#{suite_run.id}-#{result["test_case_id"]}"}
-                          data-copy-label="Copy output"
-                          style="border: 1px solid var(--border); background: var(--bg-tertiary); color: var(--text-secondary); border-radius: 8px; padding: 4px 10px; font-size: 11px; font-weight: 600; cursor: pointer; transition: background-color 0.2s ease, color 0.2s ease;"
-                        >
-                          Copy output
-                        </button>
+                        <div style="display: flex; align-items: center; gap: 8px;">
+                          <button
+                            id={"retry-suite-result-#{suite_run.id}-#{result["test_case_id"]}"}
+                            type="button"
+                            phx-click="retry_suite_result"
+                            phx-value-suite-run-id={suite_run.id}
+                            phx-value-test-case-id={result["test_case_id"]}
+                            phx-disable-with="Retrying..."
+                            disabled={@running}
+                            style="border: 1px solid var(--border); background: var(--bg-tertiary); color: var(--text-secondary); border-radius: 8px; padding: 4px 10px; font-size: 11px; font-weight: 600; cursor: pointer; transition: background-color 0.2s ease, color 0.2s ease;"
+                          >
+                            Retry
+                          </button>
+                          <button
+                            id={"copy-suite-result-#{suite_run.id}-#{result["test_case_id"]}"}
+                            type="button"
+                            phx-hook="CopyToClipboard"
+                            phx-update="ignore"
+                            data-copy-target={"suite-result-output-#{suite_run.id}-#{result["test_case_id"]}"}
+                            data-copy-label="Copy output"
+                            style="border: 1px solid var(--border); background: var(--bg-tertiary); color: var(--text-secondary); border-radius: 8px; padding: 4px 10px; font-size: 11px; font-weight: 600; cursor: pointer; transition: background-color 0.2s ease, color 0.2s ease;"
+                          >
+                            Copy output
+                          </button>
+                        </div>
                       </div>
                       <pre
                         id={"suite-result-output-#{suite_run.id}-#{result["test_case_id"]}"}

--- a/lib/aludel/web/live/suite_live/show.html.heex
+++ b/lib/aludel/web/live/suite_live/show.html.heex
@@ -643,8 +643,8 @@
                               style="font-size: 11px; color: var(--text-muted);"
                             >
                               {"Retry ##{retry_count(result)}"}
-                              <%= if retried_at = retried_at(result) do %>
-                                <span>{" • #{relative_time(retried_at)}"}</span>
+                              <%= if retried_at_time = retried_at(result) do %>
+                                <span>{" • #{relative_time(retried_at_time)}"}</span>
                               <% end %>
                             </div>
                           <% end %>

--- a/test/aludel/evals_test.exs
+++ b/test/aludel/evals_test.exs
@@ -385,6 +385,92 @@ defmodule Aludel.EvalsTest do
       assert result.total_passed == 15
       assert result.total_failed == 5
     end
+
+    test "retry_suite_run_test_case/2 replaces the existing result and recalculates aggregates" do
+      prompt = prompt_fixture()
+      {:ok, version} = Aludel.Prompts.create_prompt_version(prompt, "Hello {{name}}")
+      suite = suite_fixture(%{prompt_id: prompt.id})
+
+      provider =
+        provider_fixture(%{
+          pricing: %{"input" => 1000.0, "output" => 2000.0}
+        })
+
+      passing_test_case =
+        test_case_fixture(%{
+          suite_id: suite.id,
+          variable_values: %{"name" => "Bob"},
+          assertions: [%{"type" => "contains", "value" => "Hello"}]
+        })
+
+      retried_test_case =
+        test_case_fixture(%{
+          suite_id: suite.id,
+          variable_values: %{"name" => "Alice"},
+          assertions: [%{"type" => "contains", "value" => "Hello"}]
+        })
+
+      suite_run =
+        suite_run_fixture(%{
+          suite_id: suite.id,
+          prompt_version_id: version.id,
+          provider_id: provider.id,
+          passed: 1,
+          failed: 1,
+          avg_cost_usd: Decimal.new("0.003"),
+          avg_latency_ms: 140,
+          results: [
+            %{
+              "test_case_id" => passing_test_case.id,
+              "passed" => true,
+              "output" => "Hello Bob",
+              "assertion_results" => [
+                %{"type" => "contains", "passed" => true, "value" => "Hello"}
+              ],
+              "cost_usd" => 0.003,
+              "latency_ms" => 140
+            },
+            %{
+              "test_case_id" => retried_test_case.id,
+              "passed" => false,
+              "output" => "Rate limit exceeded",
+              "assertion_results" => [],
+              "cost_usd" => nil,
+              "latency_ms" => nil
+            }
+          ]
+        })
+
+      expect(HttpClientMock, :request, fn _model, prompt, _opts ->
+        assert prompt == "Hello Alice"
+
+        {:ok, build_mock_response("Hello Alice", 5, 10)}
+      end)
+
+      assert {:ok, updated_suite_run} =
+               Evals.retry_suite_run_test_case(suite_run, retried_test_case.id)
+
+      retried_result =
+        Enum.find(updated_suite_run.results, fn result ->
+          result["test_case_id"] == retried_test_case.id
+        end)
+
+      assert retried_result["passed"] == true
+      assert retried_result["output"] == "Hello Alice"
+      assert retried_result["retry_count"] == 1
+      assert is_binary(retried_result["retried_at"])
+      assert updated_suite_run.passed == 2
+      assert updated_suite_run.failed == 0
+      assert Decimal.compare(updated_suite_run.avg_cost_usd, Decimal.new("0")) == :gt
+      assert updated_suite_run.avg_latency_ms >= 0
+
+      reloaded_suite_run = Evals.get_suite_run!(suite_run.id)
+
+      assert Enum.any?(reloaded_suite_run.results, fn result ->
+               result["test_case_id"] == retried_test_case.id and
+                 result["retry_count"] == 1 and result["output"] == "Hello Alice"
+             end)
+    end
   end
 
   describe "execute_suite/3" do

--- a/test/aludel_web/live/suite_live/show_test.exs
+++ b/test/aludel_web/live/suite_live/show_test.exs
@@ -6,6 +6,9 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
   import Aludel.EvalsFixtures
   import Aludel.PromptsFixtures
   import Aludel.ProvidersFixtures
+  import Mox
+
+  alias Aludel.Interfaces.HttpClientMock
 
   test "displays suite details", %{conn: conn} do
     prompt = prompt_fixture(%{name: "Test Prompt"})
@@ -698,6 +701,82 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
                view,
                "#copy-suite-result-#{suite_run.id}-#{test_case.id}",
                "Copy output"
+             )
+    end
+  end
+
+  describe "retry test case result" do
+    test "retries a single result and refreshes the rendered output", %{conn: conn} do
+      prompt = prompt_fixture_with_version(%{template: "Hello {{name}}"})
+      suite = suite_fixture(%{prompt_id: prompt.id})
+      prompt = Aludel.Prompts.get_prompt_with_versions!(prompt.id)
+      version = hd(prompt.versions)
+
+      provider =
+        provider_fixture(%{
+          name: "OpenAI",
+          pricing: %{"input" => 1000.0, "output" => 2000.0}
+        })
+
+      test_case =
+        test_case_fixture(%{
+          suite_id: suite.id,
+          variable_values: %{"name" => "Alice"},
+          assertions: [%{"type" => "contains", "value" => "Hello"}]
+        })
+
+      suite_run =
+        suite_run_fixture(%{
+          suite_id: suite.id,
+          prompt_version_id: version.id,
+          provider_id: provider.id,
+          passed: 0,
+          failed: 1,
+          results: [
+            %{
+              "test_case_id" => test_case.id,
+              "passed" => false,
+              "output" => "Rate limit exceeded",
+              "assertion_results" => [],
+              "cost_usd" => nil,
+              "latency_ms" => nil
+            }
+          ]
+        })
+
+      {:ok, view, _html} = live(conn, "/suites/#{suite.id}")
+
+      Mox.allow(HttpClientMock, self(), view.pid)
+
+      expect(HttpClientMock, :request, fn _model, prompt, _opts ->
+        assert prompt == "Hello Alice"
+
+        {:ok, %{content: "Hello Alice", input_tokens: 5, output_tokens: 10}}
+      end)
+
+      assert has_element?(
+               view,
+               "#retry-suite-result-#{suite_run.id}-#{test_case.id}",
+               "Retry"
+             )
+
+      html =
+        view
+        |> element("#retry-suite-result-#{suite_run.id}-#{test_case.id}")
+        |> render_click()
+
+      assert html =~ "Test case retried successfully"
+
+      assert has_element?(
+               view,
+               "#suite-result-output-#{suite_run.id}-#{test_case.id}",
+               "Hello Alice"
+             )
+
+      assert has_element?(
+               view,
+               "#suite-result-retry-meta-#{suite_run.id}-#{test_case.id}",
+               "Retry #1"
              )
     end
   end


### PR DESCRIPTION
## Motivation (required)

This change fixes issue #44 by letting users retry a single suite test result instead of rerunning the entire suite. The existing suite-run model stores per-test outcomes inline in `suite_runs.results`, so the fix updates that embedded result in place, recalculates the suite aggregates, and exposes the action from the suite results UI.

Closes #44.

## Test Plan (required)

Commands run:

```bash
mix test test/aludel/evals_test.exs test/aludel_web/live/suite_live/show_test.exs
mix precommit
```

Results:

- Added a context regression test covering single-result retry, retry metadata, and aggregate recomputation.
- Added a LiveView regression test covering the retry action and in-place UI refresh.
- `mix precommit` passed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retry individual test cases within suite runs directly from the UI via a per-result Retry control
  * Retried test cases show retry count and relative retried timestamp
  * Suite-level metrics (passed/failed counts, average cost/latency) are recalculated after retries

* **Tests**
  * Added end-to-end and unit tests covering retry behavior, UI interaction, and aggregate recalculation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->