### PR TITLE
feat: export raw run and suite results as JSON

### DIFF
--- a/lib/aludel/evals.ex
+++ b/lib/aludel/evals.ex
@@ -243,6 +243,19 @@ defmodule Aludel.Evals do
   end
 
   @doc """
+  Gets a suite run by ID for export.
+
+  Preloads the suite, prompt version, and provider so the export
+  payload can be built without leaking Repo access to the web layer.
+  """
+  @spec get_suite_run_for_export!(binary()) :: SuiteRun.t()
+  def get_suite_run_for_export!(id) do
+    SuiteRun
+    |> repo().get!(id)
+    |> repo().preload([:suite, :prompt_version, :provider])
+  end
+
+  @doc """
   Reloads a suite run with associations preloaded.
   """
   @spec reload_suite_run_with_associations(SuiteRun.t()) :: SuiteRun.t()

--- a/lib/aludel/runs.ex
+++ b/lib/aludel/runs.ex
@@ -133,6 +133,19 @@ defmodule Aludel.Runs do
   end
 
   @doc """
+  Gets a run result by ID for export.
+
+  Preloads the parent run, prompt, and provider so the payload can
+  be serialized without additional lookups.
+  """
+  @spec get_run_result_for_export!(binary()) :: RunResult.t()
+  def get_run_result_for_export!(id) do
+    RunResult
+    |> repo().get!(id)
+    |> repo().preload([:provider, run: [prompt_version: :prompt]])
+  end
+
+  @doc """
   Updates an existing run result.
   """
   @spec update_run_result(RunResult.t(), map()) ::

--- a/lib/aludel/web/export_controller.ex
+++ b/lib/aludel/web/export_controller.ex
@@ -28,10 +28,16 @@ defmodule Aludel.Web.ExportController do
   end
 
   defp send_json_download(conn, payload, filename) do
+    encoded_payload = Jason.encode!(payload, pretty: true)
+
     conn
-    |> put_resp_content_type("application/json")
-    |> put_resp_header("content-disposition", ~s(attachment; filename="#{filename}"))
-    |> send_resp(200, Jason.encode!(payload, pretty: true))
+    |> put_resp_header("cache-control", "no-store, max-age=0")
+    |> put_resp_header("pragma", "no-cache")
+    |> put_resp_header("expires", "0")
+    |> send_download({:binary, encoded_payload},
+      filename: filename,
+      content_type: "application/json"
+    )
   end
 
   defp serialize_run_result_export(result) do

