### PR TITLE
feat(evals): add pluggable metric behaviour

### DIFF
--- a/lib/aludel/evals/assertion_evaluator.ex
+++ b/lib/aludel/evals/assertion_evaluator.ex
@@ -1,102 +1,26 @@
 defmodule Aludel.Evals.AssertionEvaluator do
-  @moduledoc false
+  @moduledoc """
+  Backward-compatible facade for behaviour-driven evaluation metrics.
+  """
 
-  alias Aludel.Evals.DeepCompare
-
-  @default_threshold 100.0
+  alias Aludel.Evals.Metric.Registry
+  alias Aludel.Evals.Metric.Result
 
   @spec evaluate(String.t(), map()) :: map()
-  def evaluate(output, %{"type" => "contains", "value" => value} = assertion) do
-    boolean_result(assertion, String.contains?(output, value))
-  end
+  def evaluate(output, assertion) do
+    case Registry.evaluate(output, assertion) do
+      {:ok, result} ->
+        Result.to_map(result, legacy_fields(result, assertion))
 
-  def evaluate(output, %{"type" => "not_contains", "value" => value} = assertion) do
-    boolean_result(assertion, not String.contains?(output, value))
-  end
-
-  def evaluate(output, %{"type" => "regex", "value" => pattern} = assertion) do
-    passed =
-      case Regex.compile(pattern) do
-        {:ok, regex} -> Regex.match?(regex, output)
-        {:error, _reason} -> false
-      end
-
-    boolean_result(assertion, passed)
-  end
-
-  def evaluate(output, %{"type" => "exact_match", "value" => value} = assertion) do
-    boolean_result(assertion, output == value)
-  end
-
-  def evaluate(output, %{"type" => "json_field", "field" => field, "expected" => expected}) do
-    case decode_json_output(output) do
-      {:ok, json} ->
-        actual_value = get_in(json, String.split(field, "."))
-        passed = compare_json_values(actual_value, expected)
-
-        %{
-          "type" => "json_field",
-          "passed" => passed,
-          "score" => score_from_boolean(passed),
-          "value" => %{"field" => field, "expected" => expected},
-          "actual_value" => actual_value
-        }
-
-      {:error, _reason} ->
-        %{
-          "type" => "json_field",
-          "passed" => false,
-          "score" => 0.0,
-          "value" => %{"field" => field, "expected" => expected},
-          "actual_value" => nil
-        }
+      :error ->
+        unsupported_result(assertion)
     end
-  end
-
-  def evaluate(output, %{"type" => "json_deep_compare", "expected" => expected} = assertion) do
-    threshold = normalize_threshold(assertion)
-
-    case decode_json_output(output) do
-      {:ok, json} ->
-        score_details = DeepCompare.compare(json, expected)
-        score = DeepCompare.score(score_details)
-        passed = score >= threshold
-
-        %{
-          "type" => "json_deep_compare",
-          "passed" => passed,
-          "score" => score,
-          "value" => %{"expected" => expected, "threshold" => threshold},
-          "score_details" => score_details
-        }
-
-      {:error, _reason} ->
-        %{
-          "type" => "json_deep_compare",
-          "passed" => false,
-          "score" => 0.0,
-          "value" => %{"expected" => expected, "threshold" => threshold},
-          "score_details" => %{
-            "matches" => 0,
-            "total" => 0,
-            "field_scores" => %{},
-            "comparisons" => %{}
-          }
-        }
-    end
-  end
-
-  def evaluate(_output, assertion) do
-    %{
-      "type" => Map.get(assertion, "type"),
-      "passed" => false,
-      "score" => 0.0,
-      "value" => Map.get(assertion, "value")
-    }
   end
 
   @spec score_for_results([map()]) :: float() | nil
-  def score_for_results([]), do: nil
+  def score_for_results([]) do
+    nil
+  end
 
   def score_for_results(results) do
     scores =
@@ -111,37 +35,50 @@ defmodule Aludel.Evals.AssertionEvaluator do
     end
   end
 
