### PR TITLE
feat(evals): add test case import preview

### DIFF
--- a/lib/aludel/web/live/suite_live/show.ex
+++ b/lib/aludel/web/live/suite_live/show.ex
@@ -12,6 +12,7 @@ defmodule Aludel.Web.SuiteLive.Show do
   alias Aludel.Evals.AssertionParser
   alias Aludel.Evals.DocumentIngestion
   alias Aludel.Evals.TestCaseEditor
+  alias Aludel.Evals.TestCaseImporter
   alias Aludel.Executor
   alias Aludel.Projects
   alias Aludel.Prompts
@@ -20,6 +21,17 @@ defmodule Aludel.Web.SuiteLive.Show do
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
+    socket =
+      socket
+      |> assign(:show_test_case_import, false)
+      |> assign(:test_case_import_preview, nil)
+      |> assign(:test_case_import_form, to_form(%{}, as: :test_case_import))
+      |> allow_upload(:test_case_import,
+        accept: ~w(.csv .json),
+        max_entries: 1,
+        max_file_size: 2_000_000
+      )
+
     {:ok, socket}
   end
 
@@ -198,6 +210,96 @@ defmodule Aludel.Web.SuiteLive.Show do
 
       {:error, _changeset} ->
         {:noreply, put_flash(socket, :error, "Failed to create test case")}
+    end
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("toggle_test_case_import", _params, socket) do
+    socket =
+      if socket.assigns.show_test_case_import do
+        reset_test_case_import(socket)
+      else
+        assign(socket, :show_test_case_import, true)
+      end
+
+    {:noreply, socket}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("validate_test_case_import", _params, socket) do
+    {:noreply, assign(socket, :test_case_import_preview, nil)}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("cancel_test_case_import_upload", %{"ref" => ref}, socket) do
+    {:noreply, cancel_upload(socket, :test_case_import, ref)}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("preview_test_case_import", _params, socket) do
+    results =
+      consume_uploaded_entries(socket, :test_case_import, fn %{path: path}, entry ->
+        {:ok, parse_test_case_import(path, entry.client_name)}
+      end)
+
+    socket =
+      case results do
+        [{:ok, preview}] ->
+          socket
+          |> assign(:test_case_import_preview, preview)
+          |> clear_flash(:error)
+
+        [{:error, message}] ->
+          socket
+          |> assign(:test_case_import_preview, nil)
+          |> put_flash(:error, message)
+
+        [] ->
+          put_flash(socket, :error, "Choose a CSV or JSON file to preview")
+      end
+
+    {:noreply, socket}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event(
+        "confirm_test_case_import",
+        _params,
+        %{assigns: %{uploads: %{test_case_import: %{entries: [_entry | _entries]}}}} = socket
+      ) do
+    {:noreply,
+     socket
+     |> assign(:test_case_import_preview, nil)
+     |> put_flash(:error, "Preview the selected file before importing")}
+  end
+
+  def handle_event("confirm_test_case_import", _params, socket) do
+    case socket.assigns.test_case_import_preview do
+      %{summary: %{test_cases: []}} ->
+        {:noreply, put_flash(socket, :error, "No valid test cases are available to import")}
+
+      %{summary: %{test_cases: test_case_attrs, rejected: rejected}} ->
+        case Evals.import_test_cases(socket.assigns.suite, test_case_attrs) do
+          {:ok, test_cases} ->
+            suite = Evals.get_suite_with_test_cases_and_prompt!(socket.assigns.suite.id)
+
+            {:noreply,
+             socket
+             |> assign(:suite, suite)
+             |> reset_test_case_import()
+             |> put_flash(:info, import_success_message(length(test_cases), rejected))}
+
+          {:error, %{row: row}} ->
+            {:noreply,
+             put_flash(
+               socket,
+               :error,
+               "Import could not save valid row #{row}; no rows were added"
+             )}
+        end
+
+      nil ->
+        {:noreply, put_flash(socket, :error, "Preview a CSV or JSON file before importing")}
     end
   end
 
@@ -386,6 +488,39 @@ defmodule Aludel.Web.SuiteLive.Show do
       end
 
     {:noreply, socket}
