### PR TITLE
feat: support nullable run result metrics

### DIFF
--- a/lib/aludel/runs/run_result.ex
+++ b/lib/aludel/runs/run_result.ex
@@ -16,7 +16,7 @@ defmodule Aludel.Runs.RunResult do
   @type t :: %__MODULE__{}
 
   @required_fields ~w(run_id provider_id status)a
-  @optional_fields ~w(output input_tokens output_tokens latency_ms cost_usd error started_at completed_at)a
+  @optional_fields ~w(output input_tokens output_tokens latency_ms cost_usd metadata error started_at completed_at)a
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
@@ -27,6 +27,7 @@ defmodule Aludel.Runs.RunResult do
     field :output_tokens, :integer
     field :latency_ms, :integer
     field :cost_usd, :float
+    field :metadata, :map
     field :status, Ecto.Enum, values: [:pending, :running, :completed, :error]
     field :error, :string
     field :started_at, :utc_datetime

--- a/lib/aludel/runs/run_result.ex
+++ b/lib/aludel/runs/run_result.ex
@@ -49,7 +49,15 @@ defmodule Aludel.Runs.RunResult do
     run_result
     |> cast(attrs, @required_fields ++ @optional_fields)
     |> validate_required(@required_fields)
+    |> validate_change(:metadata, &validate_json_encodable_metadata/2)
     |> foreign_key_constraint(:run_id)
     |> foreign_key_constraint(:provider_id)
+  end
+
+  defp validate_json_encodable_metadata(:metadata, metadata) do
+    case Jason.encode(metadata) do
+      {:ok, _encoded_metadata} -> []
+      {:error, _reason} -> [metadata: "must be JSON-encodable"]
+    end
   end
 end

--- a/lib/aludel/web/live/run_live/show.ex
+++ b/lib/aludel/web/live/run_live/show.ex
@@ -76,5 +76,13 @@ defmodule Aludel.Web.RunLive.Show do
 
   defp show_result_metadata?(_result), do: false
 
-  defp format_result_metadata(metadata), do: Jason.encode!(metadata, pretty: true)
+  defp format_result_metadata(metadata) do
+    case Jason.encode(metadata, pretty: true) do
+      {:ok, encoded_metadata} ->
+        encoded_metadata
+
+      {:error, _reason} ->
+        inspect(metadata, pretty: true, limit: :infinity, printable_limit: :infinity)
+    end
+  end
 end

--- a/lib/aludel/web/live/run_live/show.ex
+++ b/lib/aludel/web/live/run_live/show.ex
@@ -56,4 +56,25 @@ defmodule Aludel.Web.RunLive.Show do
 
     {:noreply, assign(socket, run: run, run_results: run.run_results)}
   end
+
+  defp format_token_usage(result) do
+    [format_optional_integer(result.input_tokens), format_optional_integer(result.output_tokens)]
+    |> Enum.join(" / ")
+  end
+
+  defp format_optional_integer(nil), do: "N/A"
+  defp format_optional_integer(value), do: Integer.to_string(value)
+
+  defp format_latency(nil), do: "N/A"
+  defp format_latency(value), do: "#{value} ms"
+
+  defp format_cost(nil), do: "N/A"
+  defp format_cost(value), do: "$#{:erlang.float_to_binary(value, decimals: 4)}"
+
+  defp show_result_metadata?(%{metadata: metadata}) when is_map(metadata),
+    do: map_size(metadata) > 0
+
+  defp show_result_metadata?(_result), do: false
+
+  defp format_result_metadata(metadata), do: Jason.encode!(metadata, pretty: true)
 end

--- a/lib/aludel/web/live/run_live/show.html.heex
+++ b/lib/aludel/web/live/run_live/show.html.heex
@@ -104,7 +104,7 @@
                     Tokens
                   </div>
                   <div style="font-size: 13px; font-weight: 500; color: var(--text-primary);">
-                    {result.input_tokens} / {result.output_tokens}
+                    {format_token_usage(result)}
                   </div>
                 </div>
                 <div>
@@ -112,7 +112,7 @@
                     Latency
                   </div>
                   <div style="font-size: 13px; font-weight: 500; color: var(--text-primary);">
