### PR TITLE
feat: support embedded callback execution mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Aludel gives teams a clean way to evaluate prompt and model behavior without inv
 - Inspect output, latency, token usage, and cost side by side.
 - Version prompts and see how changes affect results over time.
 - Run evaluation suites with assertions and document attachments.
+- Route runs and suites through your app's real LLM workflow with callback execution.
 - Use it inside an existing Phoenix app or run it standalone.
 
 ## Why Aludel
@@ -26,6 +27,7 @@ Most teams evaluating LLM behavior end up with some combination of scripts, spre
 - **Provider comparison**: run the same input across models and vendors in one view.
 - **Prompt history**: keep prompt changes traceable instead of losing them in copy-pasted variants.
 - **Regression coverage**: turn important scenarios into repeatable suites with assertions.
+- **Embedded app callbacks**: evaluate your production-facing workflow without rebuilding it in the dashboard.
 - **Phoenix-native deployment**: mount it in your app or run it as a standalone dashboard.
 
 ## Structured Output Scoring
@@ -107,6 +109,71 @@ end
 
 Visit your configured path, for example `http://localhost:4000/dev/aludel`.
 
+### Execution modes
+
+Aludel supports two execution modes:
+
+- **Native** (default): Aludel renders the prompt template and calls the configured provider directly.
+- **App Callback**: your host app executes the real workflow and returns a normalized result back to Aludel.
+
+Use callback mode when your production behavior includes orchestration beyond a single prompt, such as retrieval, tool usage, routing, retries, or post-processing.
+
+Configure it in your embedded app:
+
+```elixir
+config :aludel,
+  execution_mode: :callback,
+  executor: MyApp.AludelExecutor
+```
+
+Example executor:
+
+```elixir
+defmodule MyApp.AludelExecutor do
+  @behaviour Aludel.Executor
+
+  @impl true
+  def run(%{
+        kind: kind,
+        variables: variables,
+        documents: documents,
+        provider: provider,
+        metadata: metadata
+      }) do
+    case MyApp.AI.reply(%{
+           question: variables["question"],
+           documents: documents,
+           provider: provider && provider.provider,
+           model: provider && provider.model,
+           context: %{source: :aludel, kind: kind, metadata: metadata}
+         }) do
+      {:ok, reply} ->
+        {:ok,
+         %{
+           output: reply.text,
+           input_tokens: Map.get(reply, :input_tokens),
+           output_tokens: Map.get(reply, :output_tokens),
+           latency_ms: Map.get(reply, :latency_ms),
+           cost_usd: Map.get(reply, :cost_usd),
+           metadata: %{trace_id: Map.get(reply, :trace_id)}
+         }}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+end
+```
+
+Success responses only require `output`. `input_tokens`, `output_tokens`, `latency_ms`, `cost_usd`, and `metadata` are optional.
+
+In callback mode, the existing run and suite UI stays the same:
+
+- provider selection still stays available
+- the run and suite screens show `Execution Mode`
+- missing token or cost metrics render as `N/A`
+- exports include callback metadata when present
+
 ### Standalone mode
 
 If you want to run Aludel by itself:
@@ -127,6 +194,21 @@ mix aludel.seed
 ```
 
 Visit `http://localhost:4000`.
+
+To smoke-test callback mode in the standalone app, configure a local executor module in `standalone/lib/aludel_dash.ex` or another module loaded by the standalone app, then add:
+
+```elixir
+config :aludel,
+  execution_mode: :callback,
+  executor: AludelDash.Executor
+```
+
+After restarting `mix phx.server`, create a prompt version and provider in the UI, then:
+
+1. Launch a run from `/runs/new?version=<prompt_version_id>`
+2. Run a suite from `/suites/<suite_id>`
+3. Confirm both screens show `Execution Mode`
+4. Confirm the outputs come from your executor and optional metrics render cleanly when omitted
 
 ## Provider support
 
