### PR TITLE
feat(prompts): add version diff view

### DIFF
--- a/lib/aludel/web/live/prompt_live/show.ex
+++ b/lib/aludel/web/live/prompt_live/show.ex
@@ -21,11 +21,60 @@ defmodule Aludel.Web.PromptLive.Show do
      socket
      |> assign(:page_title, prompt.name)
      |> assign(:prompt, prompt)
-     |> assign(:selected_version_id, latest_version && latest_version.id)}
+     |> select_version(prompt, latest_version && latest_version.id)}
   end
 
   @impl Phoenix.LiveView
   def handle_event("select_version", %{"version-id" => version_id}, socket) do
-    {:noreply, assign(socket, :selected_version_id, version_id)}
+    {:noreply, select_version(socket, socket.assigns.prompt, version_id)}
+  end
+
+  def handle_event("show_version_diff", _params, socket) do
+    if socket.assigns.version_comparison do
+      {:noreply, assign(socket, :show_version_diff, true)}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  def handle_event("hide_version_diff", _params, socket) do
+    {:noreply, assign(socket, :show_version_diff, false)}
+  end
+
+  defp select_version(socket, prompt, version_id) do
+    socket
+    |> assign(:selected_version_id, version_id)
+    |> assign(:version_comparison, version_comparison(prompt.versions, version_id))
+    |> assign(:show_version_diff, false)
+  end
+
+  defp version_comparison(versions, selected_version_id) do
+    case Enum.find_index(versions, &(&1.id == selected_version_id)) do
+      nil ->
+        nil
+
+      index ->
+        current_version = Enum.at(versions, index)
+        previous_version = Enum.at(versions, index + 1)
+        build_version_comparison(previous_version, current_version)
+    end
+  end
+
+  defp build_version_comparison(nil, _current_version) do
+    nil
+  end
+
+  defp build_version_comparison(previous_version, current_version) do
+    %{
+      current_version: current_version,
+      previous_version: previous_version,
+      template_diff:
+        List.myers_difference(
+          String.split(previous_version.template, "\n"),
+          String.split(current_version.template, "\n")
+        ),
+      added_variables: current_version.variables -- previous_version.variables,
+      removed_variables: previous_version.variables -- current_version.variables
+    }
   end
 end

--- a/lib/aludel/web/live/prompt_live/show.html.heex
+++ b/lib/aludel/web/live/prompt_live/show.html.heex
@@ -50,9 +50,9 @@
       </div>
     </div>
 
-    <div :if={@prompt.versions != []} class="relative flex flex-col gap-6 lg:flex-row">
+    <div :if={@prompt.versions != []} class={["relative flex flex-col gap-6 lg:flex-row"]}>
       <%!-- Main content area --%>
-      <div class="min-w-0 flex-1">
+      <div class={["min-w-0 flex-1"]}>
         <div style="display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: 16px; margin-bottom: 20px;">
           <div>
             <h2 style="margin: 0; font-size: 18px; font-weight: 600;">
@@ -74,7 +74,7 @@
             id="compare-version-button"
             type="button"
             phx-click="show_version_diff"
-            class="button-secondary"
+            class={["button-secondary"]}
             style="display: inline-flex; align-items: center; gap: 6px; padding: 8px 12px; font-size: 13px;"
           >
             <.icon name="hero-arrows-right-left" class="size-4" />
@@ -86,7 +86,7 @@
         <div
           :if={selected_version && @show_version_diff && @version_comparison}
           id="prompt-version-diff"
-          class="aludel-card"
+          class={["aludel-card"]}
         >
           <div style="display: flex; flex-wrap: wrap; align-items: start; justify-content: space-between; gap: 16px; margin-bottom: 16px;">
             <div>
@@ -101,7 +101,7 @@
               id="close-version-diff"
               type="button"
               phx-click="hide_version_diff"
-              class="button-secondary"
+              class={["button-secondary"]}
               style="display: inline-flex; align-items: center; gap: 6px; padding: 7px 10px; font-size: 12px;"
             >
               <.icon name="hero-x-mark" class="size-4" /> Close diff
@@ -163,7 +163,7 @@
               <span
                 :for={variable <- @version_comparison.added_variables}
                 data-variable-change="added"