-                    {result.latency_ms} ms
+                    {format_latency(result.latency_ms)}
                   </div>
                 </div>
                 <div>
@@ -120,7 +120,7 @@
                     Cost
                   </div>
                   <div style="font-size: 13px; font-weight: 500; color: var(--text-primary);">
-                    ${:erlang.float_to_binary(result.cost_usd, decimals: 4)}
+                    {format_cost(result.cost_usd)}
                   </div>
                 </div>
               </div>
@@ -182,6 +182,17 @@
                     style="background-color: var(--bg-tertiary); border: 1px solid var(--border); padding: 12px; border-radius: 4px; font-size: 12px; line-height: 1.5; overflow-x: auto; margin: 0; white-space: pre-wrap; word-wrap: break-word; flex: 1;"
                   ><%= result.output %></pre>
               <% end %>
+
+              <details
+                :if={show_result_metadata?(result)}
+                id={"run-result-metadata-#{result.id}"}
+                style="margin-top: 12px; border: 1px solid var(--border); border-radius: 8px; background-color: var(--bg-secondary);"
+              >
+                <summary style="cursor: pointer; padding: 10px 12px; font-size: 11px; font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.05em;">
+                  Callback metadata
+                </summary>
+                <pre style="margin: 0; padding: 0 12px 12px; font-size: 12px; line-height: 1.5; white-space: pre-wrap; word-wrap: break-word; color: var(--text-primary);"><%= format_result_metadata(result.metadata) %></pre>
+              </details>
             </div>
           </div>
         <% end %>

--- a/lib/aludel/web/live/run_live/show.html.heex
+++ b/lib/aludel/web/live/run_live/show.html.heex
@@ -103,7 +103,10 @@
                   <div style="font-size: 10px; font-weight: 500; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 2px;">
                     Tokens
                   </div>
-                  <div style="font-size: 13px; font-weight: 500; color: var(--text-primary);">
+                  <div
+                    id={"run-result-token-usage-#{result.id}"}
+                    style="font-size: 13px; font-weight: 500; color: var(--text-primary);"
+                  >
                     {format_token_usage(result)}
                   </div>
                 </div>
@@ -111,7 +114,10 @@
                   <div style="font-size: 10px; font-weight: 500; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 2px;">
                     Latency
                   </div>
-                  <div style="font-size: 13px; font-weight: 500; color: var(--text-primary);">
+                  <div
+                    id={"run-result-latency-#{result.id}"}
+                    style="font-size: 13px; font-weight: 500; color: var(--text-primary);"
+                  >
                     {format_latency(result.latency_ms)}
                   </div>
                 </div>
@@ -119,7 +125,10 @@
                   <div style="font-size: 10px; font-weight: 500; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 2px;">
                     Cost
                   </div>
-                  <div style="font-size: 13px; font-weight: 500; color: var(--text-primary);">
+                  <div
+                    id={"run-result-cost-#{result.id}"}
+                    style="font-size: 13px; font-weight: 500; color: var(--text-primary);"
+                  >
                     {format_cost(result.cost_usd)}
                   </div>
                 </div>

--- a/priv/repo/migrations/20260426110000_add_metadata_to_run_results.exs
+++ b/priv/repo/migrations/20260426110000_add_metadata_to_run_results.exs
@@ -1,0 +1,9 @@
+defmodule Aludel.Repo.Migrations.AddMetadataToRunResults do
+  use Ecto.Migration
+
+  def change do
+    alter table(:run_results) do
+      add :metadata, :map
+    end
+  end
+end

--- a/test/aludel/runs/run_result_test.exs
+++ b/test/aludel/runs/run_result_test.exs
@@ -187,5 +187,21 @@ defmodule Aludel.Runs.RunResultTest do
       assert changeset.valid?
       refute Map.has_key?(changeset.changes, :error)
     end
+
+    test "accepts callback metadata", %{run: run, provider: provider} do
+      metadata = %{"trace_id" => "trace-123", "host" => "embedded-app"}
+
+      changeset =
+        RunResult.changeset(%RunResult{}, %{
+          run_id: run.id,
+          provider_id: provider.id,
+          output: "Hello world",
+          status: :completed,
+          metadata: metadata
+        })
+
+      assert changeset.valid?
+      assert changeset.changes.metadata == metadata
+    end
   end
 end

