### PR TITLE
feat: add prompt evolution metrics export

### DIFF
--- a/lib/aludel/prompts/evolution/export.ex
+++ b/lib/aludel/prompts/evolution/export.ex
@@ -1,0 +1,126 @@
+defmodule Aludel.Prompts.Evolution.Export do
+  @moduledoc """
+  Export serialization for prompt evolution metrics.
+  """
+
+  alias Aludel.Prompts.Prompt
+  alias Decimal
+
+  @doc """
+  Serializes evolution metrics to JSON format.
+
+  Returns a map with prompt metadata and evolution metrics including
+  version history, performance data, and provider breakdowns.
+  """
+  @spec to_json(Prompt.t(), [map()]) :: map()
+  def to_json(prompt, metrics) do
+    %{
+      type: "prompt_evolution",
+      exported_at: iso8601(DateTime.utc_now()),
+      prompt: %{
+        id: prompt.id,
+        name: prompt.name,
+        description: prompt.description,
+        tags: prompt.tags
+      },
+      metrics:
+        Enum.map(metrics, fn metric ->
+          %{
+            version_id: metric.version_id,
+            version_number: metric.version_number,
+            created_at: iso8601(metric.created_at),
+            total_runs: metric.total_runs,
+            avg_pass_rate: metric.avg_pass_rate,
+            avg_score: decimal_to_float(metric.avg_score),
+            avg_cost_usd: decimal_to_float(metric.avg_cost_usd),
+            avg_latency_ms: metric.avg_latency_ms,
+            provider_breakdown:
+              Enum.map(metric.provider_breakdown, fn breakdown ->
+                %{
+                  provider_id: breakdown.provider_id,
+                  provider_name: breakdown.provider_name,
+                  runs: breakdown.runs,
+                  avg_pass_rate: breakdown.avg_pass_rate,
+                  avg_score: decimal_to_float(breakdown.avg_score),
+                  avg_cost_usd: decimal_to_float(breakdown.avg_cost_usd),
+                  avg_latency_ms: breakdown.avg_latency_ms
+                }
+              end)
+          }
+        end)
+    }
+  end
+
+  @doc """
+  Serializes evolution metrics to CSV format.
+
+  Returns a CSV string with headers and one row per version-provider combination.
+  """
+  @spec to_csv([map()]) :: String.t()
+  def to_csv(metrics) do
+    header =
+      "version,created_at,total_runs,avg_pass_rate,avg_score,avg_cost_usd,avg_latency_ms,provider_name,provider_runs,provider_pass_rate,provider_score,provider_cost_usd,provider_latency_ms\n"
+
+    rows =
+      metrics
+      |> Enum.flat_map(fn metric ->
+        if Enum.empty?(metric.provider_breakdown) do
+          [
+            csv_row([
+              metric.version_number,
+              format_datetime(metric.created_at),
+              metric.total_runs,
+              format_number(metric.avg_pass_rate),
+              format_number(decimal_to_float(metric.avg_score)),
+              format_number(decimal_to_float(metric.avg_cost_usd)),
+              format_number(metric.avg_latency_ms),
+              "",
+              "",
+              "",
+              "",
+              "",
+              ""
+            ])
+          ]
+        else
+          Enum.map(metric.provider_breakdown, fn breakdown ->
+            csv_row([
+              metric.version_number,
+              format_datetime(metric.created_at),
+              metric.total_runs,
+              format_number(metric.avg_pass_rate),
+              format_number(decimal_to_float(metric.avg_score)),
+              format_number(decimal_to_float(metric.avg_cost_usd)),
+              format_number(metric.avg_latency_ms),
+              breakdown.provider_name,
+              breakdown.runs,
+              format_number(breakdown.avg_pass_rate),
+              format_number(decimal_to_float(breakdown.avg_score)),
+              format_number(decimal_to_float(breakdown.avg_cost_usd)),
+              format_number(breakdown.avg_latency_ms)
+            ])
+          end)
+        end
+      end)
+      |> Enum.join("\n")
+
+    header <> rows
+  end
+
+  defp csv_row(values) when is_list(values) do
+    Enum.map_join(values, ",", &to_string/1)
+  end
+
+  defp format_number(nil), do: ""
+  defp format_number(num) when is_float(num), do: :erlang.float_to_binary(num, decimals: 4)
+  defp format_number(num), do: num
+
+  defp format_datetime(nil), do: ""
+  defp format_datetime(%DateTime{} = datetime), do: DateTime.to_iso8601(datetime)
+
+  defp decimal_to_float(nil), do: nil
+  defp decimal_to_float(%Decimal{} = decimal), do: Decimal.to_float(decimal)
+
+  defp iso8601(nil), do: nil
+  defp iso8601(%DateTime{} = datetime), do: DateTime.to_iso8601(datetime)
+end

--- a/lib/aludel/web/export_controller.ex
+++ b/lib/aludel/web/export_controller.ex
@@ -28,6 +28,13 @@ defmodule Aludel.Web.ExportController do
     send_json_download(conn, payload, "suite-run-#{id}.json")
   end
 