-                class="tag"
+                class={["tag"]}
                 style="border-color: rgba(22, 163, 74, 0.45); color: #16a34a;"
               >
                 + {variable}
@@ -171,7 +171,7 @@
               <span
                 :for={variable <- @version_comparison.removed_variables}
                 data-variable-change="removed"
-                class="tag"
+                class={["tag"]}
                 style="border-color: rgba(220, 38, 38, 0.45); color: #dc2626;"
               >
                 - {variable}
@@ -183,7 +183,7 @@
         <div
           :if={selected_version && !@show_version_diff}
           id="prompt-version-content"
-          class="aludel-card"
+          class={["aludel-card"]}
         >
           <div style="border-radius: 6px; padding: 14px; margin-bottom: 14px; background-color: var(--bg-tertiary); border: 1px solid var(--border);">
             <pre style="font-size: 13px; white-space: pre-wrap; font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace; margin: 0; max-height: 500px; overflow-y: auto; line-height: 1.5;">{selected_version.template}</pre>
@@ -214,7 +214,10 @@
       </div>
 
       <%!-- Timeline sidebar --%>
-      <div class="w-full shrink-0 border-t border-[var(--border)] pt-6 lg:w-80 lg:border-t-0 lg:border-l lg:pt-0 lg:pl-6">
+      <div class={[
+        "w-full shrink-0 border-t border-[var(--border)] pt-6",
+        "lg:w-80 lg:border-t-0 lg:border-l lg:pt-0 lg:pl-6"
+      ]}>
         <h3 style="margin: 0 0 16px 0; font-size: 12px; font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.08em; display: flex; align-items: center; gap: 6px;">
           <.icon name="hero-clock" class="size-3" /> History
         </h3>

--- a/lib/aludel/web/live/prompt_live/show.html.heex
+++ b/lib/aludel/web/live/prompt_live/show.html.heex
@@ -50,21 +50,141 @@
       </div>
     </div>
 
-    <div :if={@prompt.versions != []} style="display: flex; gap: 24px; position: relative;">
+    <div :if={@prompt.versions != []} class="relative flex flex-col gap-6 lg:flex-row">
       <%!-- Main content area --%>
-      <div style="flex: 1; min-width: 0;">
-        <div style="margin-bottom: 20px;">
-          <h2 style="margin: 0; font-size: 18px; font-weight: 600;">
-            <%= if @selected_version_id do %>
-              <% selected = Enum.find(@prompt.versions, &(&1.id == @selected_version_id)) %> v{selected.version}
-            <% else %>
-              Current Version
-            <% end %>
-          </h2>
+      <div class="min-w-0 flex-1">
+        <div style="display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: 16px; margin-bottom: 20px;">
+          <div>
+            <h2 style="margin: 0; font-size: 18px; font-weight: 600;">
+              <%= if @selected_version_id do %>
+                <% selected = Enum.find(@prompt.versions, &(&1.id == @selected_version_id)) %> v{selected.version}
+              <% else %>
+                Current Version
+              <% end %>
+            </h2>
+            <p
+              :if={@version_comparison}
+              style="margin: 4px 0 0; color: var(--text-secondary); font-size: 12px;"
+            >
+              Previous version: v{@version_comparison.previous_version.version}
+            </p>
+          </div>
+          <button
+            :if={@version_comparison && !@show_version_diff}
+            id="compare-version-button"
+            type="button"
+            phx-click="show_version_diff"
+            class="button-secondary"
+            style="display: inline-flex; align-items: center; gap: 6px; padding: 8px 12px; font-size: 13px;"
+          >
+            <.icon name="hero-arrows-right-left" class="size-4" />
+            Compare with v{@version_comparison.previous_version.version}
+          </button>
         </div>
 
         <% selected_version = Enum.find(@prompt.versions, &(&1.id == @selected_version_id)) %>