-  defp boolean_result(assertion, passed) do
+  defp legacy_fields(%Result{type: type}, assertion)
+       when type in ["contains", "not_contains", "regex", "exact_match"] do
+    %{"value" => assertion["value"]}
+  end
+
+  defp legacy_fields(
+         %Result{metadata: %{"valid_configuration" => false}},
+         assertion
+       ) do
+    %{"value" => Map.get(assertion, "value")}
+  end
+
+  defp legacy_fields(%Result{type: "json_field", metadata: metadata}, assertion) do
     %{
-      "type" => assertion["type"],
-      "passed" => passed,
-      "score" => score_from_boolean(passed),
-      "value" => assertion["value"]
+      "value" => %{
+        "field" => assertion["field"],
+        "expected" => assertion["expected"]
+      },
+      "actual_value" => metadata["actual_value"]
     }
   end
 
-  defp score_from_boolean(true), do: 100.0
-  defp score_from_boolean(false), do: 0.0
-
-  defp normalize_threshold(%{"threshold" => threshold}) when is_integer(threshold),
-    do: threshold / 1
-
-  defp normalize_threshold(%{"threshold" => threshold}) when is_float(threshold), do: threshold
-  defp normalize_threshold(_assertion), do: @default_threshold
-
-  defp decode_json_output(output) do
-    output
-    |> String.trim()
-    |> String.replace(~r/^```json\s*/i, "")
-    |> String.replace(~r/^```\s*/, "")
-    |> String.replace(~r/```\s*$/, "")
-    |> String.trim()
-    |> Jason.decode()
+  defp legacy_fields(%Result{type: "json_deep_compare", metadata: metadata}, assertion) do
+    %{
+      "value" => %{
+        "expected" => assertion["expected"],
+        "threshold" => metadata["threshold"]
+      },
+      "score_details" => metadata["score_details"]
+    }
   end
 
-  defp compare_json_values(actual, expected) when is_map(actual) or is_list(actual) do
-    Jason.encode!(actual) == Jason.encode!(expected)
+  defp legacy_fields(_result, assertion) do
+    %{"value" => Map.get(assertion, "value")}
   end
 
-  defp compare_json_values(actual, expected), do: actual == expected
+  defp unsupported_result(assertion) do
+    %Result{
+      type: Map.get(assertion, "type"),
+      passed: false,
+      score: 0.0,
+      reason: "Unsupported metric type",
+      metadata: %{}
+    }
+    |> Result.to_map(%{"value" => Map.get(assertion, "value")})
+  end
 end

--- a/lib/aludel/evals/assertion_parser.ex
+++ b/lib/aludel/evals/assertion_parser.ex
@@ -3,14 +3,7 @@ defmodule Aludel.Evals.AssertionParser do
   Parses and validates assertion payloads from suite editor forms.
   """
 
-  @valid_types [
-    "contains",
-    "not_contains",
-    "regex",
-    "exact_match",
-    "json_field",
-    "json_deep_compare"
-  ]
+  alias Aludel.Evals.Metric.Registry
 
   @type parse_mode :: :json | :visual
 
@@ -212,11 +205,12 @@ defmodule Aludel.Evals.AssertionParser do
 
   defp validate_assertion(assertion, idx) do
     type = Map.get(assertion, "type")
+    valid_types = Registry.types()
 
     cond do
-      type not in @valid_types ->
+      type not in valid_types ->
         {:error,
-         "Invalid assertion type at index #{idx}: #{inspect(type)}. Must be one of: #{Enum.join(@valid_types, ", ")}"}
+         "Invalid assertion type at index #{idx}: #{inspect(type)}. Must be one of: #{Enum.join(valid_types, ", ")}"}
 
       type == "json_field" ->
         validate_json_field_assertion(assertion, idx)

--- a/lib/aludel/evals/metric.ex
+++ b/lib/aludel/evals/metric.ex
@@ -10,6 +10,14 @@ defmodule Aludel.Evals.Metric do
 
   @default_threshold 100.0
 
+  @type json_value ::
+          nil
+          | boolean()
+          | number()
+          | String.t()
+          | [json_value()]
+          | %{optional(String.t()) => json_value()}
+
   @callback type() :: String.t()
   @callback evaluate(String.t(), map()) :: Result.t()
 
@@ -24,7 +32,7 @@ defmodule Aludel.Evals.Metric do
     }
   end
 
-  @spec decode_json(String.t()) :: {:ok, Jason.decode_value()} | {:error, Jason.DecodeError.t()}
+  @spec decode_json(String.t()) :: {:ok, json_value()} | {:error, Jason.DecodeError.t()}
   def decode_json(output) do
     output
     |> String.trim()

--- a/lib/aludel/evals/metric.ex
+++ b/lib/aludel/evals/metric.ex
@@ -1,0 +1,78 @@
+defmodule Aludel.Evals.Metric do
+  @moduledoc """
+  Contract and shared helpers for evaluation metrics.
+
+  Metrics return a normalized result. Compatibility with historical assertion
+  result maps is handled by `Aludel.Evals.AssertionEvaluator`.
+  """
+
+  alias Aludel.Evals.Metric.Result
+
+  @default_threshold 100.0
+
+  @callback type() :: String.t()
+  @callback evaluate(String.t(), map()) :: Result.t()
+
+  @spec boolean_result(String.t(), boolean(), String.t(), String.t(), map()) :: Result.t()
+  def boolean_result(type, passed, success_reason, failure_reason, metadata \\ %{}) do
+    %Result{
+      type: type,
+      passed: passed,
+      score: score_from_boolean(passed),
+      reason: if(passed, do: success_reason, else: failure_reason),
+      metadata: metadata
+    }
+  end
+
+  @spec decode_json(String.t()) :: {:ok, Jason.decode_value()} | {:error, Jason.DecodeError.t()}
+  def decode_json(output) do
+    output
+    |> String.trim()
+    |> String.replace(~r/^```json\s*/i, "")
+    |> String.replace(~r/^```\s*/, "")
+    |> String.replace(~r/```\s*$/, "")
+    |> String.trim()
+    |> Jason.decode()
+  end
+
+  @spec compare_json_values(term(), term()) :: boolean()
+  def compare_json_values(actual, expected) when is_map(actual) or is_list(actual) do
+    Jason.encode!(actual) == Jason.encode!(expected)
+  end
+
+  def compare_json_values(actual, expected) do
+    actual == expected
+  end
+
+  @spec normalize_threshold(map()) :: float()
+  def normalize_threshold(%{"threshold" => threshold}) when is_integer(threshold) do
+    threshold / 1
+  end
+
+  def normalize_threshold(%{"threshold" => threshold}) when is_float(threshold) do
+    threshold
+  end
+
+  def normalize_threshold(_assertion) do
+    @default_threshold
+  end
+
+  @spec invalid_result(String.t()) :: Result.t()
+  def invalid_result(type) do
+    %Result{
+      type: type,
+      passed: false,
+      score: 0.0,
+      reason: "Invalid metric configuration",
+      metadata: %{"valid_configuration" => false}
+    }
+  end
+
+  defp score_from_boolean(true) do
+    100.0
+  end
+
+  defp score_from_boolean(false) do
+    0.0
+  end
+end