+  @doc """
+  Exports prompt evolution metrics in JSON or CSV format.
+
+  Returns a timestamped download with evolution metrics including version history,
+  performance data, and provider-specific breakdowns.
+  """
+  @spec evolution(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def evolution(conn, %{"id" => id, "format" => format}) do
     prompt = Prompts.get_prompt!(id)
     metrics = Prompts.get_evolution_metrics(id)
@@ -267,6 +274,7 @@ defmodule Aludel.Web.ExportController do
   end
 
   defp format_number(nil), do: ""
+  defp format_number(num) when is_float(num), do: :erlang.float_to_binary(num, decimals: 4)
   defp format_number(num), do: num
 
   defp format_datetime(nil), do: ""

--- a/lib/aludel/web/export_controller.ex
+++ b/lib/aludel/web/export_controller.ex
@@ -6,6 +6,7 @@ defmodule Aludel.Web.ExportController do
   import Plug.Conn
 
   alias Aludel.Evals
+  alias Aludel.Prompts
   alias Aludel.Runs
   alias Decimal
 
@@ -25,6 +26,38 @@ defmodule Aludel.Web.ExportController do
       |> serialize_suite_run_export()
 
     send_json_download(conn, payload, "suite-run-#{id}.json")
+  end
+
+  def evolution(conn, %{"id" => id, "format" => format}) do
+    prompt = Prompts.get_prompt!(id)
+    metrics = Prompts.get_evolution_metrics(id)
+
+    case format do
+      "json" ->
+        payload = serialize_evolution_json(prompt, metrics)
+        timestamp = DateTime.utc_now() |> DateTime.to_unix()
+        filename = "prompt-evolution-#{timestamp}.json"
+        send_json_download(conn, payload, filename)
+
+      "csv" ->
+        csv_content = serialize_evolution_csv(metrics)
+        timestamp = DateTime.utc_now() |> DateTime.to_unix()
+        filename = "prompt-evolution-#{timestamp}.csv"
+
+        conn
+        |> put_resp_header("cache-control", "no-store, max-age=0")
+        |> put_resp_header("pragma", "no-cache")
+        |> put_resp_header("expires", "0")
+        |> send_download({:binary, csv_content},
+          filename: filename,
+          content_type: "text/csv"
+        )
+
+      _ ->
+        conn
+        |> put_status(400)
+        |> send_resp(400, "Unsupported format. Use 'json' or 'csv'.")
+    end
   end
 
   defp send_json_download(conn, payload, filename) do
@@ -140,6 +173,104 @@ defmodule Aludel.Web.ExportController do
   end
 
   defp suite_result_error(_result), do: nil
+
+  defp serialize_evolution_json(prompt, metrics) do
+    %{
+      type: "prompt_evolution",
+      exported_at: iso8601(DateTime.utc_now()),
+      prompt: %{
+        id: prompt.id,
+        name: prompt.name,
+        description: prompt.description,
+        tags: prompt.tags
+      },
+      metrics:
+        Enum.map(metrics, fn metric ->
+          %{
+            version_id: metric.version_id,
+            version_number: metric.version_number,
+            created_at: iso8601(metric.created_at),
+            total_runs: metric.total_runs,
+            avg_pass_rate: metric.avg_pass_rate,
+            avg_score: decimal_to_float(metric.avg_score),
+            avg_cost_usd: decimal_to_float(metric.avg_cost_usd),
+            avg_latency_ms: metric.avg_latency_ms,
+            provider_breakdown:
+              Enum.map(metric.provider_breakdown, fn breakdown ->
+                %{
+                  provider_id: breakdown.provider_id,
+                  provider_name: breakdown.provider_name,
+                  runs: breakdown.runs,
+                  avg_pass_rate: breakdown.avg_pass_rate,
+                  avg_score: decimal_to_float(breakdown.avg_score),
+                  avg_cost_usd: decimal_to_float(breakdown.avg_cost_usd),
+                  avg_latency_ms: breakdown.avg_latency_ms
+                }
+              end)
+          }
+        end)
+    }
+  end
+
+  defp serialize_evolution_csv(metrics) do
+    header =
+      "version,created_at,total_runs,avg_pass_rate,avg_score,avg_cost_usd,avg_latency_ms,provider_name,provider_runs,provider_pass_rate,provider_score,provider_cost_usd,provider_latency_ms\n"
+
+    rows =
+      metrics
+      |> Enum.flat_map(fn metric ->
+        if Enum.empty?(metric.provider_breakdown) do
+          [
+            csv_row([
+              metric.version_number,
+              format_datetime(metric.created_at),
+              metric.total_runs,
+              format_number(metric.avg_pass_rate),
+              format_number(decimal_to_float(metric.avg_score)),
+              format_number(decimal_to_float(metric.avg_cost_usd)),
+              format_number(metric.avg_latency_ms),
+              "",
+              "",
+              "",
+              "",
+              "",
+              ""
+            ])
+          ]
+        else
+          Enum.map(metric.provider_breakdown, fn breakdown ->
+            csv_row([
+              metric.version_number,
+              format_datetime(metric.created_at),
+              metric.total_runs,
+              format_number(metric.avg_pass_rate),
+              format_number(decimal_to_float(metric.avg_score)),
+              format_number(decimal_to_float(metric.avg_cost_usd)),
+              format_number(metric.avg_latency_ms),
+              breakdown.provider_name,
+              breakdown.runs,
+              format_number(breakdown.avg_pass_rate),
+              format_number(decimal_to_float(breakdown.avg_score)),
+              format_number(decimal_to_float(breakdown.avg_cost_usd)),
+              format_number(breakdown.avg_latency_ms)
+            ])
+          end)
+        end
+      end)
+      |> Enum.join("\n")
+
+    header <> rows
+  end
+
+  defp csv_row(values) when is_list(values) do
+    Enum.map_join(values, ",", &to_string/1)
+  end
+
+  defp format_number(nil), do: ""
+  defp format_number(num), do: num
+
+  defp format_datetime(nil), do: ""
+  defp format_datetime(%DateTime{} = datetime), do: DateTime.to_iso8601(datetime)
 
   defp decimal_to_float(nil), do: nil
   defp decimal_to_float(%Decimal{} = decimal), do: Decimal.to_float(decimal)

--- a/lib/aludel/web/export_controller.ex
+++ b/lib/aludel/web/export_controller.ex
@@ -7,6 +7,7 @@ defmodule Aludel.Web.ExportController do
 
   alias Aludel.Evals
   alias Aludel.Prompts
+  alias Aludel.Prompts.Evolution.Export, as: EvolutionExport
   alias Aludel.Runs
   alias Decimal
 
@@ -41,13 +42,13 @@ defmodule Aludel.Web.ExportController do
 
     case format do
       "json" ->
-        payload = serialize_evolution_json(prompt, metrics)
+        payload = EvolutionExport.to_json(prompt, metrics)
         timestamp = DateTime.utc_now() |> DateTime.to_unix()
         filename = "prompt-evolution-#{timestamp}.json"
         send_json_download(conn, payload, filename)
 
       "csv" ->
-        csv_content = serialize_evolution_csv(metrics)
+        csv_content = EvolutionExport.to_csv(metrics)
         timestamp = DateTime.utc_now() |> DateTime.to_unix()
         filename = "prompt-evolution-#{timestamp}.csv"
 
@@ -180,105 +181,6 @@ defmodule Aludel.Web.ExportController do
   end
 
   defp suite_result_error(_result), do: nil
-
-  defp serialize_evolution_json(prompt, metrics) do
-    %{
-      type: "prompt_evolution",
-      exported_at: iso8601(DateTime.utc_now()),
-      prompt: %{
-        id: prompt.id,
-        name: prompt.name,
-        description: prompt.description,
-        tags: prompt.tags
-      },
-      metrics:
-        Enum.map(metrics, fn metric ->
-          %{
-            version_id: metric.version_id,
-            version_number: metric.version_number,
-            created_at: iso8601(metric.created_at),
-            total_runs: metric.total_runs,
-            avg_pass_rate: metric.avg_pass_rate,
-            avg_score: decimal_to_float(metric.avg_score),
-            avg_cost_usd: decimal_to_float(metric.avg_cost_usd),
-            avg_latency_ms: metric.avg_latency_ms,
-            provider_breakdown:
-              Enum.map(metric.provider_breakdown, fn breakdown ->
-                %{
-                  provider_id: breakdown.provider_id,
-                  provider_name: breakdown.provider_name,
-                  runs: breakdown.runs,
-                  avg_pass_rate: breakdown.avg_pass_rate,
-                  avg_score: decimal_to_float(breakdown.avg_score),
-                  avg_cost_usd: decimal_to_float(breakdown.avg_cost_usd),
-                  avg_latency_ms: breakdown.avg_latency_ms
-                }
-              end)
-          }
-        end)
-    }
-  end
-
-  defp serialize_evolution_csv(metrics) do
-    header =
-      "version,created_at,total_runs,avg_pass_rate,avg_score,avg_cost_usd,avg_latency_ms,provider_name,provider_runs,provider_pass_rate,provider_score,provider_cost_usd,provider_latency_ms\n"
-
-    rows =
-      metrics
-      |> Enum.flat_map(fn metric ->
-        if Enum.empty?(metric.provider_breakdown) do
-          [
-            csv_row([
-              metric.version_number,
-              format_datetime(metric.created_at),
-              metric.total_runs,
-              format_number(metric.avg_pass_rate),
-              format_number(decimal_to_float(metric.avg_score)),
-              format_number(decimal_to_float(metric.avg_cost_usd)),
-              format_number(metric.avg_latency_ms),
-              "",
-              "",
-              "",
-              "",
-              "",
-              ""
-            ])
-          ]
-        else
-          Enum.map(metric.provider_breakdown, fn breakdown ->
-            csv_row([
-              metric.version_number,
-              format_datetime(metric.created_at),
-              metric.total_runs,
-              format_number(metric.avg_pass_rate),
-              format_number(decimal_to_float(metric.avg_score)),
-              format_number(decimal_to_float(metric.avg_cost_usd)),
-              format_number(metric.avg_latency_ms),
-              breakdown.provider_name,
-              breakdown.runs,
-              format_number(breakdown.avg_pass_rate),
-              format_number(decimal_to_float(breakdown.avg_score)),
-              format_number(decimal_to_float(breakdown.avg_cost_usd)),
-              format_number(breakdown.avg_latency_ms)
-            ])
-          end)
-        end
-      end)
-      |> Enum.join("\n")
-
-    header <> rows
-  end
-
-  defp csv_row(values) when is_list(values) do
-    Enum.map_join(values, ",", &to_string/1)
-  end
-
-  defp format_number(nil), do: ""
-  defp format_number(num) when is_float(num), do: :erlang.float_to_binary(num, decimals: 4)
-  defp format_number(num), do: num
-
-  defp format_datetime(nil), do: ""
-  defp format_datetime(%DateTime{} = datetime), do: DateTime.to_iso8601(datetime)
 
   defp decimal_to_float(nil), do: nil
   defp decimal_to_float(%Decimal{} = decimal), do: Decimal.to_float(decimal)

--- a/lib/aludel/web/live/prompt_live/evolution.ex
+++ b/lib/aludel/web/live/prompt_live/evolution.ex
@@ -11,7 +11,12 @@ defmodule Aludel.Web.PromptLive.Evolution do
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, view_mode: :overall, show_breakdown_sidebar: false)}
+    {:ok,
+     assign(socket,
+       view_mode: :overall,
+       show_breakdown_sidebar: false,
+       show_export_dropdown: false
+     )}
   end
 
   @impl Phoenix.LiveView