--- a/test/aludel/runs/run_result_test.exs
+++ b/test/aludel/runs/run_result_test.exs
@@ -203,5 +203,19 @@ defmodule Aludel.Runs.RunResultTest do
       assert changeset.valid?
       assert changeset.changes.metadata == metadata
     end
+
+    test "rejects metadata that cannot be encoded as JSON", %{run: run, provider: provider} do
+      changeset =
+        RunResult.changeset(%RunResult{}, %{
+          run_id: run.id,
+          provider_id: provider.id,
+          output: "Hello world",
+          status: :completed,
+          metadata: %{"pid" => self()}
+        })
+
+      refute changeset.valid?
+      assert %{metadata: ["must be JSON-encodable"]} = errors_on(changeset)
+    end
   end
 end

--- a/test/aludel_web/live/run_live/show_test.exs
+++ b/test/aludel_web/live/run_live/show_test.exs
@@ -180,10 +180,11 @@ defmodule Aludel.Web.RunLive.ShowTest do
           }
         })
 
-      {:ok, view, html} = live(conn, "/runs/#{run.id}")
+      {:ok, view, _html} = live(conn, "/runs/#{run.id}")
 
-      assert html =~ "N/A / N/A"
-      assert html =~ "N/A"
+      assert has_element?(view, "#run-result-token-usage-#{result.id}", "N/A / N/A")
+      assert has_element?(view, "#run-result-latency-#{result.id}", "N/A")
+      assert has_element?(view, "#run-result-cost-#{result.id}", "N/A")
       assert has_element?(view, "#run-result-metadata-#{result.id}")
       assert has_element?(view, "#run-result-metadata-#{result.id} summary", "Callback metadata")
 

--- a/test/aludel_web/live/run_live/show_test.exs
+++ b/test/aludel_web/live/run_live/show_test.exs
@@ -160,6 +160,46 @@ defmodule Aludel.Web.RunLive.ShowTest do
       assert html =~ "API call failed"
     end
 
+    test "renders missing metrics as N/A and shows callback metadata", %{conn: conn} do
+      run = run_fixture(%{name: "Callback Run"})
+      provider = provider_fixture(%{name: "Callback Provider"})
+
+      result =
+        run_result_fixture(%{
+          run_id: run.id,
+          provider_id: provider.id,
+          output: "Callback output",
+          status: :completed,
+          input_tokens: nil,
+          output_tokens: nil,
+          latency_ms: nil,
+          cost_usd: nil,
+          metadata: %{
+            "trace_id" => "trace-123",
+            "job_id" => "job-456"
+          }
+        })
+
+      {:ok, view, html} = live(conn, "/runs/#{run.id}")
+
+      assert html =~ "N/A / N/A"
+      assert html =~ "N/A"
+      assert has_element?(view, "#run-result-metadata-#{result.id}")
+      assert has_element?(view, "#run-result-metadata-#{result.id} summary", "Callback metadata")
+
+      assert has_element?(
+               view,
+               "#run-result-metadata-#{result.id} pre",
+               "\"trace_id\": \"trace-123\""
+             )
+
+      assert has_element?(
+               view,
+               "#run-result-metadata-#{result.id} pre",
+               "\"job_id\": \"job-456\""
+             )
+    end
+
     test "shows copy actions for successful outputs", %{conn: conn, run: run, result1: result1} do
       {:ok, view, _html} = live(conn, "/runs/#{run.id}")
 

--- a/test/support/migrations/20260426110000_add_metadata_to_run_results.exs
+++ b/test/support/migrations/20260426110000_add_metadata_to_run_results.exs
@@ -1,0 +1,9 @@
+defmodule Aludel.TestSupport.Migrations.AddMetadataToRunResults do
+  use Ecto.Migration
+
+  def change do
+    alter table(:run_results) do
+      add :metadata, :map
+    end
+  end
+end


### PR DESCRIPTION
## Motivation (required)

The run results UI assumed token, latency, and cost metrics were always present, which breaks callback-mode executions that only return output plus partial metrics. This change makes the run results view tolerant of missing metrics and adds a metadata inspector for callback details such as trace IDs.

Closes #75.