--- a/lib/aludel/web/export_controller.ex
+++ b/lib/aludel/web/export_controller.ex
@@ -1,0 +1,140 @@
+defmodule Aludel.Web.ExportController do
+  @moduledoc false
+
+  use Phoenix.Controller, formats: [:json]
+
+  import Plug.Conn
+
+  alias Aludel.Evals
+  alias Aludel.Runs
+  alias Decimal
+
+  def run_result(conn, %{"id" => id}) do
+    payload =
+      id
+      |> Runs.get_run_result_for_export!()
+      |> serialize_run_result_export()
+
+    send_json_download(conn, payload, "run-result-#{id}.json")
+  end
+
+  def suite_run(conn, %{"id" => id}) do
+    payload =
+      id
+      |> Evals.get_suite_run_for_export!()
+      |> serialize_suite_run_export()
+
+    send_json_download(conn, payload, "suite-run-#{id}.json")
+  end
+
+  defp send_json_download(conn, payload, filename) do
+    conn
+    |> put_resp_content_type("application/json")
+    |> put_resp_header("content-disposition", ~s(attachment; filename="#{filename}"))
+    |> send_resp(200, Jason.encode!(payload, pretty: true))
+  end
+
+  defp serialize_run_result_export(result) do
+    %{
+      type: "run_result",
+      exported_at: iso8601(DateTime.utc_now()),
+      run: %{
+        id: result.run.id,
+        name: result.run.name,
+        status: to_string(result.run.status),
+        prompt_version_id: result.run.prompt_version_id,
+        prompt_id: result.run.prompt_version.prompt.id,
+        prompt_name: result.run.prompt_version.prompt.name,
+        variable_values: result.run.variable_values,
+        started_at: iso8601(result.run.started_at),
+        completed_at: iso8601(result.run.completed_at)
+      },
+      result: %{
+        id: result.id,
+        provider: serialize_provider(result.provider),
+        status: to_string(result.status),
+        output: result.output,
+        error: result.error,
+        input_tokens: result.input_tokens,
+        output_tokens: result.output_tokens,
+        latency_ms: result.latency_ms,
+        cost_usd: result.cost_usd,
+        metadata: result.metadata,
+        started_at: iso8601(result.started_at),
+        completed_at: iso8601(result.completed_at),
+        inserted_at: iso8601(result.inserted_at),
+        updated_at: iso8601(result.updated_at)
+      }
+    }
+  end
+
+  defp serialize_suite_run_export(suite_run) do
+    %{
+      type: "suite_run",
+      exported_at: iso8601(DateTime.utc_now()),
+      suite_run: %{
+        id: suite_run.id,
+        suite: %{
+          id: suite_run.suite.id,
+          name: suite_run.suite.name
+        },
+        prompt_version: %{
+          id: suite_run.prompt_version.id,
+          version: suite_run.prompt_version.version,
+          prompt_id: suite_run.prompt_version.prompt_id
+        },
+        provider: serialize_provider(suite_run.provider),
+        summary: %{
+          passed: suite_run.passed,
+          failed: suite_run.failed,
+          total: suite_run.passed + suite_run.failed,
+          avg_cost_usd: decimal_to_float(suite_run.avg_cost_usd),
+          avg_latency_ms: suite_run.avg_latency_ms
+        },
+        results: Enum.map(suite_run.results, &serialize_suite_result/1),
+        inserted_at: iso8601(suite_run.inserted_at),
+        updated_at: iso8601(suite_run.updated_at)
+      }
+    }
+  end
+
+  defp serialize_suite_result(result) do
+    %{
+      test_case_id: result["test_case_id"],
+      status: if(result["passed"], do: "passed", else: "failed"),
+      passed: result["passed"],
+      output: result["output"],
+      error: suite_result_error(result),
+      input_tokens: result["input_tokens"],
+      output_tokens: result["output_tokens"],
+      latency_ms: result["latency_ms"],
+      cost_usd: result["cost_usd"],
+      assertion_results: Map.get(result, "assertion_results", []),
+      retry_count: result["retry_count"],
+      retried_at: result["retried_at"]
+    }
+  end
+
+  defp serialize_provider(provider) do
+    %{
+      id: provider.id,
+      name: provider.name,
+      type: to_string(provider.provider),
+      model: provider.model
+    }
+  end
+
+  defp suite_result_error(%{"passed" => false} = result) do
+    assertion_results = Map.get(result, "assertion_results", [])
+
+    if assertion_results == [], do: result["output"], else: nil
+  end
+
+  defp suite_result_error(_result), do: nil
+
+  defp decimal_to_float(nil), do: nil
+  defp decimal_to_float(%Decimal{} = decimal), do: Decimal.to_float(decimal)
+
+  defp iso8601(nil), do: nil
+  defp iso8601(%DateTime{} = datetime), do: DateTime.to_iso8601(datetime)
+end

--- a/lib/aludel/web/live/run_live/show.html.heex
+++ b/lib/aludel/web/live/run_live/show.html.heex
@@ -140,30 +140,40 @@
                 <div style="font-size: 11px; font-weight: 500; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.05em;">
                   Output
                 </div>