--- a/lib/aludel/evals/metric/registry.ex
+++ b/lib/aludel/evals/metric/registry.ex
@@ -1,0 +1,49 @@
+defmodule Aludel.Evals.Metric.Registry do
+  @moduledoc """
+  Registry for the built-in evaluation metrics.
+
+  New metric modules are added here without changing suite execution or result
+  aggregation code.
+  """
+
+  alias Aludel.Evals.Metrics.Contains
+  alias Aludel.Evals.Metrics.ExactMatch
+  alias Aludel.Evals.Metrics.JSONDeepCompare
+  alias Aludel.Evals.Metrics.JSONField
+  alias Aludel.Evals.Metrics.NotContains
+  alias Aludel.Evals.Metrics.Regex
+
+  @metrics [
+    {"contains", Contains},
+    {"not_contains", NotContains},
+    {"regex", Regex},
+    {"exact_match", ExactMatch},
+    {"json_field", JSONField},
+    {"json_deep_compare", JSONDeepCompare}
+  ]
+
+  @spec types() :: [String.t()]
+  def types do
+    Enum.map(@metrics, &elem(&1, 0))
+  end
+
+  @spec fetch(String.t()) :: {:ok, module()} | :error
+  def fetch(type) do
+    case List.keyfind(@metrics, type, 0) do
+      {_type, module} -> {:ok, module}
+      nil -> :error
+    end
+  end
+
+  @spec evaluate(String.t(), map()) :: {:ok, Aludel.Evals.Metric.Result.t()} | :error
+  def evaluate(output, %{"type" => type} = assertion) do
+    case fetch(type) do
+      {:ok, module} -> {:ok, module.evaluate(output, assertion)}
+      :error -> :error
+    end
+  end
+
+  def evaluate(_output, _assertion) do
+    :error
+  end
+end

