### PR TITLE
feat(prompts): show evolution metric deltas

### DIFF
--- a/lib/aludel/prompts/evolution.ex
+++ b/lib/aludel/prompts/evolution.ex
@@ -7,6 +7,7 @@ defmodule Aludel.Prompts.Evolution do
   import Ecto.Query
 
   alias Aludel.Evals.SuiteRun
+  alias Aludel.Prompts.Evolution.Deltas
   alias Aludel.Prompts.PromptVersion
   alias Aludel.Providers.Provider
 
@@ -29,6 +30,7 @@ defmodule Aludel.Prompts.Evolution do
     prompt_id
     |> get_versions()
     |> Enum.map(&build_version_metrics/1)
+    |> Deltas.annotate()
   end
 
   @doc false

--- a/lib/aludel/prompts/evolution/deltas.ex
+++ b/lib/aludel/prompts/evolution/deltas.ex
@@ -1,0 +1,82 @@
+defmodule Aludel.Prompts.Evolution.Deltas do
+  @moduledoc false
+
+  @delta_keys [:pass_rate, :cost_usd, :latency_ms]
+
+  @spec annotate([map()]) :: [map()]
+  def annotate(metrics) do
+    {annotated_metrics, _previous_metric} =
+      Enum.map_reduce(metrics, nil, fn metric, previous_metric ->
+        {annotate_metric(metric, previous_metric), metric}
+      end)
+
+    annotated_metrics
+  end
+
+  defp annotate_metric(metric, previous_metric) do
+    previous_providers =
+      previous_metric
+      |> provider_breakdown()
+      |> Map.new(&{&1.provider_id, &1})
+
+    provider_breakdown =
+      metric
+      |> provider_breakdown()
+      |> Enum.map(fn provider_metrics ->
+        previous_provider = Map.get(previous_providers, provider_metrics.provider_id)
+        Map.put(provider_metrics, :deltas, build_deltas(provider_metrics, previous_provider))
+      end)
+
+    metric
+    |> Map.put(:deltas, build_deltas(metric, previous_metric))
+    |> Map.put(:provider_breakdown, provider_breakdown)
+  end
+
+  defp build_deltas(_current, nil) do
+    Map.new(@delta_keys, &{&1, nil})
+  end
+
+  defp build_deltas(current, previous) do
+    %{
+      pass_rate: pass_rate_delta(current.avg_pass_rate, previous.avg_pass_rate),
+      cost_usd: decimal_delta(current.avg_cost_usd, previous.avg_cost_usd),
+      latency_ms: number_delta(current.avg_latency_ms, previous.avg_latency_ms)
+    }
+  end
+
+  defp provider_breakdown(nil) do
+    []
+  end
+
+  defp provider_breakdown(metric) do
+    Map.get(metric, :provider_breakdown, [])
+  end
+
+  defp pass_rate_delta(current, previous)
+       when is_number(current) and is_number(previous) do
+    current
+    |> Kernel.-(previous)
+    |> Float.round(2)
+  end
+
+  defp pass_rate_delta(_current, _previous) do
+    nil
+  end
+
+  defp decimal_delta(%Decimal{} = current, %Decimal{} = previous) do
+    Decimal.sub(current, previous)
+  end
+
+  defp decimal_delta(_current, _previous) do
+    nil
+  end
+
+  defp number_delta(current, previous)
+       when is_number(current) and is_number(previous) do
+    current - previous
+  end
+
+  defp number_delta(_current, _previous) do
+    nil
+  end
+end