+  end
+
+  defp parse_test_case_import(path, client_name) do
+    case File.read(path) do
+      {:ok, payload} ->
+        case client_name |> Path.extname() |> String.downcase() do
+          ".csv" -> TestCaseImporter.parse_csv(payload)
+          ".json" -> TestCaseImporter.parse_json(payload)
+          _extension -> {:error, "Import file must be CSV or JSON"}
+        end
+
+      {:error, _reason} ->
+        {:error, "Import file could not be read"}
+    end
+  end
+
+  defp reset_test_case_import(socket) do
+    socket =
+      Enum.reduce(socket.assigns.uploads.test_case_import.entries, socket, fn entry, socket ->
+        cancel_upload(socket, :test_case_import, entry.ref)
+      end)
+
+    socket
+    |> assign(:show_test_case_import, false)
+    |> assign(:test_case_import_preview, nil)
+  end
+
+  defp import_success_message(created, 0) do
+    "Imported #{created} test case(s)"
+  end
+
+  defp import_success_message(created, rejected) do
+    "Imported #{created} test case(s); #{rejected} row(s) were rejected"
   end
 
   defp handle_test_case_uploads(socket, test_case) do

--- a/lib/aludel/web/live/suite_live/show.html.heex
+++ b/lib/aludel/web/live/suite_live/show.html.heex
@@ -139,16 +139,162 @@
     </div>
     <%!-- Column 2: Test Cases --%>
     <div style="padding: 24px; overflow-y: auto; overflow-x: hidden; border-right: 1px solid var(--border);">
-      <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px;">
+      <div style="display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 16px;">
         <h2 style="margin: 0;">Test Cases</h2>
-        <button
-          phx-click="add_test_case"
-          class="button-primary"
-          style="font-size: 13px; padding: 6px 12px;"
-        >
-          + Add Test Case
-        </button>
+        <div style="display: flex; align-items: center; gap: 8px;">
+          <button
+            id="toggle-test-case-import"
+            phx-click="toggle_test_case_import"
+            class={["button-secondary"]}
+            style="font-size: 13px; padding: 6px 12px;"
+          >
+            <.icon name="hero-arrow-up-tray" class="size-4" /> Import
+          </button>
+          <button
+            id="add-test-case"
+            phx-click="add_test_case"
+            class={["button-primary"]}
+            style="font-size: 13px; padding: 6px 12px;"
+          >
+            + Add Test Case
+          </button>
+        </div>
       </div>