--- a/lib/aludel/evals/metric/result.ex
+++ b/lib/aludel/evals/metric/result.ex
@@ -1,0 +1,28 @@
+defmodule Aludel.Evals.Metric.Result do
+  @moduledoc """
+  Normalized result returned by every evaluation metric.
+  """
+
+  @enforce_keys [:type, :score, :passed, :reason, :metadata]
+  defstruct [:type, :score, :passed, :reason, :metadata]
+
+  @type t :: %__MODULE__{
+          type: String.t(),
+          score: float(),
+          passed: boolean(),
+          reason: String.t(),
+          metadata: map()
+        }
+
+  @spec to_map(t(), map()) :: map()
+  def to_map(%__MODULE__{} = result, legacy_fields \\ %{}) do
+    %{
+      "type" => result.type,
+      "score" => result.score,
+      "passed" => result.passed,
+      "reason" => result.reason,
+      "metadata" => result.metadata
+    }
+    |> Map.merge(legacy_fields)
+  end
+end

--- a/lib/aludel/evals/metrics/contains.ex
+++ b/lib/aludel/evals/metrics/contains.ex
@@ -1,0 +1,26 @@
+defmodule Aludel.Evals.Metrics.Contains do
+  @moduledoc false
+
+  @behaviour Aludel.Evals.Metric
+
+  alias Aludel.Evals.Metric
+
+  @impl true
+  def type do
+    "contains"
+  end
+
+  @impl true
+  def evaluate(output, %{"value" => value}) do
+    Metric.boolean_result(
+      type(),
+      String.contains?(output, value),
+      "Output contains expected value",
+      "Output does not contain expected value"
+    )
+  end
+
+  def evaluate(_output, _assertion) do
+    Metric.invalid_result(type())
+  end
+end

--- a/lib/aludel/evals/metrics/exact_match.ex
+++ b/lib/aludel/evals/metrics/exact_match.ex
@@ -1,0 +1,26 @@
+defmodule Aludel.Evals.Metrics.ExactMatch do
+  @moduledoc false
+
+  @behaviour Aludel.Evals.Metric
+
+  alias Aludel.Evals.Metric
+
+  @impl true
+  def type do
+    "exact_match"
+  end
+
+  @impl true
+  def evaluate(output, %{"value" => value}) do
+    Metric.boolean_result(
+      type(),
+      output == value,
+      "Output exactly matches expected value",
+      "Output does not exactly match expected value"
+    )
+  end
+
+  def evaluate(_output, _assertion) do
+    Metric.invalid_result(type())
+  end
+end