--- a/lib/aludel/web/components/evolution_components.ex
+++ b/lib/aludel/web/components/evolution_components.ex
@@ -1,0 +1,137 @@
+defmodule Aludel.Web.EvolutionComponents do
+  @moduledoc false
+
+  use Aludel.Web, :html
+
+  attr :metric, :atom, required: true
+  attr :delta, :any, default: nil
+  attr :compact, :boolean, default: false
+
+  def metric_delta(assigns) do
+    assigns =
+      assigns
+      |> assign(:direction, delta_direction(assigns.metric, assigns.delta))
+      |> assign(:icon, delta_icon(assigns.delta))
+      |> assign(:label, delta_label(assigns.metric, assigns.delta))
+      |> assign(:color, delta_color(delta_direction(assigns.metric, assigns.delta)))
+
+    ~H"""
+    <span
+      :if={not is_nil(@delta)}
+      data-metric-delta={@metric}
+      data-delta-direction={@direction}
+      style={"display: inline-flex; align-items: center; gap: 3px; margin-top: 4px; font-size: 11px; font-weight: 600; color: #{@color};"}
+    >
+      <.icon name={@icon} class="size-3" />
+      {@label}<span :if={not @compact}>&nbsp;vs previous</span>
+    </span>
+    """
+  end
+
+  defp delta_direction(_metric, nil) do
+    nil
+  end
+
+  defp delta_direction(metric, delta) when metric in [:cost_usd, :latency_ms] do
+    delta
+    |> numeric_value()
+    |> lower_is_better_direction()
+  end
+
+  defp delta_direction(_metric, delta) do
+    delta
+    |> numeric_value()
+    |> higher_is_better_direction()
+  end
+
+  defp lower_is_better_direction(value) when value < 0 do
+    :improved
+  end
+
+  defp lower_is_better_direction(value) when value > 0 do
+    :regressed
+  end
+
+  defp lower_is_better_direction(_value) do
+    :unchanged
+  end
+
+  defp higher_is_better_direction(value) when value > 0 do
+    :improved
+  end
+
+  defp higher_is_better_direction(value) when value < 0 do
+    :regressed
+  end
+
+  defp higher_is_better_direction(_value) do
+    :unchanged
+  end
+
+  defp delta_icon(nil) do
+    "hero-minus-small"
+  end
+
+  defp delta_icon(delta) do
+    case numeric_value(delta) do
+      value when value > 0 -> "hero-arrow-trending-up"
+      value when value < 0 -> "hero-arrow-trending-down"
+      _value -> "hero-minus-small"
+    end
+  end
+
+  defp delta_label(_metric, nil) do
+    nil
+  end
+
+  defp delta_label(:pass_rate, delta) do
+    value = numeric_value(delta)
+    "#{sign(value)}#{format_number(abs(value), 1)} pp"
+  end
+
+  defp delta_label(:cost_usd, delta) do
+    value = numeric_value(delta)
+    "#{sign(value)}$#{format_number(abs(value), 4)}"
+  end
+
+  defp delta_label(:latency_ms, delta) do
+    value = numeric_value(delta)
+    "#{sign(value)}#{round(abs(value))} ms"
+  end
+
+  defp delta_color(:improved) do
+    "#059669"
+  end
+
+  defp delta_color(:regressed) do
+    "#dc2626"
+  end
+
+  defp delta_color(_direction) do
+    "var(--text-muted)"
+  end
+
+  defp numeric_value(%Decimal{} = value) do
+    Decimal.to_float(value)
+  end
+
+  defp numeric_value(value) do
+    value
+  end
+
+  defp sign(value) when value > 0 do
+    "+"
+  end
+
+  defp sign(value) when value < 0 do
+    "-"
+  end
+
+  defp sign(_value) do
+    ""
+  end
+
+  defp format_number(value, decimals) do
+    :erlang.float_to_binary(value / 1, decimals: decimals)
+  end
+end

--- a/lib/aludel/web/live/prompt_live/evolution.html.heex
+++ b/lib/aludel/web/live/prompt_live/evolution.html.heex
@@ -185,7 +185,10 @@
             </thead>
             <tbody>
               <%= for metric <- @metrics do %>
-                <tr style="border-bottom: 1px solid var(--border); transition: background-color 0.15s;">
+                <tr
+                  id={"evolution-version-#{metric.version_number}"}
+                  style="border-bottom: 1px solid var(--border); transition: background-color 0.15s;"
+                >
                   <td style="padding: 16px; font-weight: 600; color: var(--text-primary);">
                     v{metric.version_number}
                   </td>
@@ -218,6 +221,10 @@
                     <% else %>
                       <span style="color: var(--text-muted);">—</span>
                     <% end %>
+                    <Aludel.Web.EvolutionComponents.metric_delta
+                      metric={:pass_rate}
+                      delta={metric.deltas.pass_rate}
+                    />
                   </td>
                   <td style="padding: 16px; font-size: 14px; color: var(--text-secondary);">
                     <%= if metric.avg_score do %>
@@ -238,6 +245,10 @@
                     <% else %>
                       <span style="color: var(--text-muted);">—</span>
                     <% end %>
+                    <Aludel.Web.EvolutionComponents.metric_delta
+                      metric={:cost_usd}
+                      delta={metric.deltas.cost_usd}
+                    />
                   </td>
                   <td style="padding: 16px; font-size: 14px; color: var(--text-secondary);">
                     <%= if metric.avg_latency_ms do %>
@@ -245,6 +256,10 @@
                     <% else %>
                       <span style="color: var(--text-muted);">—</span>
                     <% end %>
