### PR TITLE
chore: prepare 0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-04-25
+
+### Added
+- Configurable document storage backends for uploaded test case documents, including local, AWS S3, and Google Cloud Storage adapters
+- Retry actions for individual suite test results
+
+### Changed
+- Modeled explicit run execution states across runs and run results for clearer execution lifecycle tracking
+- Updated `req_llm` to 1.10.0
+
 ## [0.1.19] - 2026-04-19
 
 ### Added

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Aludel.MixProject do
   def project do
     [
       app: :aludel,
-      version: "0.1.19",
+      version: "0.2.0",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Motivation (required)

Prepare the `0.2.0` release from the current `main` diff by bumping the package version and recording the release notes for the changes that landed after `v0.1.19`.

This keeps the published package metadata and changelog aligned before tagging or publishing the next release.

## Test Plan (required)

Commands run:

```bash
mix deps.get
mix format mix.exs
mix precommit
```

Observed result:

- `mix precommit` passed
- ExUnit finished with `567 tests, 0 failures`

## Next Steps

- If CI passes, create the `v0.2.0` tag from this branch or after merge, following the repo's release flow.
- Publish the Hex release once the tag/release step is complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 0.2.0

* **New Features**
  * Configurable test document storage adapters: local, AWS S3, and Google Cloud Storage
  * Retry actions for individual suite test results

* **Changed**
  * Updated behavior for modeled explicit run execution states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->