-        <div :if={selected_version} class="aludel-card">
+        <div
+          :if={selected_version && @show_version_diff && @version_comparison}
+          id="prompt-version-diff"
+          class="aludel-card"
+        >
+          <div style="display: flex; flex-wrap: wrap; align-items: start; justify-content: space-between; gap: 16px; margin-bottom: 16px;">
+            <div>
+              <p style="margin: 0 0 4px; color: var(--text-secondary); font-size: 11px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase;">
+                Version comparison
+              </p>
+              <h3 style="margin: 0; font-size: 16px; font-weight: 650;">
+                v{@version_comparison.previous_version.version} to v{@version_comparison.current_version.version}
+              </h3>
+            </div>
+            <button
+              id="close-version-diff"
+              type="button"
+              phx-click="hide_version_diff"
+              class="button-secondary"
+              style="display: inline-flex; align-items: center; gap: 6px; padding: 7px 10px; font-size: 12px;"
+            >
+              <.icon name="hero-x-mark" class="size-4" /> Close diff
+            </button>
+          </div>
+
+          <div style="display: flex; flex-wrap: wrap; gap: 14px; margin-bottom: 10px; color: var(--text-secondary); font-size: 11px;">
+            <span><strong style="color: #16a34a;">+</strong> Added</span>
+            <span><strong style="color: #dc2626;">-</strong> Removed</span>
+            <span><strong style="color: var(--text-muted);">·</strong> Unchanged</span>
+          </div>
+
+          <div
+            id="template-diff-lines"
+            style="overflow-x: auto; border: 1px solid var(--border); border-radius: 8px; background: var(--bg-tertiary); font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, monospace; font-size: 12px; line-height: 1.55;"
+          >
+            <%= for {kind, lines} <- @version_comparison.template_diff do %>
+              <% prefix = if(kind == :ins, do: "+", else: if(kind == :del, do: "-", else: " ")) %>
+              <% background =
+                if(kind == :ins,
+                  do: "rgba(22, 163, 74, 0.12)",
+                  else: if(kind == :del, do: "rgba(220, 38, 38, 0.12)", else: "transparent")
+                ) %>
+              <% color =
+                if(kind == :ins,
+                  do: "#16a34a",
+                  else: if(kind == :del, do: "#dc2626", else: "var(--text-muted)")
+                ) %>
+              <div
+                :for={line <- lines}
+                data-diff-kind={kind}
+                style={"display: grid; grid-template-columns: 28px minmax(0, 1fr); min-height: 24px; background: #{background};"}
+              >
+                <span style={"user-select: none; padding: 2px 8px; border-right: 1px solid var(--border); color: #{color}; font-weight: 700;"}>
+                  {prefix}
+                </span>
+                <span style="padding: 2px 10px; white-space: pre-wrap; overflow-wrap: anywhere; color: var(--text-primary);">
+                  {if(line == "", do: " ", else: line)}
+                </span>
+              </div>
+            <% end %>
+          </div>
+
+          <div
+            id="variable-diff"
+            style="margin-top: 18px; padding-top: 16px; border-top: 1px solid var(--border);"
+          >
+            <p style="margin: 0 0 10px; font-size: 13px; font-weight: 650;">Variable changes</p>
+            <div
+              :if={
+                @version_comparison.added_variables == [] &&
+                  @version_comparison.removed_variables == []
+              }
+              style="color: var(--text-secondary); font-size: 12px;"
+            >
+              No variable changes.
+            </div>
+            <div style="display: flex; flex-wrap: wrap; gap: 8px;">
+              <span
+                :for={variable <- @version_comparison.added_variables}
+                data-variable-change="added"
+                class="tag"
+                style="border-color: rgba(22, 163, 74, 0.45); color: #16a34a;"
+              >
+                + {variable}
+              </span>
+              <span
+                :for={variable <- @version_comparison.removed_variables}
+                data-variable-change="removed"
+                class="tag"
+                style="border-color: rgba(220, 38, 38, 0.45); color: #dc2626;"
+              >
+                - {variable}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div
+          :if={selected_version && !@show_version_diff}
+          id="prompt-version-content"
+          class="aludel-card"
+        >
           <div style="border-radius: 6px; padding: 14px; margin-bottom: 14px; background-color: var(--bg-tertiary); border: 1px solid var(--border);">
             <pre style="font-size: 13px; white-space: pre-wrap; font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace; margin: 0; max-height: 500px; overflow-y: auto; line-height: 1.5;">{selected_version.template}</pre>
           </div>