+                    <Aludel.Web.EvolutionComponents.metric_delta
+                      metric={:latency_ms}
+                      delta={metric.deltas.latency_ms}
+                    />
                   </td>
                 </tr>
               <% end %>
@@ -341,6 +356,10 @@
                       —
                     </div>
                   <% end %>
+                  <Aludel.Web.EvolutionComponents.metric_delta
+                    metric={:pass_rate}
+                    delta={metric.deltas.pass_rate}
+                  />
                 </div>
 
                 <div style="padding: 12px; background-color: var(--bg-secondary); border-radius: 6px; border: 1px solid var(--border);">
@@ -373,6 +392,10 @@
                       —
                     </div>
                   <% end %>
+                  <Aludel.Web.EvolutionComponents.metric_delta
+                    metric={:cost_usd}
+                    delta={metric.deltas.cost_usd}
+                  />
                 </div>
 
                 <div style="padding: 12px; background-color: var(--bg-secondary); border-radius: 6px; border: 1px solid var(--border);">
@@ -388,6 +411,10 @@
                       —
                     </div>
                   <% end %>
+                  <Aludel.Web.EvolutionComponents.metric_delta
+                    metric={:latency_ms}
+                    delta={metric.deltas.latency_ms}
+                  />
                 </div>
               </div>
 
@@ -399,7 +426,10 @@
                   </h4>
                   <div style="display: flex; flex-direction: column; gap: 10px;">
                     <%= for breakdown <- Enum.sort_by(metric.provider_breakdown, & &1.avg_pass_rate, :desc) do %>
-                      <div style="padding: 14px; background-color: var(--bg-tertiary); border: 1px solid var(--border); border-radius: 6px;">
+                      <div
+                        id={"provider-breakdown-#{metric.version_number}-#{breakdown.provider_id}"}
+                        style="padding: 14px; background-color: var(--bg-tertiary); border: 1px solid var(--border); border-radius: 6px;"
+                      >
                         <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px;">
                           <div style="font-size: 14px; font-weight: 600; color: var(--text-primary);">
                             {breakdown.provider_name}
@@ -431,11 +461,55 @@
                             {pass_rate}%
                           </span>
                         <% end %>
+                        <Aludel.Web.EvolutionComponents.metric_delta
+                          metric={:pass_rate}
+                          delta={breakdown.deltas.pass_rate}
+                          compact
+                        />
                         <div
                           :if={breakdown.avg_score}
                           style="margin-top: 8px; font-size: 12px; color: #8b5cf6; font-weight: 600;"
                         >
                           {Decimal.to_float(breakdown.avg_score)}% avg score
+                        </div>
+                        <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px; margin-top: 10px;">
+                          <div>
+                            <div style="font-size: 10px; color: var(--text-muted); text-transform: uppercase;">
+                              Avg Cost
+                            </div>
+                            <div style="font-size: 12px; color: var(--text-secondary); font-family: 'SF Mono', Monaco, monospace;">
+                              <%= if breakdown.avg_cost_usd do %>
+                                ${:erlang.float_to_binary(
+                                  Decimal.to_float(breakdown.avg_cost_usd),
+                                  decimals: 4
+                                )}
+                              <% else %>
+                                —
+                              <% end %>
+                            </div>
+                            <Aludel.Web.EvolutionComponents.metric_delta
+                              metric={:cost_usd}
+                              delta={breakdown.deltas.cost_usd}
+                              compact
+                            />
+                          </div>
+                          <div>
+                            <div style="font-size: 10px; color: var(--text-muted); text-transform: uppercase;">
+                              Avg Latency
+                            </div>
+                            <div style="font-size: 12px; color: var(--text-secondary);">
+                              <%= if breakdown.avg_latency_ms do %>
+                                {breakdown.avg_latency_ms}ms
+                              <% else %>
+                                —
+                              <% end %>
+                            </div>
+                            <Aludel.Web.EvolutionComponents.metric_delta
+                              metric={:latency_ms}
+                              delta={breakdown.deltas.latency_ms}
+                              compact
+                            />
+                          </div>
                         </div>
                       </div>
                     <% end %>

