### PR TITLE
feat(evals): add headless suite task

### DIFF
--- a/lib/mix/tasks/aludel.eval.ex
+++ b/lib/mix/tasks/aludel.eval.ex
@@ -1,0 +1,197 @@
+defmodule Mix.Tasks.Aludel.Eval do
+  @moduledoc """
+  Runs one Aludel evaluation suite and emits machine-readable JSON.
+
+      mix aludel.eval \
+        --suite-id SUITE_ID \
+        --prompt-version-id PROMPT_VERSION_ID \
+        --provider-id PROVIDER_ID
+
+  The task exits unsuccessfully when arguments or targets are invalid, execution
+  cannot complete, the suite has no test cases, or any test case fails.
+  """
+
+  @shortdoc "Runs an Aludel suite and emits JSON"
+  @requirements ["app.start"]
+
+  use Mix.Task
+
+  alias Aludel.Evals
+  alias Aludel.Prompts
+  alias Aludel.Providers
+  alias Decimal
+
+  @schema_version 1
+  @switches [suite_id: :string, prompt_version_id: :string, provider_id: :string]
+  @required_options [:suite_id, :prompt_version_id, :provider_id]
+
+  @impl Mix.Task
+  def run(args) do
+    case args |> parse_options() |> execute() do
+      {:ok, %{status: "passed"} = payload} ->
+        emit(payload)
+
+      {:ok, payload} ->
+        emit(payload)
+        Mix.raise("Evaluation did not pass")
+
+      {:error, error} ->
+        emit(error_payload(error))
+        Mix.raise(error.message)
+    end
+  end
+
+  defp parse_options(args) do
+    case OptionParser.parse(args, strict: @switches) do
+      {options, [], []} -> validate_required_options(options)
+      {_options, _positional, _invalid} -> {:error, cli_error("invalid_arguments", usage())}
+    end
+  end
+
+  defp validate_required_options(options) do
+    missing_options = Enum.reject(@required_options, &Keyword.has_key?(options, &1))
+
+    if missing_options == [] do
+      {:ok, Map.new(options)}
+    else
+      missing_flags = Enum.map_join(missing_options, ", ", &option_flag/1)
+      {:error, cli_error("invalid_arguments", "Missing required options: #{missing_flags}")}
+    end
+  end
+
+  defp execute({:error, error}) do
+    {:error, error}
+  end
+
+  defp execute({:ok, options}) do
+    with {:ok, suite} <- fetch_target("suite", fn -> Evals.get_suite!(options.suite_id) end),
+         {:ok, prompt_version} <-
+           fetch_target("prompt_version", fn ->
+             Prompts.get_prompt_version!(options.prompt_version_id)
+           end),
+         {:ok, provider} <-
+           fetch_target("provider", fn -> Providers.get_provider!(options.provider_id) end),
+         :ok <- validate_prompt_version(suite, prompt_version),
+         {:ok, suite_run} <- execute_suite(suite, prompt_version, provider) do
+      {:ok, suite_run_payload(suite_run)}
+    end
+  end
+
+  defp fetch_target(resource, fetch) do
+    {:ok, fetch.()}
+  rescue
+    _error in [Ecto.NoResultsError, Ecto.Query.CastError] ->
+      {:error, cli_error("#{resource}_not_found", "#{resource} was not found")}
+  end
+
+  defp validate_prompt_version(suite, prompt_version) do
+    if prompt_version.prompt_id == suite.prompt_id do
+      :ok
+    else
+      {:error,
+       cli_error(
+         "prompt_version_mismatch",
+         "prompt_version does not belong to the suite prompt"
+       )}
+    end
+  end
+
+  defp execute_suite(suite, prompt_version, provider) do
+    case Evals.execute_suite(suite, prompt_version, provider) do
+      {:ok, suite_run} ->
+        {:ok, suite_run}
+
+      {:error, _reason} ->
+        {:error, cli_error("execution_failed", "Suite execution could not be persisted")}
+    end
+  rescue
+    _error ->
+      {:error, cli_error("execution_failed", "Suite execution failed")}
+  catch
+    _kind, _reason ->
+      {:error, cli_error("execution_failed", "Suite execution failed")}
+  end
+
+  defp suite_run_payload(suite_run) do
+    total = suite_run.passed + suite_run.failed
+    status = if suite_run.failed == 0 and total > 0, do: "passed", else: "failed"
+
+    %{
+      type: "aludel_eval",
+      schema_version: @schema_version,
+      status: status,
+      suite_run_id: suite_run.id,
+      suite_id: suite_run.suite_id,
+      prompt_version_id: suite_run.prompt_version_id,
+      provider_id: suite_run.provider_id,
+      summary: %{
+        passed: suite_run.passed,
+        failed: suite_run.failed,
+        total: total,
+        pass_rate: pass_rate(suite_run.passed, total),
+        avg_score: decimal_to_string(suite_run.avg_score),
+        avg_cost_usd: decimal_to_string(suite_run.avg_cost_usd),
+        avg_latency_ms: suite_run.avg_latency_ms
+      },
+      results: Enum.map(suite_run.results, &result_payload/1)
+    }
+  end
+
+  defp result_payload(result) do
+    %{
+      test_case_id: result["test_case_id"],
+      status: if(result["passed"], do: "passed", else: "failed"),
+      passed: result["passed"],
+      score: result["score"],
+      output: result["output"],
+      assertion_results: Map.get(result, "assertion_results", []),
+      input_tokens: result["input_tokens"],
+      output_tokens: result["output_tokens"],
+      cost_usd: result["cost_usd"],
+      latency_ms: result["latency_ms"]
+    }
+  end
+
+  defp error_payload(error) do
+    %{
+      type: "aludel_eval",
+      schema_version: @schema_version,
+      status: "error",
+      error: error
+    }
+  end
+
+  defp cli_error(code, message) do
+    %{code: code, message: message}
+  end
+
+  defp pass_rate(_passed, 0) do
+    0.0
+  end
+
+  defp pass_rate(passed, total) do
+    Float.round(passed / total * 100, 2)
+  end
+
+  defp decimal_to_string(nil) do
+    nil
+  end
+
+  defp decimal_to_string(%Decimal{} = decimal) do
+    Decimal.to_string(decimal, :normal)
+  end
+
+  defp emit(payload) do
+    payload
+    |> Jason.encode!()
+    |> Mix.shell().info()
+  end
+
+  defp option_flag(option) do
+    "--#{option |> Atom.to_string() |> String.replace("_", "-")}"
+  end
+
+  defp usage do
+    "Usage: mix aludel.eval --suite-id ID --prompt-version-id ID --provider-id ID"
+  end
+end