@@ -59,5 +64,13 @@ defmodule Aludel.Web.PromptLive.Evolution do
 
   def handle_event("toggle_breakdown_sidebar", _params, socket) do
     {:noreply, assign(socket, :show_breakdown_sidebar, !socket.assigns.show_breakdown_sidebar)}
+  end
+
+  def handle_event("toggle_export_dropdown", _params, socket) do
+    {:noreply, assign(socket, :show_export_dropdown, !socket.assigns.show_export_dropdown)}
+  end
+
+  def handle_event("close_export_dropdown", _params, socket) do
+    {:noreply, assign(socket, :show_export_dropdown, false)}
   end
 end

--- a/lib/aludel/web/live/prompt_live/evolution.html.heex
+++ b/lib/aludel/web/live/prompt_live/evolution.html.heex
@@ -11,9 +11,51 @@
             {@prompt.description}
           </p>
         </div>
-        <.link navigate={aludel_path("prompts/#{@prompt.id}/edit")} class="button-primary">
-          <.icon name="hero-pencil" class="size-4" /> Edit Prompt
-        </.link>
+        <div style="display: flex; gap: 12px;">
+          <%= if not Enum.empty?(@metrics) do %>
+            <div style="position: relative;">
+              <button
+                type="button"
+                phx-click="toggle_export_dropdown"
+                class="button-secondary"
+                style="display: flex; align-items: center; gap: 6px;"
+              >
+                <.icon name="hero-arrow-down-tray" class="size-4" /> Export
+                <.icon name="hero-chevron-down" class="size-3" />
+              </button>
+              <%= if @show_export_dropdown do %>
+                <div
+                  style="position: absolute; top: 100%; right: 0; margin-top: 8px; background: var(--bg-primary); border: 1px solid var(--border); border-radius: 8px; box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1); min-width: 160px; z-index: 50;"
+                  phx-click-away="close_export_dropdown"
+                >
+                  <a
+                    href={aludel_path("prompts/#{@prompt.id}/evolution/export/json")}
+                    download
+                    style="display: flex; align-items: center; gap: 8px; padding: 12px 16px; text-decoration: none; color: var(--text-primary); transition: background-color 0.15s;"
+                    onmouseover="this.style.backgroundColor='var(--bg-secondary)'"
+                    onmouseout="this.style.backgroundColor='transparent'"
+                  >
+                    <.icon name="hero-document-text" class="size-4" />
+                    <span style="font-size: 14px; font-weight: 500;">Export as JSON</span>
+                  </a>
+                  <a
+                    href={aludel_path("prompts/#{@prompt.id}/evolution/export/csv")}
+                    download
+                    style="display: flex; align-items: center; gap: 8px; padding: 12px 16px; text-decoration: none; color: var(--text-primary); border-top: 1px solid var(--border); transition: background-color 0.15s;"
+                    onmouseover="this.style.backgroundColor='var(--bg-secondary)'"
+                    onmouseout="this.style.backgroundColor='transparent'"
+                  >
+                    <.icon name="hero-table-cells" class="size-4" />
+                    <span style="font-size: 14px; font-weight: 500;">Export as CSV</span>
+                  </a>
+                </div>
+              <% end %>
+            </div>
+          <% end %>
+          <.link navigate={aludel_path("prompts/#{@prompt.id}/edit")} class="button-primary">
+            <.icon name="hero-pencil" class="size-4" /> Edit Prompt
+          </.link>
+        </div>
       </div>
       <div :if={@prompt.tags != []} style="display: flex; gap: 8px;">
         <span :for={tag <- @prompt.tags} class="tag">