--- a/test/aludel/prompts/evolution/deltas_test.exs
+++ b/test/aludel/prompts/evolution/deltas_test.exs
@@ -1,0 +1,67 @@
+defmodule Aludel.Prompts.Evolution.DeltasTest do
+  use ExUnit.Case, async: true
+
+  alias Aludel.Prompts.Evolution.Deltas
+
+  test "annotates versions and matching providers against their predecessor" do
+    metrics = [
+      metric(1, 60.0, "0.0100", 500),
+      metric(2, 90.0, "0.0080", 420)
+    ]
+
+    [first, second] = Deltas.annotate(metrics)
+
+    assert first.deltas == %{pass_rate: nil, cost_usd: nil, latency_ms: nil}
+    assert second.deltas.pass_rate == 30.0
+    assert Decimal.equal?(second.deltas.cost_usd, Decimal.new("-0.0020"))
+    assert second.deltas.latency_ms == -80
+
+    [first_provider] = first.provider_breakdown
+    [second_provider] = second.provider_breakdown
+
+    assert first_provider.deltas == %{pass_rate: nil, cost_usd: nil, latency_ms: nil}
+    assert second_provider.deltas.pass_rate == 30.0
+    assert Decimal.equal?(second_provider.deltas.cost_usd, Decimal.new("-0.0020"))
+    assert second_provider.deltas.latency_ms == -80
+  end
+
+  test "leaves deltas empty when there is no comparable value or provider" do
+    first =
+      metric(1, nil, nil, nil)
+      |> Map.put(:provider_breakdown, [])
+
+    second = metric(2, 90.0, "0.0080", 420)
+
+    [_first, annotated_second] = Deltas.annotate([first, second])
+
+    assert annotated_second.deltas == %{pass_rate: nil, cost_usd: nil, latency_ms: nil}
+
+    [provider] = annotated_second.provider_breakdown
+    assert provider.deltas == %{pass_rate: nil, cost_usd: nil, latency_ms: nil}
+  end
+
+  defp metric(version_number, pass_rate, cost, latency) do
+    %{
+      version_number: version_number,
+      avg_pass_rate: pass_rate,
+      avg_cost_usd: decimal(cost),
+      avg_latency_ms: latency,
+      provider_breakdown: [
+        %{
+          provider_id: "provider-1",
+          avg_pass_rate: pass_rate,
+          avg_cost_usd: decimal(cost),
+          avg_latency_ms: latency
+        }
+      ]
+    }
+  end
+
+  defp decimal(nil) do
+    nil
+  end
+
+  defp decimal(value) do
+    Decimal.new(value)
+  end
+end

--- a/test/aludel_web/components/evolution_components_test.exs
+++ b/test/aludel_web/components/evolution_components_test.exs
@@ -1,0 +1,49 @@
+defmodule Aludel.Web.EvolutionComponentsTest do
+  use Aludel.Web.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Aludel.Web.EvolutionComponents
+
+  test "marks a pass-rate increase as an improvement" do
+    document =
+      render_component(&EvolutionComponents.metric_delta/1, metric: :pass_rate, delta: 30.0)
+      |> LazyHTML.from_fragment()
+
+    match =
+      LazyHTML.filter(
+        document,
+        "[data-metric-delta='pass_rate'][data-delta-direction='improved']"
+      )
+
+    assert LazyHTML.to_html(match) =~ "+30.0 pp"
+  end
+
+  test "treats lower cost as an improvement and higher latency as a regression" do
+    cost_document =
+      render_component(&EvolutionComponents.metric_delta/1,
+        metric: :cost_usd,
+        delta: Decimal.new("-0.0020")
+      )
+      |> LazyHTML.from_fragment()
+
+    latency_document =
+      render_component(&EvolutionComponents.metric_delta/1, metric: :latency_ms, delta: 80)
+      |> LazyHTML.from_fragment()
+
+    improved_cost =
+      LazyHTML.filter(
+        cost_document,
+        "[data-metric-delta='cost_usd'][data-delta-direction='improved']"
+      )
+
+    regressed_latency =
+      LazyHTML.filter(
+        latency_document,
+        "[data-metric-delta='latency_ms'][data-delta-direction='regressed']"
+      )
+
+    assert LazyHTML.to_html(improved_cost) =~ "-$0.0020"
+    assert LazyHTML.to_html(regressed_latency) =~ "+80 ms"
+  end
+end


### PR DESCRIPTION
## Motivation

Prompt evolution showed only absolute metrics, making version-over-version improvements and regressions difficult to identify. This change adds pass-rate, cost, and latency deltas for each version and matching provider while preserving the absolute values. Favorable, unfavorable, and unchanged changes receive distinct visual cues.

Closes #80

## Test Plan

- Added isolated coverage for version and provider delta calculations, including missing baselines.
- Added component coverage for higher-is-better and lower-is-better visual semantics.
- The focused evolution suite passes with 35 tests and zero failures.
- The full suite passes with 645 tests and zero failures.
- Formatting, static analysis, security scanning, and Dialyzer pass.

## Next Steps

None.