### PR TITLE
chore(release): prepare v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-05-17
+
+### Added
+- Embedded callback execution mode for running Aludel evaluations through a host application's real LLM workflow
+- Suite creation now supports attaching test case documents before the suite is saved
+
+### Changed
+- Run and suite screens now expose execution mode context and preserve callback metadata in exports
+- Updated `req_llm` to 1.11.0, `llm_db` to 2026.4.8, Phoenix to 1.8.7, Ecto to 3.13.6, Postgrex to 0.22.1, and ExAws to 2.7.0
+
+### Fixed
+- Ollama providers no longer send an authentication marker when no API key is configured
+- Suite creation and editing now surface test case persistence failures instead of silently dropping failed test cases
+
 ## [0.2.1] - 2026-05-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Callback mode does not require Aludel to use those API keys directly, but provid
 
 ## Document Storage
 
-Uploaded test case documents go through `Aludel.Storage`.
+Uploaded test case documents go through `Aludel.Storage`. Documents can be attached while creating new suite test cases or while editing existing test cases.
 
 - Development uses the local filesystem adapter from `config/dev.exs`.
 - Production uses `config/runtime.exs` and requires `ALUDEL_STORAGE_BACKEND`.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Aludel.MixProject do
   def project do
     [
       app: :aludel,
-      version: "0.2.1",
+      version: "0.3.0",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Motivation (required)

Prepare the 0.3.0 release after the embedded callback execution mode and suite creation document upload work landed on main. This bumps the package version, adds release notes, and keeps the README document storage note aligned with current upload behavior.

```mermaid
flowchart LR
  A[Release prep PR] --> B[main]
  B --> C[v0.3.0 tag]
  C --> D[GitHub release]
  C --> E[Hex package aludel 0.3.0]
```

## Test Plan (required)

- `mix format`
- `mix compile --warnings-as-errors`
- `mix precommit` - Credo clean, Sobelow completed, ExUnit finished with 613 tests and 0 failures
- `mix hex.build` - built aludel 0.3.0 with checksum `58c871e7c878b61fd77dad5f79439fa53171c33539383b285006ce2ee7d1d2d1`

## Next Steps

After this PR merges to main, create the `v0.3.0` tag, publish the GitHub release, and publish aludel 0.3.0 to Hex.