--- a/test/mix/tasks/aludel.eval_test.exs
+++ b/test/mix/tasks/aludel.eval_test.exs
@@ -1,0 +1,148 @@
+defmodule Mix.Tasks.Aludel.EvalTest do
+  use Aludel.DataCase, async: false
+
+  import Aludel.EvalsFixtures
+  import Aludel.PromptsFixtures
+  import Aludel.ProvidersFixtures
+  import ExUnit.CaptureIO
+  import Mox
+
+  alias Aludel.Interfaces.HttpClientMock
+  alias Aludel.Prompts
+  alias Mix.Tasks.Aludel.Eval, as: EvalTask
+
+  test "emits passing JSON for a successful suite run" do
+    %{suite: suite, prompt_version: prompt_version, provider: provider} = evaluation_targets()
+
+    expect(HttpClientMock, :request, fn _model, _prompt, _options ->
+      {:ok, %{content: "Hello Alice", input_tokens: 5, output_tokens: 3}}
+    end)
+
+    output =
+      capture_io(fn ->
+        EvalTask.run(task_args(suite, prompt_version, provider))
+      end)
+
+    payload = Jason.decode!(output)
+
+    assert payload["type"] == "aludel_eval"
+    assert payload["schema_version"] == 1
+    assert payload["status"] == "passed"
+    assert payload["suite_id"] == suite.id
+    assert payload["prompt_version_id"] == prompt_version.id
+    assert payload["provider_id"] == provider.id
+    assert payload["summary"]["passed"] == 1
+    assert payload["summary"]["failed"] == 0
+    assert payload["summary"]["pass_rate"] == 100.0
+    assert [%{"status" => "passed", "passed" => true}] = payload["results"]
+  end
+
+  test "emits failing JSON and raises when an assertion fails" do
+    %{suite: suite, prompt_version: prompt_version, provider: provider} = evaluation_targets()
+
+    expect(HttpClientMock, :request, fn _model, _prompt, _options ->
+      {:ok, %{content: "Goodbye", input_tokens: 4, output_tokens: 2}}
+    end)
+
+    output =
+      capture_io(fn ->
+        assert_raise Mix.Error, "Evaluation did not pass", fn ->
+          EvalTask.run(task_args(suite, prompt_version, provider))
+        end
+      end)
+
+    payload = Jason.decode!(output)
+
+    assert payload["status"] == "failed"
+    assert payload["summary"]["passed"] == 0
+    assert payload["summary"]["failed"] == 1
+    assert [%{"status" => "failed", "passed" => false}] = payload["results"]
+  end
+
+  test "treats an empty suite as a failing evaluation" do
+    prompt = prompt_fixture()
+    {:ok, prompt_version} = Prompts.create_prompt_version(prompt, "Hello {{name}}")
+    suite = suite_fixture(%{prompt_id: prompt.id})
+    provider = provider_fixture()
+
+    output =
+      capture_io(fn ->
+        assert_raise Mix.Error, "Evaluation did not pass", fn ->
+          EvalTask.run(task_args(suite, prompt_version, provider))
+        end
+      end)
+
+    payload = Jason.decode!(output)
+
+    assert payload["status"] == "failed"
+    assert payload["summary"]["total"] == 0
+    assert payload["summary"]["pass_rate"] == 0.0
+    assert payload["results"] == []
+  end
+
+  test "emits a JSON error for missing required options" do
+    output =
+      capture_io(fn ->
+        assert_raise Mix.Error, ~r/Missing required options/, fn ->
+          EvalTask.run([])
+        end
+      end)
+
+    payload = Jason.decode!(output)
+
+    assert payload == %{
+             "type" => "aludel_eval",
+             "schema_version" => 1,
+             "status" => "error",
+             "error" => %{
+               "code" => "invalid_arguments",
+               "message" =>
+                 "Missing required options: --suite-id, --prompt-version-id, --provider-id"
+             }
+           }
+  end
+
+  test "rejects a prompt version from another prompt before execution" do
+    %{suite: suite, provider: provider} = evaluation_targets()
+    other_prompt = prompt_fixture()
+    {:ok, other_version} = Prompts.create_prompt_version(other_prompt, "Other {{name}}")
+
+    output =
+      capture_io(fn ->
+        assert_raise Mix.Error, "prompt_version does not belong to the suite prompt", fn ->
+          EvalTask.run(task_args(suite, other_version, provider))
+        end
+      end)
+
+    payload = Jason.decode!(output)
+
+    assert payload["status"] == "error"
+    assert payload["error"]["code"] == "prompt_version_mismatch"
+  end
+
+  defp evaluation_targets do
+    prompt = prompt_fixture()
+    {:ok, prompt_version} = Prompts.create_prompt_version(prompt, "Hello {{name}}")
+    suite = suite_fixture(%{prompt_id: prompt.id})
+
+    _test_case =
+      test_case_fixture(%{
+        suite_id: suite.id,
+        variable_values: %{"name" => "Alice"},
+        assertions: [%{"type" => "contains", "value" => "Hello"}]
+      })
+
+    %{suite: suite, prompt_version: prompt_version, provider: provider_fixture()}
+  end
+
+  defp task_args(suite, prompt_version, provider) do
+    [
+      "--suite-id",
+      suite.id,
+      "--prompt-version-id",
+      prompt_version.id,
+      "--provider-id",
+      provider.id
+    ]
+  end
+end


### PR DESCRIPTION
## Motivation

Aludel suite execution was available only through the LiveView, which prevented straightforward CI, scheduled, and terminal usage. This change adds `mix aludel.eval` as a first-class headless entrypoint while reusing the existing suite execution service.

- Require explicit suite, prompt-version, and provider IDs
- Reject prompt versions that do not belong to the suite prompt
- Emit a versioned JSON envelope with target IDs, summary metrics, and individual results
- Preserve failed suite runs for diagnosis while exiting unsuccessfully
- Exit unsuccessfully for invalid arguments, missing targets, execution errors, empty suites, or failed assertions
- Keep JSON on standard output for downstream automation

Closes #116

## Test Plan

- Added task coverage for passing evaluation output, failed assertions, empty suites, missing options, and cross-prompt version rejection.
- The focused task and suite execution suite passes with 18 tests and zero failures.
- The full suite passes with 657 tests and zero failures.
- Formatting, static analysis, security scanning, and Dialyzer pass.

## Next Steps

None.