@@ -94,7 +214,7 @@
       </div>
 
       <%!-- Timeline sidebar --%>
-      <div style="width: 320px; flex-shrink: 0; border-left: 1px solid var(--border); padding-left: 24px;">
+      <div class="w-full shrink-0 border-t border-[var(--border)] pt-6 lg:w-80 lg:border-t-0 lg:border-l lg:pt-0 lg:pl-6">
         <h3 style="margin: 0 0 16px 0; font-size: 12px; font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.08em; display: flex; align-items: center; gap: 6px;">
           <.icon name="hero-clock" class="size-3" /> History
         </h3>
@@ -109,6 +229,7 @@
                 do: "0 0 0 1px var(--accent), 0 2px 8px rgba(99, 102, 241, 0.12)",
                 else: "none" %>
             <div
+              id={"prompt-version-#{version.id}"}
               phx-click="select_version"
               phx-value-version-id={version.id}
               style={"padding: 10px 12px; border-radius: 6px; cursor: pointer; transition: all 0.2s ease; border: 1px solid #{border_color}; background-color: #{bg_color}; box-shadow: #{box_shadow};"}

--- a/test/aludel_web/live/prompt_live/show_test.exs
+++ b/test/aludel_web/live/prompt_live/show_test.exs
@@ -108,5 +108,61 @@ defmodule Aludel.Web.PromptLive.ShowTest do
 
       assert has_element?(view, "a[href=\"/prompts/#{prompt.id}/evolution\"]")
     end
+
+    test "compares the selected version with its previous version", %{conn: conn} do
+      prompt = prompt_fixture(%{name: "Comparable Prompt"})
+
+      {:ok, _v1} =
+        Prompts.create_prompt_version(prompt, "System prompt\nHello {{name}} from {{legacy}}")
+
+      {:ok, _v2} =
+        Prompts.create_prompt_version(prompt, "System prompt\nHi {{name}} about {{topic}}")
+
+      {:ok, view, _html} = live(conn, "/prompts/#{prompt.id}")
+
+      assert has_element?(view, "#compare-version-button")
+
+      view
+      |> element("#compare-version-button")
+      |> render_click()
+
+      assert has_element?(view, "#prompt-version-diff")
+
+      assert has_element?(
+               view,
+               "#template-diff-lines [data-diff-kind='del']",
+               "Hello {{name}} from {{legacy}}"
+             )
+
+      assert has_element?(
+               view,
+               "#template-diff-lines [data-diff-kind='ins']",
+               "Hi {{name}} about {{topic}}"
+             )
+
+      assert has_element?(view, "#variable-diff [data-variable-change='added']", "topic")
+      assert has_element?(view, "#variable-diff [data-variable-change='removed']", "legacy")
+
+      view
+      |> element("#close-version-diff")
+      |> render_click()
+
+      assert has_element?(view, "#prompt-version-content")
+      refute has_element?(view, "#prompt-version-diff")
+    end
+
+    test "does not offer a comparison for the oldest version", %{conn: conn} do
+      prompt = prompt_fixture(%{name: "Oldest Prompt"})
+      {:ok, oldest_version} = Prompts.create_prompt_version(prompt, "Original")
+      {:ok, _latest_version} = Prompts.create_prompt_version(prompt, "Updated")
+
+      {:ok, view, _html} = live(conn, "/prompts/#{prompt.id}")
+
+      view
+      |> element("#prompt-version-#{oldest_version.id}")
+      |> render_click()
+
+      refute has_element?(view, "#compare-version-button")
+    end
   end
 end


### PR DESCRIPTION
## Summary

- add an in-place comparison between the selected prompt version and its immediate predecessor
- render line-level template additions, removals, and unchanged content
- show added and removed prompt variables alongside the template diff
- preserve the normal version detail view with explicit compare and close controls
- make the details/history layout responsive on smaller screens
- add stable DOM selectors and focused LiveView coverage for comparison and oldest-version behavior

Closes #74.

## Validation

- focused PromptLive show suite passes with 11 tests
- full pre-commit suite passes with 641 tests
- Dialyzer passes with no findings