+      <%= if @show_test_case_import do %>
+        <section
+          id="test-case-import-panel"
+          style="margin-bottom: 16px; padding: 16px; border: 1px solid var(--border); border-radius: 10px; background: linear-gradient(145deg, var(--bg-secondary), var(--bg-primary));"
+        >
+          <div style="display: flex; justify-content: space-between; gap: 12px; margin-bottom: 12px;">
+            <div>
+              <h3 style="margin: 0 0 4px; font-size: 15px;">Import test cases</h3>
+              <p style="margin: 0; color: var(--text-secondary); font-size: 12px; line-height: 1.5;">
+                Upload CSV or JSON with input, expected, and assertion fields. Review validation before importing.
+              </p>
+            </div>
+            <button
+              id="cancel-test-case-import"
+              type="button"
+              phx-click="toggle_test_case_import"
+              aria-label="Close import panel"
+              class={["button-secondary"]}
+              style="align-self: flex-start; padding: 6px;"
+            >
+              <.icon name="hero-x-mark" class="size-4" />
+            </button>
+          </div>
+
+          <.form
+            for={@test_case_import_form}
+            id="test-case-import-form"
+            phx-change="validate_test_case_import"
+            phx-submit="preview_test_case_import"
+          >
+            <label
+              for="test-case-import-file"
+              style="display: block; padding: 16px; border: 1px dashed var(--border); border-radius: 8px; background-color: var(--bg-primary); cursor: pointer; text-align: center;"
+            >
+              <.icon name="hero-document-arrow-up" class="size-5" />
+              <span style="display: block; margin-top: 6px; font-size: 13px; font-weight: 600;">
+                Choose a .csv or .json file
+              </span>
+              <span style="display: block; margin-top: 2px; font-size: 11px; color: var(--text-muted);">
+                Maximum file size: 2 MB
+              </span>
+            </label>
+            <.live_file_input
+              upload={@uploads.test_case_import}
+              id="test-case-import-file"
+              style="position: absolute; width: 1px; height: 1px; overflow: hidden; opacity: 0;"
+            />
+
+            <%= for entry <- @uploads.test_case_import.entries do %>
+              <div
+                id={"test-case-import-entry-#{entry.ref}"}
+                style="display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-top: 10px; padding: 8px 10px; border-radius: 6px; background-color: var(--bg-tertiary); font-size: 12px;"
+              >
+                <span style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+                  {entry.client_name}
+                </span>
+                <button
+                  type="button"
+                  phx-click="cancel_test_case_import_upload"
+                  phx-value-ref={entry.ref}
+                  aria-label="Remove import file"
+                  class={["button-secondary"]}
+                  style="padding: 4px;"
+                >
+                  <.icon name="hero-x-mark" class="size-3" />
+                </button>
+              </div>
+            <% end %>
+
+            <button
+              id="preview-test-case-import"
+              type="submit"
+              class={["button-primary"]}
+              disabled={@uploads.test_case_import.entries == []}
+              style="width: 100%; margin-top: 12px; font-size: 13px;"
+            >
+              Preview import
+            </button>
+          </.form>
+
+          <%= if @test_case_import_preview && @uploads.test_case_import.entries == [] do %>
+            <div
+              id="test-case-import-preview"
+              style="margin-top: 14px; padding-top: 14px; border-top: 1px solid var(--border);"
+            >
+              <div style="display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px;">
+                <div
+                  id="test-case-import-valid-count"
+                  style="padding: 10px; border-radius: 7px; background-color: color-mix(in srgb, #059669 10%, transparent); color: #059669;"
+                >
+                  <strong style="display: block; font-size: 18px;">
+                    {@test_case_import_preview.summary.created}
+                  </strong>
+                  <span style="font-size: 11px;">Valid rows</span>
+                </div>
+                <div
+                  id="test-case-import-rejected-count"
+                  style="padding: 10px; border-radius: 7px; background-color: color-mix(in srgb, #dc2626 10%, transparent); color: #dc2626;"
+                >
+                  <strong style="display: block; font-size: 18px;">
+                    {@test_case_import_preview.summary.rejected}
+                  </strong>
+                  <span style="font-size: 11px;">Rejected rows</span>
+                </div>
+              </div>
+
+              <div
+                :if={@test_case_import_preview.errors != []}
+                id="test-case-import-errors"
+                style="margin-top: 10px; display: flex; flex-direction: column; gap: 6px;"
+              >
+                <div
+                  :for={error <- @test_case_import_preview.errors}
+                  id={"test-case-import-error-#{error.row}"}
+                  style="padding: 8px 10px; border-left: 3px solid #dc2626; background-color: var(--bg-tertiary); font-size: 12px; color: var(--text-secondary);"
+                >
+                  <strong style="color: var(--text-primary);">Row {error.row}:</strong>
+                  {error.message}
+                </div>
+              </div>
+
+              <button
+                id="confirm-test-case-import"
+                type="button"
+                phx-click="confirm_test_case_import"
+                class={["button-primary"]}
+                disabled={@test_case_import_preview.summary.created == 0}
+                style="width: 100%; margin-top: 12px; font-size: 13px;"
+              >
+                Import {@test_case_import_preview.summary.created} valid test case(s)
+              </button>
+            </div>
+          <% end %>
+        </section>
+      <% end %>
       <div
         id="test-cases"
         phx-hook="AssertionTypeToggle"

--- a/test/aludel_web/live/suite_live/show_test.exs
+++ b/test/aludel_web/live/suite_live/show_test.exs
@@ -8,6 +8,7 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
   import Aludel.ProvidersFixtures
   import Mox
 
+  alias Aludel.Evals
   alias Aludel.Interfaces.HttpClientMock
 
   test "displays suite details", %{conn: conn} do
@@ -35,6 +36,115 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
     {:ok, view, _html} = live(conn, "/suites/#{suite.id}")
 
     assert has_element?(view, "#run-suite-btn")
