### PR TITLE
feat(evals): persist imported test cases

### DIFF
--- a/lib/aludel/evals.ex
+++ b/lib/aludel/evals.ex
@@ -20,6 +20,7 @@ defmodule Aludel.Evals do
   alias Aludel.Storage
   alias Ecto.Association.NotLoaded
   alias Ecto.Changeset
+  alias Ecto.Multi
 
   # Suite functions
 
@@ -164,6 +165,44 @@ defmodule Aludel.Evals do
     %TestCase{}
     |> TestCase.changeset(attrs)
     |> repo().insert()
+  end
+
+  @doc """
+  Imports test case attributes into an existing suite as one transaction.
+
+  The suite association is set from the supplied suite rather than accepted
+  from imported attributes. If any row fails validation, no test cases are
+  persisted and the failing row index is returned with its changeset.
+  """
+  @spec import_test_cases(Suite.t(), [map()]) ::
+          {:ok, [TestCase.t()]}
+          | {:error, %{row: pos_integer(), changeset: Changeset.t()}}
+  def import_test_cases(%Suite{} = suite, test_case_attrs) when is_list(test_case_attrs) do
+    indexed_attrs = Enum.with_index(test_case_attrs, 1)
+
+    multi =
+      Enum.reduce(indexed_attrs, Multi.new(), fn {attrs, row}, multi ->
+        sanitized_attrs = Map.drop(attrs, [:suite_id, "suite_id"])
+
+        changeset =
+          %TestCase{suite_id: suite.id}
+          |> TestCase.changeset(sanitized_attrs)
+
+        Multi.insert(multi, {:test_case, row}, changeset)
+      end)
+
+    case repo().transaction(multi) do
+      {:ok, changes} ->
+        test_cases =
+          Enum.map(indexed_attrs, fn {_attrs, row} ->
+            Map.fetch!(changes, {:test_case, row})
+          end)
+
+        {:ok, test_cases}
+
+      {:error, {:test_case, row}, changeset, _changes} ->
+        {:error, %{row: row, changeset: changeset}}
+    end
   end
 
   @doc """

--- a/lib/aludel/evals/test_case.ex
+++ b/lib/aludel/evals/test_case.ex
@@ -48,6 +48,7 @@ defmodule Aludel.Evals.TestCase do
     |> cast(attrs, @required_fields ++ @optional_fields)
     |> validate_required(@required_fields)
     |> validate_assertions()
+    |> foreign_key_constraint(:suite_id)
   end
 
   defp validate_assertions(%Changeset{} = changeset) do

--- a/test/aludel/evals/import_test_cases_test.exs
+++ b/test/aludel/evals/import_test_cases_test.exs
@@ -1,0 +1,75 @@
+defmodule Aludel.Evals.ImportTestCasesTest do
+  use Aludel.DataCase, async: true
+
+  alias Aludel.Evals
+
+  describe "import_test_cases/2" do
+    test "persists imported test cases in source order" do
+      suite = suite_fixture()
+
+      assert {:ok, test_cases} =
+               Evals.import_test_cases(suite, [
+                 test_case_attrs("first", "one"),
+                 test_case_attrs("second", "two")
+               ])
+
+      assert Enum.map(test_cases, & &1.variable_values["input"]) == ["first", "second"]
+
+      persisted_suite = Evals.get_suite_with_test_cases!(suite.id)
+
+      assert persisted_suite.test_cases
+             |> Enum.map(& &1.variable_values["input"])
+             |> MapSet.new() == MapSet.new(["first", "second"])
+    end
+
+    test "rolls back the batch and reports the failing row" do
+      suite = suite_fixture()
+
+      invalid_attrs = %{
+        variable_values: %{"input" => "invalid"},
+        assertions: [%{"type" => "unsupported", "value" => "value"}]
+      }
+
+      assert {:error, %{row: 2, changeset: changeset}} =
+               Evals.import_test_cases(suite, [
+                 test_case_attrs("valid", "value"),
+                 invalid_attrs
+               ])
+
+      refute changeset.valid?
+      assert Evals.get_suite_with_test_cases!(suite.id).test_cases == []
+    end
+
+    test "ignores suite IDs supplied by imported attributes" do
+      target_suite = suite_fixture()
+      other_suite = suite_fixture()
+
+      attrs =
+        "target"
+        |> test_case_attrs("value")
+        |> Map.put(:suite_id, other_suite.id)
+        |> Map.put("suite_id", other_suite.id)
+
+      assert {:ok, [test_case]} = Evals.import_test_cases(target_suite, [attrs])
+      assert test_case.suite_id == target_suite.id
+      assert Evals.get_suite_with_test_cases!(other_suite.id).test_cases == []
+    end
+
+    test "returns a changeset error when the target suite was deleted" do
+      suite = suite_fixture()
+      assert {:ok, _deleted_suite} = Evals.delete_suite(suite)
+
+      assert {:error, %{row: 1, changeset: changeset}} =
+               Evals.import_test_cases(suite, [test_case_attrs("stale", "value")])
+
+      assert "does not exist" in errors_on(changeset).suite_id
+    end
+  end
+
+  defp test_case_attrs(input, expected) do
+    %{
+      variable_values: %{"input" => input},
+      assertions: [%{"type" => "contains", "value" => expected}]
+    }
+  end
+end


### PR DESCRIPTION
## Motivation

The CSV and JSON importer can validate payloads, but its accepted rows could not yet be persisted into an existing suite. This change adds the focused persistence boundary needed before upload and preview UI can be connected.

- Persist imported rows atomically with `Ecto.Multi`
- Set the destination suite internally instead of trusting imported foreign keys
- Preserve source order in the returned test cases
- Return the failing row and changeset while rolling back the entire batch
- Translate stale-suite foreign-key failures into structured changeset errors

Part of #97

## Test Plan

- Added coverage for ordered batch persistence, atomic rollback, suite-ID injection resistance, and stale-suite handling.
- The focused importer and test-case suite passes with 23 tests and zero failures.
- The full suite passes with 649 tests and zero failures.
- Formatting, static analysis, security scanning, and Dialyzer pass.

## Next Steps

Connect parsing and persistence through a separate upload and preview UI pull request.