@@ -150,6 +232,8 @@ config :aludel, :llm,
 ```
 
 Ollama runs locally and does not require an API key.
+
+Callback mode does not require Aludel to use those API keys directly, but provider selection still remains part of the current run and suite flows and is passed into the executor for host-app routing when needed.
 
 ## Document Storage
 

--- a/lib/aludel/evals.ex
+++ b/lib/aludel/evals.ex
@@ -14,14 +14,12 @@ defmodule Aludel.Evals do
     TestCaseDocument
   }
 
-  alias Aludel.LLM
+  alias Aludel.Execution
   alias Aludel.Prompts.PromptVersion
   alias Aludel.Providers.Provider
   alias Aludel.Storage
   alias Ecto.Association.NotLoaded
   alias Ecto.Changeset
-
-  @default_document_load_timeout_ms 120_000
 
   # Suite functions
 
@@ -435,67 +433,29 @@ defmodule Aludel.Evals do
 
   defp execute_test_case(test_case, version, provider) do
     test_case = ensure_documents_loaded(test_case)
-    rendered_prompt = render_template(version.template, test_case.variable_values)
 
-    case load_document_inputs(test_case.documents) do
-      {:ok, documents} ->
-        case LLM.call(provider, rendered_prompt, llm_call_opts(documents)) do
-          {:ok, result} ->
-            assertion_results = build_assertion_results(test_case.assertions, result.output)
-            passed = Enum.all?(assertion_results, & &1["passed"])
-            successful_test_case_result(test_case.id, result, passed, assertion_results)
+    request = %{
+      kind: :suite,
+      prompt_version: version,
+      variables: test_case.variable_values,
+      provider: provider,
+      documents: test_case.documents,
+      metadata: %{
+        suite_id: test_case.suite_id,
+        suite_run_id: nil,
+        test_case_id: test_case.id
+      }
+    }
 
-          {:error, reason} ->
-            failed_test_case_result(test_case.id, reason)
-        end
+    case Execution.execute(request) do
+      {:ok, result} ->
+        assertion_results = build_assertion_results(test_case.assertions, result.output)
+        passed = Enum.all?(assertion_results, & &1["passed"])
+        successful_test_case_result(test_case.id, result, passed, assertion_results)
 
       {:error, reason} ->
         failed_test_case_result(test_case.id, reason)
     end
-  end
-
-  defp llm_call_opts(documents) do
-    if documents != [], do: [documents: documents], else: []
-  end
-
-  defp load_document_inputs(documents) do
-    documents
-    |> Task.async_stream(&load_document_input/1,
-      timeout: document_load_timeout_ms(),
-      on_timeout: :kill_task
-    )
-    |> Enum.reduce_while({:ok, []}, fn
-      {:ok, {:ok, input}}, {:ok, loaded_documents} ->
-        {:cont, {:ok, [input | loaded_documents]}}
-
-      {:ok, {:error, reason}}, _acc ->
-        {:halt, {:error, reason}}
-
-      {:exit, reason}, _acc ->
-        {:halt, {:error, {:document_storage_error, :unknown_document, reason}}}
-    end)
-    |> case do
-      {:ok, loaded_documents} -> {:ok, Enum.reverse(loaded_documents)}
-      {:error, reason} -> {:error, reason}
-    end
-  end
-
-  defp load_document_input(document) do
-    case safe_storage_read(document) do
-      {:ok, data} ->
-        {:ok, %{data: data, content_type: document.content_type}}
-
-      {:error, reason} ->
-        {:error, {:document_storage_error, document.filename, reason}}
-    end
-  end
-
-  defp safe_storage_read(document) do
-    Storage.read(document)
-  rescue
-    error -> {:error, Exception.message(error)}
-  catch
-    :exit, reason -> {:error, reason}
   end
 
   defp build_assertion_results(assertions, output) do
@@ -509,8 +469,11 @@ defmodule Aludel.Evals do
       "score" => AssertionEvaluator.score_for_results(assertion_results),
       "output" => result.output,
       "assertion_results" => assertion_results,
+      "input_tokens" => result.input_tokens,
+      "output_tokens" => result.output_tokens,
       "cost_usd" => result.cost_usd,
-      "latency_ms" => result.latency_ms
+      "latency_ms" => result.latency_ms,
+      "metadata" => result.metadata
     }
   end
 
@@ -521,12 +484,16 @@ defmodule Aludel.Evals do
       "score" => nil,
       "output" => error_message(reason),
       "assertion_results" => [],
+      "input_tokens" => nil,
+      "output_tokens" => nil,
       "cost_usd" => nil,
-      "latency_ms" => nil
+      "latency_ms" => nil,
+      "metadata" => nil
     }
   end
 
   defp error_message(:missing_api_key), do: "Missing API key"
+  defp error_message(:executor_not_configured), do: "Callback executor not configured"
   defp error_message({:auth_error, msg}), do: "Authentication error: #{msg}"
 
   defp error_message({:rate_limit, retry_after}) do
@@ -539,6 +506,14 @@ defmodule Aludel.Evals do
 
   defp error_message({:document_storage_error, filename, reason}),
     do: "Failed to load document #{filename}: #{format_storage_reason(reason)}"
+
+  defp error_message({:invalid_executor, module}),
+    do: "Invalid callback executor: #{inspect(module)}"
+
+  defp error_message({:invalid_executor_response, detail}),
+    do: "Invalid callback response: #{inspect(detail)}"
+
+  defp error_message(reason), do: inspect(reason)
 
   defp fetch_suite_run_result(%SuiteRun{results: results}, test_case_id) do
     case Enum.find(results, &(&1["test_case_id"] == test_case_id)) do
@@ -621,16 +596,16 @@ defmodule Aludel.Evals do
   defp decimal_from_number(number) when is_float(number), do: Decimal.from_float(number)
   defp decimal_from_number(number) when is_integer(number), do: Decimal.new(number)
 
-  defp average_cost(%{successful: successful}) when successful < 1, do: nil
+  defp average_cost(%{cost_samples: cost_samples}) when cost_samples < 1, do: nil
 
-  defp average_cost(%{total_cost: total_cost, successful: successful}) do
-    Decimal.div(total_cost, successful)
+  defp average_cost(%{total_cost: total_cost, cost_samples: cost_samples}) do
+    Decimal.div(total_cost, cost_samples)
   end
 
-  defp average_latency(%{successful: successful}) when successful < 1, do: nil
+  defp average_latency(%{latency_samples: latency_samples}) when latency_samples < 1, do: nil
 
-  defp average_latency(%{total_latency: total_latency, successful: successful}) do
-    round(total_latency / successful)
+  defp average_latency(%{total_latency: total_latency, latency_samples: latency_samples}) do
+    round(total_latency / latency_samples)
   end
 
   defp average_score(%{scored: scored}) when scored < 1, do: nil
@@ -644,27 +619,41 @@ defmodule Aludel.Evals do
   defp empty_summary_metrics do
     %{
       total_cost: Decimal.new("0"),
+      cost_samples: 0,
       total_latency: 0,
-      successful: 0,
+      latency_samples: 0,
       total_score: Decimal.new("0"),
       scored: 0
     }
   end
 
-  defp accumulate_cost_and_latency(
-         acc,
-         %{"cost_usd" => cost, "latency_ms" => latency}
-       )
-       when is_number(cost) and is_number(latency) do
-    %{
-      acc
-      | total_cost: Decimal.add(acc.total_cost, decimal_from_number(cost)),
-        total_latency: acc.total_latency + round(latency),
-        successful: acc.successful + 1
-    }
+  defp accumulate_cost_and_latency(acc, %{"cost_usd" => cost, "latency_ms" => latency}) do
+    acc
+    |> maybe_accumulate_cost(cost)
+    |> maybe_accumulate_latency(latency)
   end
 
   defp accumulate_cost_and_latency(acc, _result), do: acc
+
+  defp maybe_accumulate_cost(acc, cost) when is_number(cost) do
+    %{
+      acc
+      | total_cost: Decimal.add(acc.total_cost, decimal_from_number(cost)),
+        cost_samples: acc.cost_samples + 1
+    }
+  end
+
+  defp maybe_accumulate_cost(acc, _cost), do: acc
+
+  defp maybe_accumulate_latency(acc, latency) when is_number(latency) do
+    %{
+      acc
+      | total_latency: acc.total_latency + round(latency),
+        latency_samples: acc.latency_samples + 1
+    }
+  end
+
+  defp maybe_accumulate_latency(acc, _latency), do: acc
 
   defp accumulate_score(acc, %{"score" => score}) when is_number(score) do
     %{
@@ -681,18 +670,6 @@ defmodule Aludel.Evals do
   end
 
   defp ensure_documents_loaded(%TestCase{} = test_case), do: test_case
-
-  defp render_template(template, variables) do
-    Enum.reduce(variables, template, fn {key, value}, acc ->
-      String.replace(acc, "{{#{key}}}", to_string(value))
-    end)
-  end
-
-  defp document_load_timeout_ms do
-    :aludel
-    |> Application.get_env(:evals, [])
-    |> Keyword.get(:document_load_timeout_ms, @default_document_load_timeout_ms)
-  end
 
   defp repo, do: Aludel.Repo.get()
 

--- a/lib/aludel/execution.ex
+++ b/lib/aludel/execution.ex
@@ -104,7 +104,7 @@ defmodule Aludel.Execution do
       not is_binary(output) ->
         {:error, {:invalid_executor_response, :missing_output}}
 
-      not is_nil(metadata) and not is_map(metadata) ->
+      invalid_metadata?(metadata) ->
         {:error, {:invalid_executor_response, :invalid_metadata}}
 
       true ->
@@ -156,6 +156,13 @@ defmodule Aludel.Execution do
       value when is_integer(value) -> value / 1
       _ -> nil
     end
+  end
+
+  defp invalid_metadata?(nil), do: false
+  defp invalid_metadata?(metadata) when not is_map(metadata), do: true
+
+  defp invalid_metadata?(metadata) do
+    match?({:error, _reason}, Jason.encode(metadata))
   end
 
   defp load_documents([]), do: {:ok, []}

--- a/lib/aludel/execution.ex
+++ b/lib/aludel/execution.ex
@@ -1,0 +1,221 @@
+defmodule Aludel.Execution do
+  @moduledoc """
+  Shared execution boundary for native provider calls and host-app callbacks.
+  """
+
+  alias Aludel.Evals.TestCaseDocument
+  alias Aludel.Executor
+  alias Aludel.LLM
+  alias Aludel.Prompts.PromptVersion
+  alias Aludel.Providers.Provider
+  alias Aludel.Storage
+  alias Ecto.Association.NotLoaded
+
+  @default_document_load_timeout_ms 30_000
+
+  @type request :: %{
+          kind: :run | :suite,
+          prompt_version: PromptVersion.t(),
+          variables: map(),
+          provider: Provider.t(),
+          documents: [TestCaseDocument.t()],
+          metadata: map()
+        }
+
+  @spec execute(request()) :: {:ok, Executor.result()} | {:error, term()}
+  def execute(
+        %{
+          kind: kind,
+          prompt_version: %PromptVersion{} = prompt_version,
+          variables: variables,
+          provider: %Provider{} = provider
+        } = request
+      )
+      when kind in [:run, :suite] and is_map(variables) do
+    documents = Map.get(request, :documents, [])
+    metadata = Map.get(request, :metadata, %{})
+
+    with {:ok, loaded_documents} <- load_documents(documents),
+         {:ok, execution_mode} <- Executor.configured_execution_mode() do
+      case execution_mode do
+        :callback ->
+          execute_callback(kind, prompt_version, variables, provider, loaded_documents, metadata)
+
+        _mode ->
+          execute_native(prompt_version, variables, provider, loaded_documents)
+      end
+    end
+  end
+
+  defp execute_native(prompt_version, variables, provider, documents) do
+    rendered_prompt = render_template(prompt_version.template, variables)
+
+    documents =
+      Enum.map(documents, fn document ->
+        %{data: document.data, content_type: document.content_type}
+      end)
+
+    opts = if documents == [], do: [], else: [documents: documents]
+
+    case LLM.call(provider, rendered_prompt, opts) do
+      {:ok, result} ->
+        {:ok,
+         %{
+           output: result.output,
+           input_tokens: result.input_tokens,
+           output_tokens: result.output_tokens,
+           latency_ms: result.latency_ms,
+           cost_usd: result.cost_usd,
+           metadata: nil
+         }}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp execute_callback(kind, prompt_version, variables, provider, documents, metadata) do
+    with {:ok, executor} <- Executor.configured_executor() do
+      input = callback_input(kind, prompt_version, variables, provider, documents, metadata)
+
+      safe_invoke_callback(executor, input)
+      |> normalize_callback_result()
+    end
+  end
+
+  defp safe_invoke_callback(executor, input) do
+    executor.run(input)
+  rescue
+    error ->
+      {:error, {:executor_crash, {:raise, error}}}
+  catch
+    :exit, reason ->
+      {:error, {:executor_crash, {:exit, reason}}}
+
+    kind, reason ->
+      {:error, {:executor_crash, {kind, reason}}}
+  end
+
+  defp normalize_callback_result({:ok, result}) when is_map(result) do
+    output = Map.get(result, :output)
+    metadata = Map.get(result, :metadata)
+
+    cond do
+      not is_binary(output) ->
+        {:error, {:invalid_executor_response, :missing_output}}
+
+      not is_nil(metadata) and not is_map(metadata) ->
+        {:error, {:invalid_executor_response, :invalid_metadata}}
+
+      true ->
+        {:ok,
+         %{
+           output: output,
+           input_tokens: optional_non_neg_integer(result, :input_tokens),
+           output_tokens: optional_non_neg_integer(result, :output_tokens),
+           latency_ms: optional_non_neg_integer(result, :latency_ms),
+           cost_usd: optional_float(result, :cost_usd),
+           metadata: metadata
+         }}
+    end
+  end
+
+  defp normalize_callback_result({:error, reason}), do: {:error, reason}
+  defp normalize_callback_result(other), do: {:error, {:invalid_executor_response, other}}
+
+  defp callback_input(kind, prompt_version, variables, provider, documents, metadata) do
+    %{
+      kind: kind,
+      prompt_version: %{
+        id: prompt_version.id,
+        template: prompt_version.template,
+        version: prompt_version.version
+      },
+      variables: variables,
+      documents: documents,
+      provider: %{
+        id: provider.id,
+        provider: provider.provider,
+        model: provider.model,
+        config: provider.config
+      },
+      metadata: metadata
+    }
+  end
+
+  defp optional_non_neg_integer(result, key) do
+    case Map.get(result, key) do
+      value when is_integer(value) and value >= 0 -> value
+      _ -> nil
+    end
+  end
+
+  defp optional_float(result, key) do
+    case Map.get(result, key) do
+      value when is_float(value) -> value
+      value when is_integer(value) -> value / 1
+      _ -> nil
+    end
+  end
+
+  defp load_documents([]), do: {:ok, []}
+
+  defp load_documents(documents) when is_list(documents) do
+    documents
+    |> Task.async_stream(&load_document/1,
+      timeout: document_load_timeout_ms(),
+      on_timeout: :kill_task
+    )
+    |> Enum.reduce_while({:ok, []}, fn
+      {:ok, {:ok, document}}, {:ok, loaded_documents} ->
+        {:cont, {:ok, [document | loaded_documents]}}
+
+      {:ok, {:error, reason}}, _acc ->
+        {:halt, {:error, reason}}
+
+      {:exit, reason}, _acc ->
+        {:halt, {:error, {:document_storage_error, :unknown_document, reason}}}
+    end)
+    |> case do
+      {:ok, loaded_documents} -> {:ok, Enum.reverse(loaded_documents)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp load_document(%TestCaseDocument{} = document) do
+    case safe_storage_read(document) do
+      {:ok, data} ->
+        {:ok,
+         %{
+           name: document.filename,
+           content_type: document.content_type,
+           data: data
+         }}
+
+      {:error, reason} ->
+        {:error, {:document_storage_error, document.filename, reason}}
+    end
+  end
+
+  defp load_document(%NotLoaded{}), do: {:error, :documents_not_loaded}
+
+  defp safe_storage_read(document) do
+    Storage.read(document)
+  rescue
+    error -> {:error, Exception.message(error)}
+  catch
+    :exit, reason -> {:error, reason}
+  end
+
+  defp render_template(template, variables) do
+    Enum.reduce(variables, template, fn {key, value}, acc ->
+      String.replace(acc, "{{#{key}}}", to_string(value))
+    end)
+  end
+
+  defp document_load_timeout_ms do
+    :aludel
+    |> Application.get_env(:evals, [])
+    |> Keyword.get(:document_load_timeout_ms, @default_document_load_timeout_ms)
+  end
+end

--- a/lib/aludel/executor.ex
+++ b/lib/aludel/executor.ex
@@ -1,0 +1,87 @@
+defmodule Aludel.Executor do
+  @moduledoc """
+  Behaviour and configuration helpers for execution mode dispatch.
+  """
+
+  @type prompt_version_input :: %{
+          id: binary(),
+          template: String.t(),
+          version: integer()
+        }
+
+  @type provider_input :: %{
+          id: binary(),
+          provider: atom(),
+          model: String.t(),
+          config: map() | nil
+        }
+
+  @type document_input :: %{
+          name: String.t(),
+          content_type: String.t(),
+          data: binary()
+        }
+
+  @type input :: %{
+          kind: :run | :suite,
+          prompt_version: prompt_version_input(),
+          variables: map(),
+          documents: [document_input()],
+          provider: provider_input() | nil,
+          metadata: map() | nil
+        }
+
+  @type result :: %{
+          output: String.t(),
+          input_tokens: non_neg_integer() | nil,
+          output_tokens: non_neg_integer() | nil,
+          latency_ms: non_neg_integer() | nil,
+          cost_usd: float() | nil,
+          metadata: map() | nil
+        }
+
+  @callback run(input()) :: {:ok, result()} | {:error, term()}
+
+  @spec execution_mode() :: term()
+  def execution_mode do
+    Application.get_env(:aludel, :execution_mode, :native)
+  end
+
+  @spec configured_execution_mode() ::
+          {:ok, :native | :callback} | {:error, {:invalid_execution_mode, term()}}
+  def configured_execution_mode do
+    case execution_mode() do
+      nil -> {:ok, :native}
+      :native -> {:ok, :native}
+      :callback -> {:ok, :callback}
+      mode -> {:error, {:invalid_execution_mode, mode}}
+    end
+  end
+
+  @spec execution_mode_label() :: String.t()
+  def execution_mode_label do
+    case configured_execution_mode() do
+      {:ok, :callback} -> "App Callback"
+      {:ok, :native} -> "Native"
+      {:error, _reason} -> "Invalid Configuration"
+    end
+  end
+
+  @spec configured_executor() :: {:ok, module()} | {:error, :executor_not_configured | term()}
+  def configured_executor do
+    case Application.get_env(:aludel, :executor) do
+      nil ->
+        {:error, :executor_not_configured}
+
+      module when is_atom(module) ->
+        if Code.ensure_loaded?(module) and function_exported?(module, :run, 1) do
+          {:ok, module}
+        else
+          {:error, {:invalid_executor, module}}
+        end
+
+      other ->
+        {:error, {:invalid_executor, other}}
+    end
+  end
+end

--- a/lib/aludel/runs/executor.ex
+++ b/lib/aludel/runs/executor.ex
@@ -7,7 +7,7 @@ defmodule Aludel.Runs.Executor do
 
   require Logger
 
-  alias Aludel.LLM
+  alias Aludel.Execution, as: AppExecution
   alias Aludel.Providers.Provider
   alias Aludel.PubSub
   alias Aludel.Runs.{Execution, Run, RunResult}
@@ -65,14 +65,11 @@ defmodule Aludel.Runs.Executor do
                  running_run.prompt_version.variables,
                  running_run.variable_values
                ),
-             rendered_prompt <-
-               render_template(running_run.prompt_version.template, running_run.variable_values),
              {:ok, pending_results} <- create_pending_results(running_run, providers),
              provider_outcomes <-
                execute_providers(
                  running_run,
-                 Enum.zip(providers, pending_results),
-                 rendered_prompt
+                 Enum.zip(providers, pending_results)
                ),
              failures = collect_failures(provider_outcomes),
              {:ok, updated_run} <- complete_run(running_run, length(providers), failures) do
@@ -99,26 +96,26 @@ defmodule Aludel.Runs.Executor do
 
   defp preload_prompt_version(%Run{} = run), do: run
 
-  defp execute_providers(run, provider_results, rendered_prompt) do
+  defp execute_providers(run, provider_results) do
     case execution_mode() do
       :sequential ->
         Enum.map(provider_results, fn {provider, run_result} ->
-          {provider, execute_provider(run.id, run_result, provider, rendered_prompt)}
+          {provider, execute_provider(run, run_result, provider)}
         end)
 
       _mode ->
-        stream_provider_executions(run, provider_results, rendered_prompt)
+        stream_provider_executions(run, provider_results)
     end
   end
 
-  defp stream_provider_executions(run, provider_results, rendered_prompt) do
+  defp stream_provider_executions(run, provider_results) do
     provider_results
     |> Enum.zip(
       Task.Supervisor.async_stream_nolink(
         @execution_supervisor,
         provider_results,
         fn {provider, run_result} ->
-          execute_provider(run.id, run_result, provider, rendered_prompt)
+          execute_provider(run, run_result, provider)
         end,
         max_concurrency: execution_max_concurrency(),
         timeout: execution_timeout_ms()
@@ -133,19 +130,32 @@ defmodule Aludel.Runs.Executor do
     end)
   end
 
-  defp execute_provider(run_id, run_result, provider, rendered_prompt) do
+  defp execute_provider(run, run_result, provider) do
+    request = %{
+      kind: :run,
+      prompt_version: run.prompt_version,
+      variables: run.variable_values,
+      provider: provider,
+      documents: [],
+      metadata: %{
+        run_id: run.id,
+        prompt_id: run.prompt_version.prompt_id,
+        prompt_version_id: run.prompt_version.id
+      }
+    }
+
     with {:ok, run_result} <- mark_run_result_running(run_result),
-         result <- LLM.call(provider, rendered_prompt) do
+         result <- AppExecution.execute(request) do
       case result do
         {:ok, llm_result} ->
-          complete_run_result(run_id, run_result, provider, llm_result)
+          complete_run_result(run.id, run_result, provider, llm_result)
 
         {:error, reason} ->
-          create_error_result(run_id, run_result, provider, reason)
+          create_error_result(run.id, run_result, provider, reason)
       end
     else
       {:error, changeset} ->
-        log_run_result_failure(run_id, provider.id, changeset)
+        log_run_result_failure(run.id, provider.id, changeset)
         {:error, provider_failure(provider, {:result_transition_failed, changeset.errors})}
     end
   end
@@ -157,6 +167,7 @@ defmodule Aludel.Runs.Executor do
            output_tokens: result.output_tokens,
            latency_ms: result.latency_ms,
            cost_usd: result.cost_usd,
+           metadata: result.metadata,
            status: :completed,
            completed_at: now(),
            error: nil
@@ -247,12 +258,6 @@ defmodule Aludel.Runs.Executor do
       _missing_variables ->
         {:error, {:missing_variables, missing_variables}}
     end
-  end
-
-  defp render_template(template, variable_values) do
-    Enum.reduce(variable_values, template, fn {key, value}, acc ->
-      String.replace(acc, "{{#{key}}}", to_string(value))
-    end)
   end
 
   defp create_run_result(attrs) do

--- a/lib/aludel/web/export_controller.ex
+++ b/lib/aludel/web/export_controller.ex
@@ -117,6 +117,7 @@ defmodule Aludel.Web.ExportController do
       output_tokens: result["output_tokens"],
       latency_ms: result["latency_ms"],
       cost_usd: result["cost_usd"],
+      metadata: result["metadata"],
       assertion_results: Map.get(result, "assertion_results", []),
       retry_count: result["retry_count"],
       retried_at: result["retried_at"]

--- a/lib/aludel/web/live/run_live/new.ex
+++ b/lib/aludel/web/live/run_live/new.ex
@@ -8,6 +8,7 @@ defmodule Aludel.Web.RunLive.New do
 
   use Aludel.Web, :live_view
 
+  alias Aludel.Executor
   alias Aludel.Prompts
   alias Aludel.Providers
   alias Aludel.Runs
@@ -54,6 +55,7 @@ defmodule Aludel.Web.RunLive.New do
      |> assign(:prompt, prompt_version.prompt)
      |> assign(:variables, prompt_version.variables)
      |> assign(:providers, providers)
+     |> assign(:execution_mode_label, Executor.execution_mode_label())
      |> assign(:form, to_form(changeset))
      |> assign(:variable_values, variable_values)}
   end

--- a/lib/aludel/web/live/run_live/new.html.heex
+++ b/lib/aludel/web/live/run_live/new.html.heex
@@ -18,6 +18,15 @@
           <h2 style="margin-bottom: 16px;">Run Configuration</h2>
 
           <div style="margin-bottom: 16px;">
+            <div style="font-size: 11px; font-weight: 500; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 4px;">
+              Execution Mode
+            </div>
+            <div id="run-execution-mode" style="font-size: 14px; color: var(--text-primary);">
+              {@execution_mode_label}
+            </div>
+          </div>
+
+          <div style="margin-bottom: 16px;">
             <label for="run_name">Run Name (optional)</label>
             <.input field={@form[:name]} type="text" placeholder="My comparison run" />
           </div>

--- a/lib/aludel/web/live/suite_live/show.ex
+++ b/lib/aludel/web/live/suite_live/show.ex
@@ -12,6 +12,7 @@ defmodule Aludel.Web.SuiteLive.Show do
   alias Aludel.Evals.AssertionParser
   alias Aludel.Evals.DocumentIngestion
   alias Aludel.Evals.TestCaseEditor
+  alias Aludel.Executor
   alias Aludel.Projects
   alias Aludel.Prompts
   alias Aludel.Providers
@@ -46,6 +47,7 @@ defmodule Aludel.Web.SuiteLive.Show do
       |> assign(:all_prompts, all_prompts)
       |> assign(:projects, projects)
       |> assign(:providers, providers)
+      |> assign(:execution_mode_label, Executor.execution_mode_label())
       |> assign(:suite_runs, suite_runs)
       |> assign(:running, false)
       |> assign(:run_task_monitor_ref, nil)

--- a/lib/aludel/web/live/suite_live/show.html.heex
+++ b/lib/aludel/web/live/suite_live/show.html.heex
@@ -75,6 +75,14 @@
       <% end %>
       <div style="margin-bottom: 24px;">
         <h3 style="font-size: 14px; font-weight: 600; margin-bottom: 12px;">Run Suite</h3>
+        <div style="margin-bottom: 12px;">
+          <div style="font-size: 11px; font-weight: 500; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 4px;">
+            Execution Mode
+          </div>
+          <div id="suite-execution-mode" style="font-size: 14px; color: var(--text-primary);">
+            {@execution_mode_label}
+          </div>
+        </div>
         <.form
           for={@run_suite_form}
           id="run-suite-form"

--- a/test/aludel/evals/suite_runner_test.exs
+++ b/test/aludel/evals/suite_runner_test.exs
@@ -1,7 +1,12 @@
 defmodule Aludel.Evals.SuiteRunnerTest do
   use Aludel.DataCase
 
+  import Mox
+
   alias Aludel.Evals.SuiteRunner
+
+  setup :set_mox_global
+  setup :verify_on_exit!
 
   describe "execute/3" do
     test "returns a persisted suite run" do
@@ -30,6 +35,127 @@ defmodule Aludel.Evals.SuiteRunnerTest do
 
       assert {:error, :provider_not_found} =
                SuiteRunner.execute(suite.id, version.id, Ecto.UUID.generate())
+    end
+
+    test "executes suites through the configured callback executor" do
+      original_mode = Application.get_env(:aludel, :execution_mode)
+      original_executor = Application.get_env(:aludel, :executor)
+
+      Application.put_env(:aludel, :execution_mode, :callback)
+      Application.put_env(:aludel, :executor, Aludel.ExecutorMock)
+
+      on_exit(fn ->
+        Application.put_env(:aludel, :execution_mode, original_mode)
+        Application.put_env(:aludel, :executor, original_executor)
+      end)
+
+      prompt = prompt_fixture_with_version(%{template: "Hello {{name}}"})
+      suite = suite_fixture(%{prompt_id: prompt.id})
+      provider = provider_fixture(%{provider: :openai, model: "callback-suite-model"})
+      version = List.first(prompt.versions)
+
+      test_case =
+        test_case_fixture(%{
+          suite_id: suite.id,
+          variable_values: %{"name" => "Alice"},
+          assertions: [%{"type" => "contains", "value" => "reset password"}]
+        })
+
+      _document =
+        test_case_document_fixture(%{
+          test_case_id: test_case.id,
+          filename: "policy.txt",
+          content_type: "text/plain",
+          data: "reset password instructions"
+        })
+
+      expect(Aludel.ExecutorMock, :run, fn input ->
+        assert input.kind == :suite
+        assert input.variables == %{"name" => "Alice"}
+        assert input.provider.id == provider.id
+        assert input.metadata.suite_id == suite.id
+        assert input.metadata.test_case_id == test_case.id
+        assert [%{name: "policy.txt", content_type: "text/plain", data: data}] = input.documents
+        assert data == "reset password instructions"
+
+        {:ok,
+         %{
+           output: "Use the reset password flow.",
+           input_tokens: nil,
+           output_tokens: 9,
+           latency_ms: 222,
+           cost_usd: nil,
+           metadata: %{"trace_id" => "suite-trace-1"}
+         }}
+      end)
+
+      assert {:ok, suite_run} = SuiteRunner.execute(suite.id, version.id, provider.id)
+
+      assert suite_run.suite_id == suite.id
+      assert suite_run.provider_id == provider.id
+      assert suite_run.passed == 1
+      assert suite_run.failed == 0
+      assert suite_run.avg_latency_ms == 222
+      assert suite_run.avg_cost_usd == nil
+
+      assert [
+               %{
+                 "output" => "Use the reset password flow.",
+                 "input_tokens" => nil,
+                 "output_tokens" => 9,
+                 "latency_ms" => 222,
+                 "cost_usd" => nil,
+                 "metadata" => %{"trace_id" => "suite-trace-1"}
+               }
+             ] = suite_run.results
+    end
+
+    test "stores failed suite results when the callback executor crashes" do
+      original_mode = Application.get_env(:aludel, :execution_mode)
+      original_executor = Application.get_env(:aludel, :executor)
+
+      Application.put_env(:aludel, :execution_mode, :callback)
+      Application.put_env(:aludel, :executor, Aludel.ExecutorMock)
+
+      on_exit(fn ->
+        Application.put_env(:aludel, :execution_mode, original_mode)
+        Application.put_env(:aludel, :executor, original_executor)
+      end)
+
+      prompt = prompt_fixture_with_version(%{template: "Hello {{name}}"})
+      suite = suite_fixture(%{prompt_id: prompt.id})
+      provider = provider_fixture(%{provider: :openai, model: "callback-suite-model"})
+      version = List.first(prompt.versions)
+
+      test_case =
+        test_case_fixture(%{
+          suite_id: suite.id,
+          variable_values: %{"name" => "Alice"},
+          assertions: [%{"type" => "contains", "value" => "reset password"}]
+        })
+
+      expect(Aludel.ExecutorMock, :run, fn _input ->
+        raise "boom"
+      end)
+
+      assert {:ok, suite_run} = SuiteRunner.execute(suite.id, version.id, provider.id)
+      assert suite_run.passed == 0
+      assert suite_run.failed == 1
+      assert suite_run.avg_latency_ms == nil
+      assert suite_run.avg_cost_usd == nil
+
+      assert [
+               %{
+                 "passed" => false,
+                 "output" => output,
+                 "latency_ms" => nil,
+                 "cost_usd" => nil
+               }
+             ] = suite_run.results
+
+      assert output =~ "executor_crash"
+      assert output =~ "boom"
+      assert test_case.id in Enum.map(suite_run.results, & &1["test_case_id"])
     end
   end
 

--- a/test/aludel/execution_test.exs
+++ b/test/aludel/execution_test.exs
@@ -134,6 +134,33 @@ defmodule Aludel.ExecutionTest do
              })
   end
 
+  test "rejects callback metadata that is not JSON-encodable" do
+    Application.put_env(:aludel, :execution_mode, :callback)
+    Application.put_env(:aludel, :executor, Aludel.ExecutorMock)
+
+    prompt = prompt_fixture()
+    {:ok, version} = Aludel.Prompts.create_prompt_version(prompt, "Hello {{name}}")
+    provider = provider_fixture()
+
+    expect(Aludel.ExecutorMock, :run, fn _input ->
+      {:ok,
+       %{
+         output: "Hello Alice",
+         metadata: %{pid: self()}
+       }}
+    end)
+
+    assert {:error, {:invalid_executor_response, :invalid_metadata}} =
+             Execution.execute(%{
+               kind: :run,
+               prompt_version: version,
+               variables: %{"name" => "Alice"},
+               provider: provider,
+               documents: [],
+               metadata: %{run_id: Ecto.UUID.generate()}
+             })
+  end
+
   test "loads suite documents and normalizes callback responses" do
     Application.put_env(:aludel, :execution_mode, :callback)
     Application.put_env(:aludel, :executor, Aludel.ExecutorMock)

--- a/test/aludel/execution_test.exs
+++ b/test/aludel/execution_test.exs
@@ -1,0 +1,195 @@
+defmodule Aludel.ExecutionTest do
+  use Aludel.DataCase
+
+  import Mox
+
+  alias Aludel.Execution
+  alias Aludel.Interfaces.HttpClientMock
+
+  setup :set_mox_global
+  setup :verify_on_exit!
+
+  setup do
+    original_mode = Application.get_env(:aludel, :execution_mode)
+    original_executor = Application.get_env(:aludel, :executor)
+
+    on_exit(fn ->
+      Application.put_env(:aludel, :execution_mode, original_mode)
+      Application.put_env(:aludel, :executor, original_executor)
+    end)
+
+    :ok
+  end
+
+  test "delegates native execution to the llm client" do
+    Application.put_env(:aludel, :execution_mode, :native)
+
+    prompt = prompt_fixture()
+    {:ok, version} = Aludel.Prompts.create_prompt_version(prompt, "Hello {{name}}")
+    provider = provider_fixture(%{provider: :openai, model: "gpt-4o-mini"})
+
+    expect(HttpClientMock, :request, fn "openai:gpt-4o-mini", "Hello Alice", opts ->
+      assert Keyword.get(opts, :api_key) == "sk-test-fake-openai-key-for-testing"
+      {:ok, %{content: "Hello Alice", input_tokens: 5, output_tokens: 7}}
+    end)
+
+    assert {:ok, result} =
+             Execution.execute(%{
+               kind: :run,
+               prompt_version: version,
+               variables: %{"name" => "Alice"},
+               provider: provider,
+               documents: [],
+               metadata: %{run_id: Ecto.UUID.generate()}
+             })
+
+    assert result.output == "Hello Alice"
+    assert result.input_tokens == 5
+    assert result.output_tokens == 7
+    assert is_integer(result.latency_ms)
+    assert is_float(result.cost_usd)
+    assert result.metadata == nil
+  end
+
+  test "returns a structured error when callback mode is missing an executor" do
+    Application.put_env(:aludel, :execution_mode, :callback)
+    Application.delete_env(:aludel, :executor)
+
+    prompt = prompt_fixture()
+    {:ok, version} = Aludel.Prompts.create_prompt_version(prompt, "Hello {{name}}")
+    provider = provider_fixture()
+
+    assert {:error, :executor_not_configured} =
+             Execution.execute(%{
+               kind: :run,
+               prompt_version: version,
+               variables: %{"name" => "Alice"},
+               provider: provider,
+               documents: [],
+               metadata: %{run_id: Ecto.UUID.generate()}
+             })
+  end
+
+  test "returns a structured error when execution mode config is invalid" do
+    Application.put_env(:aludel, :execution_mode, :calback)
+
+    prompt = prompt_fixture()
+    {:ok, version} = Aludel.Prompts.create_prompt_version(prompt, "Hello {{name}}")
+    provider = provider_fixture()
+
+    assert {:error, {:invalid_execution_mode, :calback}} =
+             Execution.execute(%{
+               kind: :run,
+               prompt_version: version,
+               variables: %{"name" => "Alice"},
+               provider: provider,
+               documents: [],
+               metadata: %{run_id: Ecto.UUID.generate()}
+             })
+  end
+
+  test "normalizes callback raises into structured errors" do
+    Application.put_env(:aludel, :execution_mode, :callback)
+    Application.put_env(:aludel, :executor, Aludel.ExecutorMock)
+
+    prompt = prompt_fixture()
+    {:ok, version} = Aludel.Prompts.create_prompt_version(prompt, "Hello {{name}}")
+    provider = provider_fixture()
+
+    expect(Aludel.ExecutorMock, :run, fn _input ->
+      raise "boom"
+    end)
+
+    assert {:error, {:executor_crash, {:raise, %RuntimeError{message: "boom"}}}} =
+             Execution.execute(%{
+               kind: :run,
+               prompt_version: version,
+               variables: %{"name" => "Alice"},
+               provider: provider,
+               documents: [],
+               metadata: %{run_id: Ecto.UUID.generate()}
+             })
+  end
+
+  test "normalizes callback exits into structured errors" do
+    Application.put_env(:aludel, :execution_mode, :callback)
+    Application.put_env(:aludel, :executor, Aludel.ExecutorMock)
+
+    prompt = prompt_fixture()
+    {:ok, version} = Aludel.Prompts.create_prompt_version(prompt, "Hello {{name}}")
+    provider = provider_fixture()
+
+    expect(Aludel.ExecutorMock, :run, fn _input ->
+      exit(:boom)
+    end)
+
+    assert {:error, {:executor_crash, {:exit, :boom}}} =
+             Execution.execute(%{
+               kind: :run,
+               prompt_version: version,
+               variables: %{"name" => "Alice"},
+               provider: provider,
+               documents: [],
+               metadata: %{run_id: Ecto.UUID.generate()}
+             })
+  end
+
+  test "loads suite documents and normalizes callback responses" do
+    Application.put_env(:aludel, :execution_mode, :callback)
+    Application.put_env(:aludel, :executor, Aludel.ExecutorMock)
+
+    prompt = prompt_fixture()
+    {:ok, version} = Aludel.Prompts.create_prompt_version(prompt, "Ignored {{name}}")
+    provider = provider_fixture(%{provider: :openai, model: "gpt-4.1"})
+    suite = suite_fixture(%{prompt_id: prompt.id})
+    test_case = test_case_fixture(%{suite_id: suite.id, variable_values: %{"name" => "Alice"}})
+
+    _document =
+      test_case_document_fixture(%{
+        test_case_id: test_case.id,
+        filename: "policy.txt",
+        content_type: "text/plain",
+        data: "reset password instructions"
+      })
+
+    expect(Aludel.ExecutorMock, :run, fn input ->
+      assert input.kind == :suite
+      assert input.variables == %{"name" => "Alice"}
+      assert input.prompt_version.id == version.id
+      assert input.provider.id == provider.id
+      assert input.provider.provider == :openai
+      assert input.provider.model == "gpt-4.1"
+      assert input.metadata.suite_id == suite.id
+      assert input.metadata.test_case_id == test_case.id
+      assert [%{name: "policy.txt", content_type: "text/plain", data: data}] = input.documents
+      assert data == "reset password instructions"
+
+      {:ok,
+       %{
+         output: "Use the reset password page.",
+         input_tokens: nil,
+         output_tokens: 11,
+         latency_ms: 1234,
+         cost_usd: nil,
+         metadata: %{"trace_id" => "trace-123"}
+       }}
+    end)
+
+    assert {:ok, result} =
+             Execution.execute(%{
+               kind: :suite,
+               prompt_version: version,
+               variables: test_case.variable_values,
+               provider: provider,
+               documents: Aludel.Repo.get().preload(test_case, :documents).documents,
+               metadata: %{suite_id: suite.id, test_case_id: test_case.id}
+             })
+
+    assert result.output == "Use the reset password page."
+    assert result.input_tokens == nil
+    assert result.output_tokens == 11
+    assert result.latency_ms == 1234
+    assert result.cost_usd == nil
+    assert result.metadata == %{"trace_id" => "trace-123"}
+  end
+end

--- a/test/aludel/runs/executor_test.exs
+++ b/test/aludel/runs/executor_test.exs
@@ -166,6 +166,80 @@ defmodule Aludel.Runs.ExecutorTest do
       assert result.error =~ "task_exit"
       assert result.error =~ "boom"
     end
+
+    test "persists callback results with optional metrics and metadata", %{run: run} do
+      original_mode = Application.get_env(:aludel, :execution_mode)
+      original_executor = Application.get_env(:aludel, :executor)
+      provider = provider_fixture(%{name: "Callback Provider", model: "callback-model"})
+
+      Application.put_env(:aludel, :execution_mode, :callback)
+      Application.put_env(:aludel, :executor, Aludel.ExecutorMock)
+
+      on_exit(fn ->
+        Application.put_env(:aludel, :execution_mode, original_mode)
+        Application.put_env(:aludel, :executor, original_executor)
+      end)
+
+      expect(Aludel.ExecutorMock, :run, fn input ->
+        assert input.kind == :run
+        assert input.variables == %{"user" => "Alice"}
+        assert input.documents == []
+        assert input.provider.id == provider.id
+        assert input.provider.model == "callback-model"
+        assert input.metadata.run_id == run.id
+
+        {:ok,
+         %{
+           output: "Hello Alice from callback",
+           latency_ms: 321,
+           metadata: %{"trace_id" => "run-trace-1"}
+         }}
+      end)
+
+      assert {:ok, %Execution{} = execution} = Executor.execute(run, [provider])
+
+      assert execution.status == :ok
+      assert execution.run.status == :completed
+
+      assert [result] = execution.provider_results
+      assert result.status == :completed
+      assert result.output == "Hello Alice from callback"
+      assert result.input_tokens == nil
+      assert result.output_tokens == nil
+      assert result.latency_ms == 321
+      assert result.cost_usd == nil
+      assert result.metadata == %{"trace_id" => "run-trace-1"}
+    end
+
+    test "persists callback crashes as provider errors", %{run: run} do
+      original_mode = Application.get_env(:aludel, :execution_mode)
+      original_executor = Application.get_env(:aludel, :executor)
+      provider = provider_fixture(%{name: "Crashy Callback Provider"})
+
+      Application.put_env(:aludel, :execution_mode, :callback)
+      Application.put_env(:aludel, :executor, Aludel.ExecutorMock)
+
+      on_exit(fn ->
+        Application.put_env(:aludel, :execution_mode, original_mode)
+        Application.put_env(:aludel, :executor, original_executor)
+      end)
+
+      expect(Aludel.ExecutorMock, :run, fn _input ->
+        raise "boom"
+      end)
+
+      assert {:ok, %Execution{} = execution} = Executor.execute(run, [provider])
+      assert execution.status == :error
+      assert execution.run.status == :failed
+
+      assert [%{reason: {:executor_crash, {:raise, %RuntimeError{message: "boom"}}}}] =
+               execution.failures
+
+      assert [result] = execution.provider_results
+      assert result.status == :error
+      assert result.error =~ "executor_crash"
+      assert result.error =~ "boom"
+    end
   end
 
   describe "launch/2" do

--- a/test/aludel_web/export_controller_test.exs
+++ b/test/aludel_web/export_controller_test.exs
@@ -75,6 +75,8 @@ defmodule Aludel.Web.ExportControllerTest do
               "passed" => true,
               "score" => 75.0,
               "output" => "Structured output",
+              "input_tokens" => 14,
+              "output_tokens" => 7,
               "assertion_results" => [
                 %{
                   "type" => "json_deep_compare",
@@ -102,6 +104,7 @@ defmodule Aludel.Web.ExportControllerTest do
               ],
               "cost_usd" => 0.001,
               "latency_ms" => 250,
+              "metadata" => %{"trace_id" => "suite-export-trace"},
               "retry_count" => 1,
               "retried_at" => "2026-04-26T13:00:00Z"
             }
@@ -162,10 +165,11 @@ defmodule Aludel.Web.ExportControllerTest do
                  ],
                  "cost_usd" => 0.001,
                  "error" => nil,
-                 "input_tokens" => nil,
+                 "input_tokens" => 14,
                  "latency_ms" => 250,
+                 "metadata" => %{"trace_id" => "suite-export-trace"},
                  "output" => "Structured output",
-                 "output_tokens" => nil,
+                 "output_tokens" => 7,
                  "passed" => true,
                  "score" => 75.0,
                  "retry_count" => 1,

--- a/test/aludel_web/live/run_live/new_test.exs
+++ b/test/aludel_web/live/run_live/new_test.exs
@@ -42,6 +42,24 @@ defmodule Aludel.Web.RunLive.NewTest do
       assert html =~ "v#{version.version}"
     end
 
+    test "shows the app callback execution mode label when configured", %{
+      conn: conn,
+      version: version
+    } do
+      original_mode = Application.get_env(:aludel, :execution_mode)
+
+      Application.put_env(:aludel, :execution_mode, :callback)
+
+      on_exit(fn ->
+        Application.put_env(:aludel, :execution_mode, original_mode)
+      end)
+
+      {:ok, _view, html} = live(conn, "/runs/new?version=#{version.id}")
+
+      assert html =~ "Execution Mode"
+      assert html =~ "App Callback"
+    end
+
     test "displays form inputs for each variable", %{
       conn: conn,
       version: version

--- a/test/aludel_web/live/suite_live/show_test.exs
+++ b/test/aludel_web/live/suite_live/show_test.exs
@@ -185,6 +185,23 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
   end
 
   describe "version and provider selection" do
+    test "shows the app callback execution mode label when configured", %{conn: conn} do
+      original_mode = Application.get_env(:aludel, :execution_mode)
+
+      Application.put_env(:aludel, :execution_mode, :callback)
+
+      on_exit(fn ->
+        Application.put_env(:aludel, :execution_mode, original_mode)
+      end)
+
+      suite = suite_fixture()
+
+      {:ok, _view, html} = live(conn, "/suites/#{suite.id}")
+
+      assert html =~ "Execution Mode"
+      assert html =~ "App Callback"
+    end
+
     test "shows version and provider selectors", %{conn: conn} do
       prompt = prompt_fixture_with_version()
       suite = suite_fixture(%{prompt_id: prompt.id})

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -82,4 +82,6 @@ Mox.defmock(Aludel.Interfaces.StorageMock,
   for: Aludel.Interfaces.Storage.Behaviour
 )
 
+Mox.defmock(Aludel.ExecutorMock, for: Aludel.Executor)
+
 ExUnit.start()


### PR DESCRIPTION
## Motivation (required)

Aludel only supported native prompt rendering and provider execution, which forced embedded apps to duplicate their production orchestration inside the dashboard.

This change adds an embedded callback execution mode so host apps can route runs and suites through their real application pipeline while Aludel continues to own inputs, assertions, persistence, history, exports, and UI.

## Test Plan (required)

Automated verification:

```bash
mix precommit
```

Focused regression coverage:

```bash
mix test \
  test/aludel/execution_test.exs \
  test/aludel/runs/executor_test.exs \
  test/aludel/evals/suite_runner_test.exs \
  test/aludel_web/live/run_live/new_test.exs \
  test/aludel_web/live/suite_live/show_test.exs \
  test/aludel_web/export_controller_test.exs
```

Standalone app smoke test:

1. In `standalone/`, configure callback mode and point `:aludel` at an executor module that implements `Aludel.Executor`.
2. Start the standalone app as usual.
3. Create a prompt version and provider in the UI.
4. Run a prompt from the run screen and confirm the result is produced by the callback executor.
5. Create a suite, run it from the suite screen, and confirm assertions evaluate against the callback output.
6. Verify the run and suite screens show the `Execution Mode` label and that optional metrics render cleanly when omitted.

One-off embedded smoke run performed in the standalone app context:

- `run_status=completed`
- `run_output=standalone callback ok for run`
- `suite_passed=1`
- `suite_failed=0`
- `suite_output=standalone callback ok for suite`

## Next Steps

This keeps provider selection and the existing run/suite UI intact for v1 callback mode. A future follow-up can decide whether callback mode should support provider-optional or providerless execution flows.