-                <button
-                  :if={result.status == :error}
-                  id={"copy-run-error-#{result.id}"}
-                  type="button"
-                  phx-hook="CopyToClipboard"
-                  phx-update="ignore"
-                  data-copy-target={"run-result-error-#{result.id}"}
-                  data-copy-label="Copy error"
-                  style="border: 1px solid var(--border); background: var(--bg-tertiary); color: var(--text-secondary); border-radius: 8px; padding: 4px 10px; font-size: 11px; font-weight: 600; cursor: pointer; transition: background-color 0.2s ease, color 0.2s ease;"
-                >
-                  Copy error
-                </button>
-                <button
-                  :if={result.status != :error}
-                  id={"copy-run-output-#{result.id}"}
-                  type="button"
-                  phx-hook="CopyToClipboard"
-                  phx-update="ignore"
-                  data-copy-target={"run-result-output-#{result.id}"}
-                  data-copy-label="Copy output"
-                  style="border: 1px solid var(--border); background: var(--bg-tertiary); color: var(--text-secondary); border-radius: 8px; padding: 4px 10px; font-size: 11px; font-weight: 600; cursor: pointer; transition: background-color 0.2s ease, color 0.2s ease;"
-                >
-                  Copy output
-                </button>
+                <div style="display: flex; align-items: center; gap: 8px;">
+                  <a
+                    id={"export-run-result-#{result.id}"}
+                    href={aludel_path("runs/results/#{result.id}/export")}
+                    download
+                    style="border: 1px solid var(--border); background: var(--bg-tertiary); color: var(--text-secondary); border-radius: 8px; padding: 4px 10px; font-size: 11px; font-weight: 600; cursor: pointer; text-decoration: none; transition: background-color 0.2s ease, color 0.2s ease;"
+                  >
+                    Export JSON
+                  </a>
+                  <button
+                    :if={result.status == :error}
+                    id={"copy-run-error-#{result.id}"}
+                    type="button"
+                    phx-hook="CopyToClipboard"
+                    phx-update="ignore"
+                    data-copy-target={"run-result-error-#{result.id}"}
+                    data-copy-label="Copy error"
+                    style="border: 1px solid var(--border); background: var(--bg-tertiary); color: var(--text-secondary); border-radius: 8px; padding: 4px 10px; font-size: 11px; font-weight: 600; cursor: pointer; transition: background-color 0.2s ease, color 0.2s ease;"
+                  >
+                    Copy error
+                  </button>
+                  <button
+                    :if={result.status != :error}
+                    id={"copy-run-output-#{result.id}"}
+                    type="button"
+                    phx-hook="CopyToClipboard"
+                    phx-update="ignore"
+                    data-copy-target={"run-result-output-#{result.id}"}
+                    data-copy-label="Copy output"
+                    style="border: 1px solid var(--border); background: var(--bg-tertiary); color: var(--text-secondary); border-radius: 8px; padding: 4px 10px; font-size: 11px; font-weight: 600; cursor: pointer; transition: background-color 0.2s ease, color 0.2s ease;"
+                  >
+                    Copy output
+                  </button>
+                </div>
               </div>
               <%= cond do %>
                 <% result.status == :error -> %>

--- a/lib/aludel/web/live/suite_live/show.html.heex
+++ b/lib/aludel/web/live/suite_live/show.html.heex
@@ -558,6 +558,16 @@
                   <div style="font-size: 12px; color: var(--text-muted);">
                     {suite_run.passed + suite_run.failed} test cases
                   </div>
+                  <div style="margin-top: 8px;">
+                    <a
+                      id={"export-suite-run-#{suite_run.id}"}
+                      href={aludel_path("suites/runs/#{suite_run.id}/export")}
+                      download
+                      style="display: inline-flex; border: 1px solid var(--border); background: var(--bg-secondary); color: var(--text-secondary); border-radius: 8px; padding: 4px 10px; font-size: 11px; font-weight: 600; cursor: pointer; text-decoration: none; transition: background-color 0.2s ease, color 0.2s ease;"
+                    >
+                      Export JSON
+                    </a>
+                  </div>
                 </div>
               </div>
               <div style="background-color: var(--bg-tertiary); padding: 16px; border-radius: 6px;">

--- a/lib/aludel/web/router.ex
+++ b/lib/aludel/web/router.ex
@@ -67,10 +67,12 @@ defmodule Aludel.Web.Router do
           live "/prompts/:id", Aludel.Web.PromptLive.Show, :show, route_opts
 
           live "/runs/new", Aludel.Web.RunLive.New, :new, route_opts
+          get "/runs/results/:id/export", Aludel.Web.ExportController, :run_result
           live "/runs/:id", Aludel.Web.RunLive.Show, :show, route_opts
 
           live "/suites", Aludel.Web.SuiteLive.Index, :index, route_opts
           live "/suites/new", Aludel.Web.SuiteLive.New, :new, route_opts