--- a/lib/aludel/evals/metrics/json_deep_compare.ex
+++ b/lib/aludel/evals/metrics/json_deep_compare.ex
@@ -1,0 +1,70 @@
+defmodule Aludel.Evals.Metrics.JSONDeepCompare do
+  @moduledoc false
+
+  @behaviour Aludel.Evals.Metric
+
+  alias Aludel.Evals.DeepCompare
+  alias Aludel.Evals.Metric
+  alias Aludel.Evals.Metric.Result
+
+  @empty_score_details %{
+    "matches" => 0,
+    "total" => 0,
+    "field_scores" => %{},
+    "comparisons" => %{}
+  }
+
+  @impl true
+  def type do
+    "json_deep_compare"
+  end
+
+  @impl true
+  def evaluate(output, %{"expected" => _expected} = assertion) do
+    threshold = Metric.normalize_threshold(assertion)
+
+    case Metric.decode_json(output) do
+      {:ok, json} ->
+        score_details = DeepCompare.compare(json, assertion["expected"])
+        score = DeepCompare.score(score_details)
+        passed = score >= threshold
+
+        %Result{
+          type: type(),
+          passed: passed,
+          score: score,
+          reason: comparison_reason(passed, threshold),
+          metadata: %{
+            "decoded" => true,
+            "score_details" => score_details,
+            "threshold" => threshold
+          }
+        }
+
+      {:error, _reason} ->
+        %Result{
+          type: type(),
+          passed: false,
+          score: 0.0,
+          reason: "Output is not valid JSON",
+          metadata: %{
+            "decoded" => false,
+            "score_details" => @empty_score_details,
+            "threshold" => threshold
+          }
+        }
+    end
+  end
+
+  def evaluate(_output, _assertion) do
+    Metric.invalid_result(type())
+  end
+
+  defp comparison_reason(true, threshold) do
+    "Deep comparison meets the #{threshold}% threshold"
+  end
+
+  defp comparison_reason(false, threshold) do
+    "Deep comparison is below the #{threshold}% threshold"
+  end
+end

--- a/lib/aludel/evals/metrics/json_field.ex
+++ b/lib/aludel/evals/metrics/json_field.ex
@@ -1,0 +1,51 @@
+defmodule Aludel.Evals.Metrics.JSONField do
+  @moduledoc false
+
+  @behaviour Aludel.Evals.Metric
+
+  alias Aludel.Evals.Metric
+  alias Aludel.Evals.Metric.Result
+
+  @impl true
+  def type do
+    "json_field"
+  end
+
+  @impl true
+  def evaluate(output, %{"field" => field, "expected" => expected}) do
+    case Metric.decode_json(output) do
+      {:ok, json} ->
+        actual_value = get_in(json, String.split(field, "."))
+        passed = Metric.compare_json_values(actual_value, expected)
+
+        Metric.boolean_result(
+          type(),
+          passed,
+          "JSON field matches expected value",
+          "JSON field does not match expected value",
+          %{
+            "actual_value" => actual_value,
+            "decoded" => true,
+            "field" => field
+          }
+        )
+
+      {:error, _reason} ->
+        %Result{
+          type: type(),
+          passed: false,
+          score: 0.0,
+          reason: "Output is not valid JSON",
+          metadata: %{
+            "actual_value" => nil,
+            "decoded" => false,
+            "field" => field
+          }
+        }
+    end
+  end
+
+  def evaluate(_output, _assertion) do
+    Metric.invalid_result(type())
+  end
+end

--- a/lib/aludel/evals/metrics/not_contains.ex
+++ b/lib/aludel/evals/metrics/not_contains.ex
@@ -1,0 +1,26 @@
+defmodule Aludel.Evals.Metrics.NotContains do
+  @moduledoc false
+
+  @behaviour Aludel.Evals.Metric
+
+  alias Aludel.Evals.Metric
+
+  @impl true
+  def type do
+    "not_contains"
+  end
+
+  @impl true
+  def evaluate(output, %{"value" => value}) do
+    Metric.boolean_result(
+      type(),
+      not String.contains?(output, value),
+      "Output excludes disallowed value",
+      "Output contains disallowed value"
+    )
+  end
+
+  def evaluate(_output, _assertion) do
+    Metric.invalid_result(type())
+  end
+end