--- a/lib/aludel/web/router.ex
+++ b/lib/aludel/web/router.ex
@@ -64,6 +64,7 @@ defmodule Aludel.Web.Router do
           live "/prompts/new", Aludel.Web.PromptLive.New, :new, route_opts
           live "/prompts/:id/edit", Aludel.Web.PromptLive.New, :edit, route_opts
           live "/prompts/:id/evolution", Aludel.Web.PromptLive.Evolution, :show, route_opts
+          get "/prompts/:id/evolution/export/:format", Aludel.Web.ExportController, :evolution
           live "/prompts/:id", Aludel.Web.PromptLive.Show, :show, route_opts
 
           live "/runs/new", Aludel.Web.RunLive.New, :new, route_opts

--- a/priv/static/app.css
+++ b/priv/static/app.css
@@ -1398,6 +1398,17 @@
       box-shadow: 0 2px 3px -1px color-mix(in oklab, currentColor calc(var(--depth) * 100%), #0000);
     }
   }
+  .hero-arrow-down-tray {
+    --hero-arrow-down-tray: url('data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20fill%3D%22none%22%20viewBox%3D%220%200%2024%2024%22%20stroke-width%3D%221.5%22%20stroke%3D%22currentColor%22%20aria-hidden%3D%22true%22%20data-slot%3D%22icon%22%3E%20%20%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M3%2016.5v2.25A2.25%202.25%200%200%200%205.25%2021h13.5A2.25%202.25%200%200%200%2021%2018.75V16.5M16.5%2012%2012%2016.5m0%200L7.5%2012m4.5%204.5V3%22%2F%3E%3C%2Fsvg%3E');
+    -webkit-mask: var(--hero-arrow-down-tray);
+    mask: var(--hero-arrow-down-tray);
+    mask-repeat: no-repeat;
+    background-color: currentColor;
+    vertical-align: middle;
+    display: inline-block;
+    width: 1.5rem;
+    height: 1.5rem;
+  }
   .hero-arrow-path {
     --hero-arrow-path: url('data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20fill%3D%22none%22%20viewBox%3D%220%200%2024%2024%22%20stroke-width%3D%221.5%22%20stroke%3D%22currentColor%22%20aria-hidden%3D%22true%22%20data-slot%3D%22icon%22%3E%20%20%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M16.023%209.348h4.992v-.001M2.985%2019.644v-4.992m0%200h4.992m-4.993%200%203.181%203.183a8.25%208.25%200%200%200%2013.803-3.7M4.031%209.865a8.25%208.25%200%200%201%2013.803-3.7l3.181%203.182m0-4.991v4.99%22%2F%3E%3C%2Fsvg%3E');
     -webkit-mask: var(--hero-arrow-path);
@@ -1743,6 +1754,17 @@
     --hero-sun: url('data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20fill%3D%22none%22%20viewBox%3D%220%200%2024%2024%22%20stroke-width%3D%221.5%22%20stroke%3D%22currentColor%22%20aria-hidden%3D%22true%22%20data-slot%3D%22icon%22%3E%20%20%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M12%203v2.25m6.364.386-1.591%201.591M21%2012h-2.25m-.386%206.364-1.591-1.591M12%2018.75V21m-4.773-4.227-1.591%201.591M5.25%2012H3m4.227-4.773L5.636%205.636M15.75%2012a3.75%203.75%200%201%201-7.5%200%203.75%203.75%200%200%201%207.5%200Z%22%2F%3E%3C%2Fsvg%3E');
     -webkit-mask: var(--hero-sun);
     mask: var(--hero-sun);
+    mask-repeat: no-repeat;
+    background-color: currentColor;
+    vertical-align: middle;
+    display: inline-block;
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+  .hero-table-cells {
+    --hero-table-cells: url('data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20fill%3D%22none%22%20viewBox%3D%220%200%2024%2024%22%20stroke-width%3D%221.5%22%20stroke%3D%22currentColor%22%20aria-hidden%3D%22true%22%20data-slot%3D%22icon%22%3E%20%20%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M3.375%2019.5h17.25m-17.25%200a1.125%201.125%200%200%201-1.125-1.125M3.375%2019.5h7.5c.621%200%201.125-.504%201.125-1.125m-9.75%200V5.625m0%2012.75v-1.5c0-.621.504-1.125%201.125-1.125m18.375%202.625V5.625m0%2012.75c0%20.621-.504%201.125-1.125%201.125m1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125m0%203.75h-7.5A1.125%201.125%200%200%201%2012%2018.375m9.75-12.75c0-.621-.504-1.125-1.125-1.125H3.375c-.621%200-1.125.504-1.125%201.125m19.5%200v1.5c0%20.621-.504%201.125-1.125%201.125M2.25%205.625v1.5c0%20.621.504%201.125%201.125%201.125m0%200h17.25m-17.25%200h7.5c.621%200%201.125.504%201.125%201.125M3.375%208.25c-.621%200-1.125.504-1.125%201.125v1.5c0%20.621.504%201.125%201.125%201.125m17.25-3.75h-7.5c-.621%200-1.125.504-1.125%201.125m8.625-1.125c.621%200%201.125.504%201.125%201.125v1.5c0%20.621-.504%201.125-1.125%201.125m-17.25%200h7.5m-7.5%200c-.621%200-1.125.504-1.125%201.125v1.5c0%20.621.504%201.125%201.125%201.125M12%2010.875v-1.5m0%201.5c0%20.621-.504%201.125-1.125%201.125M12%2010.875c0%20.621.504%201.125%201.125%201.125m-2.25%200c.621%200%201.125.504%201.125%201.125M13.125%2012h7.5m-7.5%200c-.621%200-1.125.504-1.125%201.125M20.625%2012c.621%200%201.125.504%201.125%201.125v1.5c0%20.621-.504%201.125-1.125%201.125m-17.25%200h7.5M12%2014.625v-1.5m0%201.5c0%20.621-.504%201.125-1.125%201.125M12%2014.625c0%20.621.504%201.125%201.125%201.125m-2.25%200c.621%200%201.125.504%201.125%201.125m0%201.5v-1.5m0%200c0-.621.504-1.125%201.125-1.125m0%200h7.5%22%2F%3E%3C%2Fsvg%3E');
+    -webkit-mask: var(--hero-table-cells);
+    mask: var(--hero-table-cells);
     mask-repeat: no-repeat;
     background-color: currentColor;
     vertical-align: middle;

--- a/test/aludel/prompts/evolution/export_test.exs
+++ b/test/aludel/prompts/evolution/export_test.exs
@@ -1,0 +1,280 @@
+defmodule Aludel.Prompts.Evolution.ExportTest do
+  use Aludel.DataCase, async: true
+
+  alias Aludel.Prompts.Evolution.Export
+  alias Aludel.Prompts.Prompt
+  alias Decimal
+
+  describe "to_json/2" do
+    test "serializes prompt and metrics to JSON structure" do
+      prompt = %Prompt{
+        id: "prompt-123",
+        name: "Test Prompt",
+        description: "A test prompt",
+        tags: ["test", "example"]
+      }
+
+      created_at = ~U[2026-01-15 10:00:00Z]
+
+      metrics = [
+        %{
+          version_id: "v1",
+          version_number: 1,
+          created_at: created_at,
+          total_runs: 10,
+          avg_pass_rate: 85.5,
+          avg_score: Decimal.new("75.25"),
+          avg_cost_usd: Decimal.new("0.0025"),
+          avg_latency_ms: 250,
+          provider_breakdown: [
+            %{
+              provider_id: "p1",
+              provider_name: "Provider A",
+              runs: 5,
+              avg_pass_rate: 90.0,
+              avg_score: Decimal.new("80.0"),
+              avg_cost_usd: Decimal.new("0.0030"),
+              avg_latency_ms: 200
+            }
+          ]
+        }
+      ]
+
+      result = Export.to_json(prompt, metrics)
+
+      assert result.type == "prompt_evolution"
+      assert result.prompt.id == "prompt-123"
+      assert result.prompt.name == "Test Prompt"
+      assert result.prompt.description == "A test prompt"
+      assert result.prompt.tags == ["test", "example"]
+
+      assert length(result.metrics) == 1
+      [metric] = result.metrics
+
+      assert metric.version_id == "v1"
+      assert metric.version_number == 1
+      assert metric.created_at == "2026-01-15T10:00:00Z"
+      assert metric.total_runs == 10
+      assert metric.avg_pass_rate == 85.5
+      assert metric.avg_score == 75.25
+      assert metric.avg_cost_usd == 0.0025
+      assert metric.avg_latency_ms == 250
+
+      assert length(metric.provider_breakdown) == 1
+      [breakdown] = metric.provider_breakdown
+
+      assert breakdown.provider_id == "p1"
+      assert breakdown.provider_name == "Provider A"
+      assert breakdown.runs == 5
+      assert breakdown.avg_pass_rate == 90.0
+      assert breakdown.avg_score == 80.0
+      assert breakdown.avg_cost_usd == 0.003
+      assert breakdown.avg_latency_ms == 200
+    end
+
+    test "handles nil decimal values" do
+      prompt = %Prompt{
+        id: "prompt-123",
+        name: "Test Prompt",
+        description: nil,
+        tags: []
+      }
+
+      metrics = [
+        %{
+          version_id: "v1",
+          version_number: 1,
+          created_at: ~U[2026-01-15 10:00:00Z],
+          total_runs: 5,
+          avg_pass_rate: 100.0,
+          avg_score: nil,
+          avg_cost_usd: nil,
+          avg_latency_ms: nil,
+          provider_breakdown: []
+        }
+      ]
+
+      result = Export.to_json(prompt, metrics)
+
+      [metric] = result.metrics
+      assert metric.avg_score == nil
+      assert metric.avg_cost_usd == nil
+      assert metric.avg_latency_ms == nil
+    end
+
+    test "includes exported_at timestamp" do
+      prompt = %Prompt{
+        id: "prompt-123",
+        name: "Test Prompt",
+        description: nil,
+        tags: []
+      }
+
+      result = Export.to_json(prompt, [])
+
+      assert is_binary(result.exported_at)
+      assert String.contains?(result.exported_at, "T")
+      assert String.contains?(result.exported_at, "Z")
+    end
+  end
+
+  describe "to_csv/1" do
+    test "generates CSV with proper headers" do
+      metrics = []
+
+      csv = Export.to_csv(metrics)
+
+      [header | _] = String.split(csv, "\n", trim: true)
+
+      assert header ==
+               "version,created_at,total_runs,avg_pass_rate,avg_score,avg_cost_usd,avg_latency_ms,provider_name,provider_runs,provider_pass_rate,provider_score,provider_cost_usd,provider_latency_ms"
+    end
+
+    test "formats floats with 4 decimal places" do
+      metrics = [
+        %{
+          version_number: 1,
+          created_at: ~U[2026-01-15 10:00:00Z],
+          total_runs: 10,
+          avg_pass_rate: 85.5,
+          avg_score: Decimal.new("75.2567"),
+          avg_cost_usd: Decimal.new("0.002"),
+          avg_latency_ms: 250,
+          provider_breakdown: [
+            %{
+              provider_name: "Provider A",
+              runs: 5,
+              avg_pass_rate: 90.125,
+              avg_score: Decimal.new("80.999"),
+              avg_cost_usd: Decimal.new("0.0030"),
+              avg_latency_ms: 200
+            }
+          ]
+        }
+      ]
+
+      csv = Export.to_csv(metrics)
+      [_header, row] = String.split(csv, "\n", trim: true)
+
+      assert row =~ "85.5000"
+      assert row =~ "75.2567"
+      assert row =~ "0.0020"
+      assert row =~ "90.1250"
+      assert row =~ "80.9990"
+      assert row =~ "0.0030"
+    end
+
+    test "generates one row per provider when breakdown exists" do
+      metrics = [
+        %{
+          version_number: 1,
+          created_at: ~U[2026-01-15 10:00:00Z],
+          total_runs: 15,
+          avg_pass_rate: 88.0,
+          avg_score: Decimal.new("82.0"),
+          avg_cost_usd: Decimal.new("0.0025"),
+          avg_latency_ms: 300,
+          provider_breakdown: [
+            %{
+              provider_name: "Provider A",
+              runs: 10,
+              avg_pass_rate: 90.0,
+              avg_score: Decimal.new("85.0"),
+              avg_cost_usd: Decimal.new("0.0020"),
+              avg_latency_ms: 250
+            },
+            %{
+              provider_name: "Provider B",
+              runs: 5,
+              avg_pass_rate: 80.0,
+              avg_score: Decimal.new("75.0"),
+              avg_cost_usd: Decimal.new("0.0035"),
+              avg_latency_ms: 400
+            }
+          ]
+        }
+      ]
+
+      csv = Export.to_csv(metrics)
+      rows = String.split(csv, "\n", trim: true)
+
+      assert length(rows) == 3
+      [_header, row1, row2] = rows
+
+      assert row1 =~ "Provider A"
+      assert row2 =~ "Provider B"
+    end
+
+    test "generates single row with empty provider fields when no breakdown" do
+      metrics = [
+        %{
+          version_number: 2,
+          created_at: ~U[2026-01-16 10:00:00Z],
+          total_runs: 5,
+          avg_pass_rate: 100.0,
+          avg_score: Decimal.new("95.0"),
+          avg_cost_usd: Decimal.new("0.0015"),
+          avg_latency_ms: 150,
+          provider_breakdown: []
+        }
+      ]
+
+      csv = Export.to_csv(metrics)
+      [_header, row] = String.split(csv, "\n", trim: true)
+
+      # Version and aggregate metrics should be present
+      assert row =~ "2"
+      assert row =~ "2026-01-16T10:00:00Z"
+      assert row =~ "5"
+      assert row =~ "100.0000"
+      assert row =~ "95.0000"
+      assert row =~ "0.0015"
+      assert row =~ "150"
+
+      # Provider fields should be empty (ending commas)
+      assert String.ends_with?(row, ",,,,,,")
+    end
+
+    test "handles nil values in metrics" do
+      metrics = [
+        %{
+          version_number: 1,
+          created_at: nil,
+          total_runs: 0,
+          avg_pass_rate: nil,
+          avg_score: nil,
+          avg_cost_usd: nil,
+          avg_latency_ms: nil,
+          provider_breakdown: []
+        }
+      ]
+
+      csv = Export.to_csv(metrics)
+      [_header, row] = String.split(csv, "\n", trim: true)
+
+      # Should have version and zeros, but empty strings for nil values
+      assert row =~ "1"
+      assert row =~ "0"
+    end
+
+    test "formats datetime as ISO8601" do
+      metrics = [
+        %{
+          version_number: 1,
+          created_at: ~U[2026-05-28 14:30:45Z],
+          total_runs: 1,
+          avg_pass_rate: 100.0,
+          avg_score: Decimal.new("100.0"),
+          avg_cost_usd: Decimal.new("0.001"),
+          avg_latency_ms: 100,
+          provider_breakdown: []
+        }
+      ]
+
+      csv = Export.to_csv(metrics)
+      [_header, row] = String.split(csv, "\n", trim: true)
+
+      assert row =~ "2026-05-28T14:30:45Z"
+    end
+  end
+end

--- a/test/aludel_web/export_controller_test.exs
+++ b/test/aludel_web/export_controller_test.exs
@@ -180,4 +180,117 @@ defmodule Aludel.Web.ExportControllerTest do
              ]
     end
   end
+
+  describe "GET /prompts/:id/evolution/export/:format" do
+    test "downloads evolution metrics as JSON", %{conn: conn} do
+      prompt = prompt_fixture_with_version(%{name: "Evolution Export Prompt"})
+      prompt = Aludel.Prompts.get_prompt_with_versions!(prompt.id)
+      version = hd(prompt.versions)
+      suite = suite_fixture(%{name: "Evolution Suite", prompt_id: prompt.id})
+      provider = provider_fixture(%{name: "Evolution Provider"})
+
+      _suite_run =
+        suite_run_fixture(%{
+          suite_id: suite.id,
+          prompt_version_id: version.id,
+          provider_id: provider.id,
+          passed: 5,
+          failed: 1,
+          avg_cost_usd: Decimal.new("0.0015"),
+          avg_latency_ms: 300,
+          avg_score: Decimal.new("80.5")
+        })
+
+      conn = get(conn, "/prompts/#{prompt.id}/evolution/export/json")
+
+      assert [content_type] = get_resp_header(conn, "content-type")
+      assert content_type =~ "application/json"
+      assert get_resp_header(conn, "cache-control") == ["no-store, max-age=0"]
+      assert get_resp_header(conn, "pragma") == ["no-cache"]
+      assert get_resp_header(conn, "expires") == ["0"]
+
+      assert [disposition] = get_resp_header(conn, "content-disposition")
+      assert disposition =~ ~r/attachment; filename="prompt-evolution-.*\.json"/
+
+      payload = Jason.decode!(conn.resp_body)
+
+      assert payload["type"] == "prompt_evolution"
+      assert payload["prompt"]["id"] == prompt.id
+      assert payload["prompt"]["name"] == "Evolution Export Prompt"
+      assert is_list(payload["metrics"])
+
+      [metric] = payload["metrics"]
+      assert metric["version_number"] == version.version
+      assert metric["total_runs"] == 1
+      assert metric["avg_pass_rate"] == 83.33
+      assert metric["avg_score"] == 80.5
+      assert metric["avg_cost_usd"] == 0.0015
+      assert metric["avg_latency_ms"] == 300
+
+      [provider_breakdown] = metric["provider_breakdown"]
+      assert provider_breakdown["provider_name"] == "Evolution Provider"
+      assert provider_breakdown["runs"] == 1
+    end
+
+    test "downloads evolution metrics as CSV", %{conn: conn} do
+      prompt = prompt_fixture_with_version(%{name: "CSV Export Prompt"})
+      prompt = Aludel.Prompts.get_prompt_with_versions!(prompt.id)
+      version = hd(prompt.versions)
+      suite = suite_fixture(%{name: "CSV Suite", prompt_id: prompt.id})
+      provider = provider_fixture(%{name: "CSV Provider"})
+
+      _suite_run =
+        suite_run_fixture(%{
+          suite_id: suite.id,
+          prompt_version_id: version.id,
+          provider_id: provider.id,
+          passed: 10,
+          failed: 2,
+          avg_cost_usd: Decimal.new("0.0020"),
+          avg_latency_ms: 400,
+          avg_score: Decimal.new("90.0")
+        })
+
+      conn = get(conn, "/prompts/#{prompt.id}/evolution/export/csv")
+
+      assert [content_type] = get_resp_header(conn, "content-type")
+      assert content_type =~ "text/csv"
+      assert get_resp_header(conn, "cache-control") == ["no-store, max-age=0"]
+      assert get_resp_header(conn, "pragma") == ["no-cache"]
+      assert get_resp_header(conn, "expires") == ["0"]
+
+      assert [disposition] = get_resp_header(conn, "content-disposition")
+      assert disposition =~ ~r/attachment; filename="prompt-evolution-.*\.csv"/
+
+      csv_content = conn.resp_body
+      [header | rows] = String.split(csv_content, "\n", trim: true)
+
+      assert header ==
+               "version,created_at,total_runs,avg_pass_rate,avg_score,avg_cost_usd,avg_latency_ms,provider_name,provider_runs,provider_pass_rate,provider_score,provider_cost_usd,provider_latency_ms"
+
+      assert length(rows) == 1
+      row = hd(rows)
+      assert row =~ "#{version.version}"
+      assert row =~ "83.33"
+      assert row =~ "90.0"
+      assert row =~ "0.0020"
+      assert row =~ "400"
+      assert row =~ "CSV Provider"
+    end
+
+    test "returns 404 when prompt not found", %{conn: conn} do
+      assert_error_sent 404, fn ->
+        get(conn, "/prompts/00000000-0000-0000-0000-000000000000/evolution/export/json")
+      end
+    end
+
+    test "returns error for unsupported format", %{conn: conn} do
+      prompt = prompt_fixture_with_version(%{name: "Format Test Prompt"})
+
+      conn = get(conn, "/prompts/#{prompt.id}/evolution/export/xml")
+
+      assert conn.status == 400
+      assert conn.resp_body =~ "Unsupported format"
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Add CSV and JSON export for prompt evolution metrics
- Export includes version history, performance metrics, and provider breakdown
- Add export dropdown UI to evolution screen

## Implementation Details

**Backend:**
- New route: `GET /prompts/:id/evolution/export/:format` (supports `json` and `csv`)
- Reuses existing `Prompts.get_evolution_metrics/1` data
- JSON format includes full prompt metadata and nested provider breakdowns
- CSV format provides tabular data with one row per version-provider combination

**Frontend:**
- Export dropdown button with format selection (JSON/CSV)
- Only visible when metrics exist
- Uses LiveView events for dropdown state management

**Tests:**
- Comprehensive test coverage for both export formats
- Validates export structure, content, and error cases

## Test Plan

- [x] Code passes `mix format`
- [x] Code passes `credo` with no issues
- [x] Code passes `dialyzer`
- [x] Code passes `sobelow`
- [ ] Manually test JSON export downloads correctly
- [ ] Manually test CSV export downloads correctly
- [ ] Verify CSV opens correctly in Excel/Google Sheets
- [ ] Verify export button only appears when metrics exist
- [ ] Verify dropdown closes on click-away

## Mermaid Diagram

```mermaid
sequenceDiagram
    participant User
    participant Browser
    participant LiveView
    participant Router
    participant Controller
    participant Prompts

    User->>Browser: Click Export dropdown
    Browser->>LiveView: toggle_export_dropdown event
    LiveView->>Browser: Show dropdown menu
    
    User->>Browser: Click "Export as JSON/CSV"
    Browser->>Router: GET /prompts/:id/evolution/export/:format
    Router->>Controller: evolution(conn, params)
    Controller->>Prompts: get_evolution_metrics(id)
    Prompts-->>Controller: metrics data
    Controller->>Controller: serialize to JSON/CSV
    Controller-->>Browser: File download (with cache headers)
    Browser->>User: Save file
```

Closes #76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Users can now download prompt evolution metrics in JSON and CSV formats
* A new export dropdown menu appears on the prompt evolution page with download options
* Exported data includes version information, run counts, pass rates, scores, costs, and latency per provider

## Tests
* Added test coverage for the new export functionality and error scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ccarvalho-eng/aludel/pull/143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->