+          get "/suites/runs/:id/export", Aludel.Web.ExportController, :suite_run
           live "/suites/:id", Aludel.Web.SuiteLive.Show, :show, route_opts
 
           live "/providers", Aludel.Web.ProviderLive.Index, :index, route_opts

--- a/test/aludel_web/export_controller_test.exs
+++ b/test/aludel_web/export_controller_test.exs
@@ -1,0 +1,125 @@
+defmodule Aludel.Web.ExportControllerTest do
+  use Aludel.Web.ConnCase, async: true
+
+  import Aludel.EvalsFixtures
+  import Aludel.PromptsFixtures
+  import Aludel.ProvidersFixtures
+  import Aludel.RunsFixtures
+
+  describe "GET /runs/results/:id/export" do
+    test "downloads a run result payload as JSON", %{conn: conn} do
+      run = run_fixture(%{name: "Export Run"})
+      provider = provider_fixture(%{name: "Export Provider"})
+
+      result =
+        run_result_fixture(%{
+          run_id: run.id,
+          provider_id: provider.id,
+          output: "Callback output",
+          status: :completed,
+          input_tokens: nil,
+          output_tokens: nil,
+          latency_ms: nil,
+          cost_usd: nil,
+          metadata: %{"trace_id" => "trace-123"}
+        })
+
+      conn = get(conn, "/runs/results/#{result.id}/export")
+
+      assert [content_type] = get_resp_header(conn, "content-type")
+      assert content_type =~ "application/json"
+
+      assert get_resp_header(conn, "content-disposition") == [
+               "attachment; filename=\"run-result-#{result.id}.json\""
+             ]
+
+      payload = Jason.decode!(conn.resp_body)
+
+      assert payload["type"] == "run_result"
+      assert payload["run"]["id"] == run.id
+      assert payload["run"]["name"] == "Export Run"
+      assert payload["result"]["id"] == result.id
+      assert payload["result"]["provider"]["id"] == provider.id
+      assert payload["result"]["provider"]["name"] == "Export Provider"
+      assert payload["result"]["status"] == "completed"
+      assert payload["result"]["output"] == "Callback output"
+      assert payload["result"]["metadata"]["trace_id"] == "trace-123"
+    end
+  end
+
+  describe "GET /suites/runs/:id/export" do
+    test "downloads a suite run payload as JSON", %{conn: conn} do
+      prompt = prompt_fixture_with_version(%{name: "Export Prompt"})
+      prompt = Aludel.Prompts.get_prompt_with_versions!(prompt.id)
+      version = hd(prompt.versions)
+      suite = suite_fixture(%{name: "Export Suite", prompt_id: prompt.id})
+      provider = provider_fixture(%{name: "Suite Provider"})
+      test_case = test_case_fixture(%{suite_id: suite.id})
+
+      suite_run =
+        suite_run_fixture(%{
+          suite_id: suite.id,
+          prompt_version_id: version.id,
+          provider_id: provider.id,
+          passed: 1,
+          failed: 0,
+          avg_cost_usd: Decimal.new("0.0010"),
+          avg_latency_ms: 250,
+          results: [
+            %{
+              "test_case_id" => test_case.id,
+              "passed" => true,
+              "output" => "Structured output",
+              "assertion_results" => [
+                %{"type" => "contains", "passed" => true, "value" => "Structured"}
+              ],
+              "cost_usd" => 0.001,
+              "latency_ms" => 250,
+              "retry_count" => 1,
+              "retried_at" => "2026-04-26T13:00:00Z"
+            }
+          ]
+        })
+
+      conn = get(conn, "/suites/runs/#{suite_run.id}/export")
+
+      assert [content_type] = get_resp_header(conn, "content-type")
+      assert content_type =~ "application/json"
+
+      assert get_resp_header(conn, "content-disposition") == [
+               "attachment; filename=\"suite-run-#{suite_run.id}.json\""
+             ]
+
+      payload = Jason.decode!(conn.resp_body)
+
+      assert payload["type"] == "suite_run"
+      assert payload["suite_run"]["id"] == suite_run.id
+      assert payload["suite_run"]["suite"]["id"] == suite.id
+      assert payload["suite_run"]["suite"]["name"] == "Export Suite"
+      assert payload["suite_run"]["provider"]["id"] == provider.id
+      assert payload["suite_run"]["provider"]["name"] == "Suite Provider"
+      assert payload["suite_run"]["summary"]["passed"] == 1
+      assert payload["suite_run"]["summary"]["failed"] == 0
+      assert payload["suite_run"]["summary"]["avg_cost_usd"] == 0.001
+
+      assert payload["suite_run"]["results"] == [
+               %{
+                 "assertion_results" => [
+                   %{"passed" => true, "type" => "contains", "value" => "Structured"}
+                 ],
+                 "cost_usd" => 0.001,
+                 "error" => nil,
+                 "input_tokens" => nil,
+                 "latency_ms" => 250,
+                 "output" => "Structured output",
+                 "output_tokens" => nil,
+                 "passed" => true,
+                 "retry_count" => 1,
+                 "retried_at" => "2026-04-26T13:00:00Z",
+                 "status" => "passed",
+                 "test_case_id" => test_case.id
+               }
+             ]
+    end
+  end
+end

