### PR TITLE
chore: prepare v0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-05-02
+
+### Added
+- Raw JSON export for runs and suite runs, including assertion details and suite metadata
+- `json_deep_compare` assertions for scoring structured output matches with configurable thresholds
+
+### Changed
+- Prompt evolution and suite run summaries now track average structured-output scores
+- Run result handling now supports missing cost and latency metrics when providers omit them
+- Refined Hex-facing README branding and package presentation
+- Updated `llm_db` to 2026.4.6
+
 ## [0.2.0] - 2026-04-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Aludel depends on PostgreSQL-specific features, including `JSONB`, `percentile_d
 ```elixir
 def deps do
   [
-    {:aludel, "~> 0.1"}
+    {:aludel, "~> 0.2"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Aludel.MixProject do
   def project do
     [
       app: :aludel,
-      version: "0.2.0",
+      version: "0.2.1",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Motivation (required)

Prepare the `0.2.1` release from the changes already merged on `main` since `v0.2.0`.

This updates the package version, records the release notes for the net diff since `0.2.0`, and fixes the README dependency example so the documented install range matches the current `0.2` release line.

## Test Plan (required)

Commands run:

```bash
mix precommit
mix hex.publish --dry-run
```

Results:
- `mix precommit` passed
- `mix hex.publish --dry-run` built `aludel 0.2.1` successfully

## Next Steps

- Verify GitHub Actions are green for this release-prep branch
- Tag `v0.2.1` after the PR is approved and merged