--- a/lib/aludel/evals/metrics/regex.ex
+++ b/lib/aludel/evals/metrics/regex.ex
@@ -1,0 +1,39 @@
+defmodule Aludel.Evals.Metrics.Regex do
+  @moduledoc false
+
+  @behaviour Aludel.Evals.Metric
+
+  alias Aludel.Evals.Metric
+
+  @impl true
+  def type do
+    "regex"
+  end
+
+  @impl true
+  def evaluate(output, %{"value" => pattern}) do
+    case Regex.compile(pattern) do
+      {:ok, regex} ->
+        Metric.boolean_result(
+          type(),
+          Regex.match?(regex, output),
+          "Output matches regular expression",
+          "Output does not match regular expression",
+          %{"valid_pattern" => true}
+        )
+
+      {:error, _reason} ->
+        Metric.boolean_result(
+          type(),
+          false,
+          "Output matches regular expression",
+          "Invalid regular expression",
+          %{"valid_pattern" => false}
+        )
+    end
+  end
+
+  def evaluate(_output, _assertion) do
+    Metric.invalid_result(type())
+  end
+end

--- a/lib/aludel/web/live/suite_live/show.html.heex
+++ b/lib/aludel/web/live/suite_live/show.html.heex
@@ -854,6 +854,16 @@
                         <div style="font-size: 11px; font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 10px;">
                           Assertions
                         </div>
+                        <%= for {assertion, assertion_index} <- Enum.with_index(result["assertion_results"]) do %>
+                          <%= if assertion["reason"] do %>
+                            <div
+                              id={"suite-result-metric-reason-#{suite_run.id}-#{result["test_case_id"]}-#{assertion_index}"}
+                              style="margin-bottom: 8px; padding: 8px 10px; border-radius: 6px; background: var(--bg-tertiary); color: var(--text-secondary); font-size: 12px;"
+                            >
+                              {assertion["reason"]}
+                            </div>
+                          <% end %>
+                        <% end %>
                         <div
                           id={"suite-result-assertions-table-#{suite_run.id}-#{result["test_case_id"]}"}
                           style="overflow-x: auto; max-width: 100%;"