--- a/test/aludel_web/export_controller_test.exs
+++ b/test/aludel_web/export_controller_test.exs
@@ -28,6 +28,9 @@ defmodule Aludel.Web.ExportControllerTest do
 
       assert [content_type] = get_resp_header(conn, "content-type")
       assert content_type =~ "application/json"
+      assert get_resp_header(conn, "cache-control") == ["no-store, max-age=0"]
+      assert get_resp_header(conn, "pragma") == ["no-cache"]
+      assert get_resp_header(conn, "expires") == ["0"]
 
       assert get_resp_header(conn, "content-disposition") == [
                "attachment; filename=\"run-result-#{result.id}.json\""
@@ -85,6 +88,9 @@ defmodule Aludel.Web.ExportControllerTest do
 
       assert [content_type] = get_resp_header(conn, "content-type")
       assert content_type =~ "application/json"
+      assert get_resp_header(conn, "cache-control") == ["no-store, max-age=0"]
+      assert get_resp_header(conn, "pragma") == ["no-cache"]
+      assert get_resp_header(conn, "expires") == ["0"]
 
       assert get_resp_header(conn, "content-disposition") == [
                "attachment; filename=\"suite-run-#{suite_run.id}.json\""

--- a/test/aludel_web/live/run_live/show_test.exs
+++ b/test/aludel_web/live/run_live/show_test.exs
@@ -206,6 +206,12 @@ defmodule Aludel.Web.RunLive.ShowTest do
 
       assert has_element?(view, "#run-result-output-#{result1.id}", "Hello from OpenAI")
       assert has_element?(view, "#copy-run-output-#{result1.id}", "Copy output")
+
+      assert has_element?(
+               view,
+               "#export-run-result-#{result1.id}[href='/runs/results/#{result1.id}/export']",
+               "Export JSON"
+             )
     end
 
     test "shows copy actions for failed errors", %{conn: conn} do

--- a/test/aludel_web/live/suite_live/show_test.exs
+++ b/test/aludel_web/live/suite_live/show_test.exs
@@ -702,6 +702,12 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
                "#copy-suite-result-#{suite_run.id}-#{test_case.id}",
                "Copy output"
              )
+
+      assert has_element?(
+               view,
+               "#export-suite-run-#{suite_run.id}[href='/suites/runs/#{suite_run.id}/export']",
+               "Export JSON"
+             )
     end
   end
 


### PR DESCRIPTION
## Motivation (required)

Aludel showed formatted run and suite results in the UI but had no raw export path. This change adds JSON downloads for individual run results and suite runs so results can be inspected offline and fed into external tooling without database access.

Closes #77.

## Test Plan (required)

`mix test test/aludel_web/export_controller_test.exs test/aludel_web/live/run_live/show_test.exs test/aludel_web/live/suite_live/show_test.exs`
- Passed: `48 tests, 0 failures`

`mix compile --warnings-as-errors`
- Passed

`mix precommit`
- Passed: `572 tests, 0 failures`

## Next Steps

GitHub CI should validate the new export endpoints and LiveView links on the full matrix.