+  end
+
+  describe "test case import" do
+    test "previews accepted and rejected rows before confirmed persistence", %{conn: conn} do
+      suite = suite_fixture()
+      {:ok, view, _html} = live(conn, "/suites/#{suite.id}")
+
+      view
+      |> element("#toggle-test-case-import")
+      |> render_click()
+
+      assert has_element?(view, "#test-case-import-panel")
+
+      payload = "input,expected,assertion\nfirst,ok,contains\nbad,,contains\n"
+
+      upload =
+        file_input(view, "#test-case-import-form", :test_case_import, [
+          %{name: "cases.csv", content: payload, type: "text/csv"}
+        ])
+
+      render_upload(upload, "cases.csv")
+
+      view
+      |> form("#test-case-import-form")
+      |> render_submit()
+
+      assert has_element?(view, "#test-case-import-preview")
+      assert has_element?(view, "#test-case-import-valid-count", "1")
+      assert has_element?(view, "#test-case-import-rejected-count", "1")
+      assert has_element?(view, "#test-case-import-error-3", "expected is required")
+      assert Evals.get_suite_with_test_cases!(suite.id).test_cases == []
+
+      view
+      |> element("#confirm-test-case-import")
+      |> render_click()
+
+      assert has_element?(view, "#flash-info", "Imported 1 test case(s); 1 row(s) were rejected")
+
+      assert [%{variable_values: %{"input" => "first"}}] =
+               Evals.get_suite_with_test_cases!(suite.id).test_cases
+
+      refute has_element?(view, "#test-case-import-panel")
+    end
+
+    test "keeps malformed JSON recoverable in the import panel", %{conn: conn} do
+      suite = suite_fixture()
+      {:ok, view, _html} = live(conn, "/suites/#{suite.id}")
+
+      view
+      |> element("#toggle-test-case-import")
+      |> render_click()
+
+      upload =
+        file_input(view, "#test-case-import-form", :test_case_import, [
+          %{name: "cases.json", content: "{invalid}", type: "application/json"}
+        ])
+
+      render_upload(upload, "cases.json")
+
+      view
+      |> form("#test-case-import-form")
+      |> render_submit()
+
+      assert has_element?(view, "#flash-error", "Invalid JSON payload")
+      assert has_element?(view, "#test-case-import-panel")
+      refute has_element?(view, "#test-case-import-preview")
+      assert Process.alive?(view.pid)
+    end
+
+    test "clears a stale preview when a replacement file is selected", %{conn: conn} do
+      suite = suite_fixture()
+      {:ok, view, _html} = live(conn, "/suites/#{suite.id}")
+
+      view
+      |> element("#toggle-test-case-import")
+      |> render_click()
+
+      initial_upload =
+        file_input(view, "#test-case-import-form", :test_case_import, [
+          %{
+            name: "initial.csv",
+            content: "input,expected,assertion\nfirst,ok,contains\n",
+            type: "text/csv"
+          }
+        ])
+
+      render_upload(initial_upload, "initial.csv")
+
+      view
+      |> form("#test-case-import-form")
+      |> render_submit()
+
+      assert has_element?(view, "#test-case-import-preview")
+
+      replacement_upload =
+        file_input(view, "#test-case-import-form", :test_case_import, [
+          %{
+            name: "replacement.json",
+            content: ~s([{"input":"second","expected":"ok","assertion":"contains"}]),
+            type: "application/json"
+          }
+        ])
+
+      render_upload(replacement_upload, "replacement.json")
+
+      refute has_element?(view, "#test-case-import-preview")
+      refute has_element?(view, "#confirm-test-case-import")
+      assert Evals.get_suite_with_test_cases!(suite.id).test_cases == []
+    end
   end
 
   describe "visual test case display" do


### PR DESCRIPTION
## Motivation

Suite test cases can now be parsed and persisted in batches, but users still need a safe interface for reviewing files before writing data. This change connects those foundations to the existing suite screen.

- Upload one CSV or JSON file from a suite
- Preview valid and rejected row counts with row-level validation messages
- Keep preview separate from persistence until explicit confirmation
- Import valid rows atomically and refresh the suite in place
- Prevent stale previews from being confirmed after a replacement file is selected
- Keep malformed files recoverable without leaving the suite screen

Closes #97

## Test Plan

- Added LiveView coverage for mixed valid/rejected CSV preview, confirmed persistence, malformed JSON recovery, and replacement-file preview invalidation.
- The focused Suite LiveView and importer suite passes with 63 tests and zero failures.
- The full suite passes with 652 tests and zero failures.
- Formatting, static analysis, security scanning, and Dialyzer pass.

## Next Steps

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CSV and JSON import for test cases.
  * Preview imported files before saving, including valid and rejected row counts with validation details.
  * Added options to open, cancel, and replace an import.
  * Imports are confirmed only when valid test cases are available.
* **Bug Fixes**
  * Malformed JSON files now produce an error without disrupting the suite.
  * Replacing an uploaded file clears outdated preview results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->