--- a/test/aludel/evals/metric_test.exs
+++ b/test/aludel/evals/metric_test.exs
@@ -1,0 +1,181 @@
+defmodule Aludel.Evals.MetricTest do
+  use ExUnit.Case, async: true
+
+  alias Aludel.Evals.AssertionEvaluator
+  alias Aludel.Evals.Metric.Registry
+
+  describe "registry" do
+    test "lists the supported metric types in form order" do
+      assert Registry.types() == [
+               "contains",
+               "not_contains",
+               "regex",
+               "exact_match",
+               "json_field",
+               "json_deep_compare"
+             ]
+    end
+
+    test "resolves every supported type to a metric module" do
+      for type <- Registry.types() do
+        assert {:ok, module} = Registry.fetch(type)
+        assert Code.ensure_loaded?(module)
+        assert function_exported?(module, :type, 0)
+        assert function_exported?(module, :evaluate, 2)
+        assert module.type() == type
+      end
+    end
+  end
+
+  describe "normalized results" do
+    test "preserves legacy string assertion fields" do
+      result =
+        AssertionEvaluator.evaluate("hello world", %{"type" => "contains", "value" => "hello"})
+
+      assert %{
+               "type" => "contains",
+               "passed" => true,
+               "score" => 100.0,
+               "reason" => reason,
+               "metadata" => %{},
+               "value" => "hello"
+             } = result
+
+      assert is_binary(reason)
+    end
+
+    test "explains invalid regular expressions" do
+      result = AssertionEvaluator.evaluate("hello", %{"type" => "regex", "value" => "["})
+
+      assert %{
+               "passed" => false,
+               "reason" => "Invalid regular expression",
+               "metadata" => %{"valid_pattern" => false}
+             } = result
+
+      assert result["score"] == 0.0
+    end
+
+    test "normalizes JSON field evidence while preserving actual_value" do
+      result =
+        AssertionEvaluator.evaluate(~s({"count": 2}), %{
+          "type" => "json_field",
+          "field" => "count",
+          "expected" => 2
+        })
+
+      assert %{
+               "passed" => true,
+               "actual_value" => 2,
+               "metadata" => %{
+                 "actual_value" => 2,
+                 "decoded" => true,
+                 "field" => "count"
+               }
+             } = result
+    end
+
+    test "normalizes deep comparison evidence while preserving score_details" do
+      result =
+        AssertionEvaluator.evaluate(~s({"status":"ok","count":1}), %{
+          "type" => "json_deep_compare",
+          "expected" => %{"status" => "ok", "count" => 2},
+          "threshold" => 50
+        })
+
+      assert %{
+               "passed" => true,
+               "score" => 50.0,
+               "score_details" => score_details,
+               "metadata" => %{
+                 "decoded" => true,
+                 "threshold" => 50.0
+               }
+             } = result
+
+      assert result["metadata"]["score_details"] == score_details
+    end
+
+    test "returns a normalized failure for unknown metric types" do
+      result =
+        AssertionEvaluator.evaluate("output", %{
+          "type" => "unknown",
+          "value" => "value"
+        })
+
+      assert %{
+               "type" => "unknown",
+               "passed" => false,
+               "reason" => "Unsupported metric type",
+               "metadata" => %{},
+               "value" => "value"
+             } = result
+
+      assert result["score"] == 0.0
+    end
+
+    test "returns normalized failures for malformed known metrics" do
+      assertions = [
+        %{"type" => "contains"},
+        %{"type" => "not_contains"},
+        %{"type" => "regex"},
+        %{"type" => "exact_match"},
+        %{"type" => "json_field", "field" => "status"},
+        %{"type" => "json_deep_compare"}
+      ]
+
+      for assertion <- assertions do
+        result = AssertionEvaluator.evaluate("null", assertion)
+
+        assert result["type"] == assertion["type"]
+        assert result["passed"] == false
+        assert result["score"] == 0.0
+        assert result["reason"] == "Invalid metric configuration"
+        assert result["metadata"] == %{"valid_configuration" => false}
+      end
+    end
+
+    test "returns normalized JSON decoding failures" do
+      json_field =
+        AssertionEvaluator.evaluate("not json", %{
+          "type" => "json_field",
+          "field" => "status",
+          "expected" => "ok"
+        })
+
+      deep_compare =
+        AssertionEvaluator.evaluate("not json", %{
+          "type" => "json_deep_compare",
+          "expected" => %{"status" => "ok"}
+        })
+
+      for result <- [json_field, deep_compare] do
+        assert result["passed"] == false
+        assert result["score"] == 0.0
+        assert result["reason"] == "Output is not valid JSON"
+        assert result["metadata"]["decoded"] == false
+      end
+    end
+  end
+
+  describe "score_for_results/1" do
+    test "averages numeric scores and rounds to one decimal place" do
+      assert AssertionEvaluator.score_for_results([
+               %{"score" => 100.0},
+               %{"score" => 0.0},
+               %{"score" => 33.33}
+             ]) == 44.4
+    end
+
+    test "ignores nonnumeric scores and handles missing scores" do
+      assert AssertionEvaluator.score_for_results([
+               %{"score" => 100.0},
+               %{"score" => nil},
+               %{}
+             ]) == 100.0
+
+      assert AssertionEvaluator.score_for_results([%{"score" => nil}, %{}]) == nil
+      assert AssertionEvaluator.score_for_results([]) == nil
+    end
+  end
+end

--- a/test/aludel/evals_test.exs
+++ b/test/aludel/evals_test.exs
@@ -635,6 +635,17 @@ defmodule Aludel.EvalsTest do
       assert {:ok, suite_run} = Evals.execute_suite(suite, version, provider)
       assert suite_run.passed == 1
       assert suite_run.failed == 0
+
+      assert [
+               %{
+                 "assertion_results" => [
+                   %{
+                     "reason" => "Output contains expected value",
+                     "metadata" => %{}
+                   }
+                 ]
+               }
+             ] = suite_run.results
     end
 
     test "evaluates not_contains assertion" do

--- a/test/aludel_web/export_controller_test.exs
+++ b/test/aludel_web/export_controller_test.exs
@@ -82,6 +82,11 @@ defmodule Aludel.Web.ExportControllerTest do
                   "type" => "json_deep_compare",
                   "passed" => true,
                   "score" => 75.0,
+                  "reason" => "Deep comparison meets the 70.0% threshold",
+                  "metadata" => %{
+                    "decoded" => true,
+                    "threshold" => 70.0
+                  },
                   "value" => %{
                     "expected" => %{
                       "status" => "ok",
@@ -142,6 +147,11 @@ defmodule Aludel.Web.ExportControllerTest do
                    %{
                      "passed" => true,
                      "score" => 75.0,
+                     "reason" => "Deep comparison meets the 70.0% threshold",
+                     "metadata" => %{
+                       "decoded" => true,
+                       "threshold" => 70.0
+                     },
                      "score_details" => %{
                        "field_scores" => %{
                          "count" => 0,

--- a/test/aludel_web/live/suite_live/show_test.exs
+++ b/test/aludel_web/live/suite_live/show_test.exs
@@ -1147,6 +1147,11 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
                   "type" => "json_deep_compare",
                   "passed" => true,
                   "score" => 75.0,
+                  "reason" => "Deep comparison meets the 70.0% threshold",
+                  "metadata" => %{
+                    "decoded" => true,
+                    "threshold" => 70.0
+                  },
                   "value" => %{
                     "expected" => %{
                       "status" => "ok",
@@ -1191,6 +1196,12 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
                view,
                "#suite-result-score-#{suite_run.id}-#{test_case.id}",
                "75.0% match"
+             )
+
+      assert has_element?(
+               view,
+               "#suite-result-metric-reason-#{suite_run.id}-#{test_case.id}-0",
+               "Deep comparison meets the 70.0% threshold"
              )
 
       assert has_element?(

--- a/test/mix/tasks/aludel.eval_test.exs
+++ b/test/mix/tasks/aludel.eval_test.exs
@@ -34,7 +34,19 @@ defmodule Mix.Tasks.Aludel.EvalTest do
     assert payload["summary"]["passed"] == 1
     assert payload["summary"]["failed"] == 0
     assert payload["summary"]["pass_rate"] == 100.0
-    assert [%{"status" => "passed", "passed" => true}] = payload["results"]
+
+    assert [
+             %{
+               "status" => "passed",
+               "passed" => true,
+               "assertion_results" => [
+                 %{
+                   "reason" => "Output contains expected value",
+                   "metadata" => %{}
+                 }
+               ]
+             }
+           ] = payload["results"]
   end
 
   test "emits failing JSON and raises when an assertion fails" do


### PR DESCRIPTION
## Motivation

Evaluation metric selection was duplicated across parsing and execution, which made new metric types require changes in multiple central modules and produced inconsistent result evidence.

This change introduces a metric behaviour, normalized result contract, and registry for the six existing assertion types. It keeps historical result fields compatible, fails malformed metric configurations safely, persists and exports reason/metadata evidence, and displays metric explanations in suite results.

## Test Plan

- Added focused coverage for every registered metric, malformed and unknown configurations, invalid JSON, and score aggregation.
- Verified normalized evidence through suite persistence, JSON export, and headless evaluation output.
- Added LiveView coverage using a stable metric-reason selector.
- Full project gate passes with 670 tests and no static-analysis findings.

Closes #117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added standardized evaluation results with scores, pass/fail status, explanations, and supporting metadata.
  * Added support for contains, exclusion, exact match, regular expression, JSON field, and deep JSON comparison metrics.
  * Added threshold-based scoring for deep JSON comparisons.
  * Assertion reasons and evaluation details are now displayed in suite results and included in exports.

* **Bug Fixes**
  * Invalid metrics, malformed configurations, invalid patterns, and JSON decoding failures now return clear failure explanations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->