### PR TITLE
feat(evals): persist structured execution artifacts

### DIFF
--- a/lib/aludel/evals.ex
+++ b/lib/aludel/evals.ex
@@ -15,6 +15,7 @@ defmodule Aludel.Evals do
   }
 
   alias Aludel.Execution
+  alias Aludel.Execution.Artifact
   alias Aludel.Prompts.PromptVersion
   alias Aludel.Providers.Provider
   alias Aludel.Storage
@@ -486,14 +487,24 @@ defmodule Aludel.Evals do
       }
     }
 
-    case Execution.execute(request) do
+    case Execution.execute_with_artifacts(request) do
       {:ok, result} ->
         assertion_results = build_assertion_results(test_case.assertions, result.output)
         passed = Enum.all?(assertion_results, & &1["passed"])
-        successful_test_case_result(test_case.id, result, passed, assertion_results)
+        score = AssertionEvaluator.score_for_results(assertion_results)
+        artifacts = Artifact.put_metrics(result.artifacts, assertion_results, score)
 
-      {:error, reason} ->
-        failed_test_case_result(test_case.id, reason)
+        successful_test_case_result(
+          test_case.id,
+          result,
+          passed,
+          score,
+          assertion_results,
+          artifacts
+        )
+
+      {:error, reason, artifacts} ->
+        failed_test_case_result(test_case.id, reason, artifacts)
     end
   end
 
@@ -501,22 +512,30 @@ defmodule Aludel.Evals do
     Enum.map(assertions, &AssertionEvaluator.evaluate(output, &1))
   end
 
-  defp successful_test_case_result(test_case_id, result, passed, assertion_results) do
+  defp successful_test_case_result(
+         test_case_id,
+         result,
+         passed,
+         score,
+         assertion_results,
+         artifacts
+       ) do
     %{
       "test_case_id" => test_case_id,
       "passed" => passed,
-      "score" => AssertionEvaluator.score_for_results(assertion_results),
+      "score" => score,
       "output" => result.output,
       "assertion_results" => assertion_results,
       "input_tokens" => result.input_tokens,
       "output_tokens" => result.output_tokens,
       "cost_usd" => result.cost_usd,
       "latency_ms" => result.latency_ms,
-      "metadata" => result.metadata
+      "metadata" => result.metadata,
+      "artifacts" => artifacts
     }
   end
 
-  defp failed_test_case_result(test_case_id, reason) do
+  defp failed_test_case_result(test_case_id, reason, artifacts) do
     %{
       "test_case_id" => test_case_id,
       "passed" => false,
@@ -527,7 +546,8 @@ defmodule Aludel.Evals do
       "output_tokens" => nil,
       "cost_usd" => nil,
       "latency_ms" => nil,
-      "metadata" => nil
+      "metadata" => nil,
+      "artifacts" => artifacts
     }
   end
 

--- a/lib/aludel/execution.ex
+++ b/lib/aludel/execution.ex
@@ -4,6 +4,7 @@ defmodule Aludel.Execution do
   """
 
   alias Aludel.Evals.TestCaseDocument
+  alias Aludel.Execution.Artifact
   alias Aludel.Executor
   alias Aludel.LLM
   alias Aludel.Prompts.PromptVersion
@@ -22,8 +23,35 @@ defmodule Aludel.Execution do
           metadata: map()
         }
 
-  @spec execute(request()) :: {:ok, Executor.result()} | {:error, term()}
+  @type result :: %{
+          output: String.t(),
+          input_tokens: non_neg_integer() | nil,
+          output_tokens: non_neg_integer() | nil,
+          latency_ms: non_neg_integer() | nil,
+          cost_usd: float() | nil,
+          metadata: map() | nil,
+          artifacts: map()
+        }
+
+  @spec execute(request()) :: {:ok, result()} | {:error, term()}
   def execute(
+        %{
+          kind: kind,
+          prompt_version: %PromptVersion{},
+          variables: variables,
+          provider: %Provider{}
+        } = request
+      )
+      when kind in [:run, :suite] and is_map(variables) do
+    case execute_with_artifacts(request) do
+      {:ok, result} -> {:ok, result}
+      {:error, reason, _artifacts} -> {:error, reason}
+    end
+  end
+
+  @spec execute_with_artifacts(request()) ::
+          {:ok, result()} | {:error, term(), map()}
+  def execute_with_artifacts(
         %{
           kind: kind,
           prompt_version: %PromptVersion{} = prompt_version,
@@ -39,23 +67,34 @@ defmodule Aludel.Execution do
          {:ok, execution_mode} <- Executor.configured_execution_mode() do
       case execution_mode do
         :callback ->
-          execute_callback(kind, prompt_version, variables, provider, loaded_documents, metadata)
+          execute_callback(
+            request,
+            kind,
+            prompt_version,
+            variables,
+            provider,
+            loaded_documents,
+            metadata
+          )
 
         _mode ->
-          execute_native(prompt_version, variables, provider, loaded_documents)
+          execute_native(request, prompt_version, variables, provider, loaded_documents)
       end
+    else
+      {:error, reason} -> {:error, reason, Artifact.start_unavailable(request, reason)}
     end
   end
 
-  defp execute_native(prompt_version, variables, provider, documents) do
+  defp execute_native(request, prompt_version, variables, provider, documents) do
     rendered_prompt = render_template(prompt_version.template, variables)
+    artifacts = Artifact.start_native(request, rendered_prompt, documents)
 
-    documents =
+    llm_documents =
       Enum.map(documents, fn document ->
         %{data: document.data, content_type: document.content_type}
       end)
 
-    opts = if documents == [], do: [], else: [documents: documents]
+    opts = if llm_documents == [], do: [], else: [documents: llm_documents]
 
     case LLM.call(provider, rendered_prompt, opts) do
       {:ok, result} ->
@@ -66,20 +105,34 @@ defmodule Aludel.Execution do
            output_tokens: result.output_tokens,
            latency_ms: result.latency_ms,
            cost_usd: result.cost_usd,
-           metadata: nil
+           metadata: nil,
+           artifacts: Artifact.complete(artifacts, result.output, nil)
          }}
 
       {:error, reason} ->
-        {:error, reason}
+        {:error, reason, Artifact.fail(artifacts, reason)}
     end
   end
 
-  defp execute_callback(kind, prompt_version, variables, provider, documents, metadata) do
-    with {:ok, executor} <- Executor.configured_executor() do
-      input = callback_input(kind, prompt_version, variables, provider, documents, metadata)
+  defp execute_callback(
+         request,
+         kind,
+         prompt_version,
+         variables,
+         provider,
+         documents,
+         metadata
+       ) do
+    input = callback_input(kind, prompt_version, variables, provider, documents, metadata)
+    artifacts = Artifact.start_callback(request, input)
 
-      safe_invoke_callback(executor, input)
-      |> normalize_callback_result()
+    with {:ok, executor} <- Executor.configured_executor(),
+         callback_result <- safe_invoke_callback(executor, input),
+         {:ok, result} <- normalize_callback_result(callback_result) do
+      {:ok,
+       Map.put(result, :artifacts, Artifact.complete(artifacts, result.output, result.metadata))}
+    else
+      {:error, reason} -> {:error, reason, Artifact.fail(artifacts, reason)}
     end
   end
 

--- a/lib/aludel/execution/artifact.ex
+++ b/lib/aludel/execution/artifact.ex
@@ -1,0 +1,180 @@
+defmodule Aludel.Execution.Artifact do
+  @moduledoc false
+
+  alias Aludel.Prompts.PromptVersion
+  alias Aludel.Providers.Provider
+
+  @schema_version 1
+  @max_error_length 4_000
+
+  @spec start_native(map(), String.t(), [map()]) :: map()
+  def start_native(request, rendered_prompt, documents) do
+    start(
+      "native",
+      "llm_call",
+      request,
+      documents,
+      %{"rendered_prompt" => rendered_prompt}
+    )
+  end
+
+  @spec start_callback(map(), map()) :: map()
+  def start_callback(request, callback_input) do
+    start(
+      "callback",
+      "executor_callback",
+      request,
+      callback_input.documents,
+      %{
+        "prompt_version" => normalize_prompt_version(callback_input.prompt_version, true)
+      }
+    )
+  end
+
+  @spec start_unavailable(map(), term()) :: map()
+  def start_unavailable(request, reason) do
+    start("unavailable", "execution", request, Map.get(request, :documents, []), %{})
+    |> fail(reason)
+  end
+
+  @spec complete(map(), String.t(), map() | nil) :: map()
+  def complete(artifacts, output, metadata) do
+    update_step(artifacts, fn step ->
+      step
+      |> Map.put("status", "completed")
+      |> Map.put("output", %{
+        "raw" => output,
+        "parsed" => parsed_output(output)
+      })
+      |> maybe_put("metadata", normalize_json(metadata))
+    end)
+  end
+
+  @spec fail(map(), term()) :: map()
+  def fail(artifacts, reason) do
+    update_step(artifacts, fn step ->
+      step
+      |> Map.put("status", "failed")
+      |> Map.put("error", %{
+        "type" => error_type(reason),
+        "message" => error_message(reason)
+      })
+    end)
+  end
+
+  @spec put_metrics(map(), [map()], number() | nil) :: map()
+  def put_metrics(artifacts, metric_results, score) do
+    update_step(artifacts, fn step ->
+      Map.put(step, "metrics", %{
+        "results" => normalize_json(metric_results),
+        "score" => score
+      })
+    end)
+  end
+
+  defp start(mode, kind, request, documents, input_overrides) do
+    %{
+      "schema_version" => @schema_version,
+      "steps" => [
+        %{
+          "index" => 0,
+          "kind" => kind,
+          "mode" => mode,
+          "status" => "started",
+          "input" =>
+            request
+            |> normalized_input(documents)
+            |> Map.merge(input_overrides)
+        }
+      ]
+    }
+  end
+
+  defp normalized_input(request, documents) do
+    %{
+      "kind" => request.kind |> Atom.to_string(),
+      "prompt_version" => normalize_prompt_version(request.prompt_version, false),
+      "variables" => normalize_json(request.variables),
+      "provider" => normalize_provider(request.provider),
+      "documents" => Enum.map(documents, &normalize_document/1),
+      "metadata" => normalize_json(Map.get(request, :metadata, %{}))
+    }
+  end
+
+  defp normalize_prompt_version(%PromptVersion{} = version, include_template?) do
+    %{
+      "id" => version.id,
+      "version" => version.version
+    }
+    |> maybe_put("template", if(include_template?, do: version.template, else: nil))
+  end
+
+  defp normalize_prompt_version(version, include_template?) when is_map(version) do
+    %{
+      "id" => Map.get(version, :id),
+      "version" => Map.get(version, :version)
+    }
+    |> maybe_put("template", if(include_template?, do: Map.get(version, :template), else: nil))
+  end
+
+  defp normalize_provider(%Provider{} = provider) do
+    %{
+      "id" => provider.id,
+      "model" => provider.model,
+      "type" => to_string(provider.provider)
+    }
+  end
+
+  defp normalize_document(document) when is_map(document) do
+    data = Map.get(document, :data)
+
+    %{
+      "name" => Map.get(document, :name) || Map.get(document, :filename),
+      "content_type" => Map.get(document, :content_type),
+      "size_bytes" => document_size(document, data)
+    }
+  end
+
+  defp document_size(_document, data) when is_binary(data), do: byte_size(data)
+  defp document_size(document, _data), do: Map.get(document, :size_bytes)
+
+  defp parsed_output(output) do
+    case Jason.decode(output) do
+      {:ok, parsed} -> parsed
+      {:error, _reason} -> nil
+    end
+  end
+
+  defp normalize_json(nil), do: nil
+
+  defp normalize_json(value) do
+    case Jason.encode(value) do
+      {:ok, encoded} -> Jason.decode!(encoded)
+      {:error, _reason} -> nil
+    end
+  end
+
+  defp update_step(%{"steps" => [step | remaining]} = artifacts, callback) do
+    %{artifacts | "steps" => [callback.(step) | remaining]}
+  end
+
+  defp error_type(reason) when is_atom(reason), do: Atom.to_string(reason)
+
+  defp error_type(reason) when is_tuple(reason) do
+    case Tuple.to_list(reason) do
+      [type | _remaining] when is_atom(type) -> Atom.to_string(type)
+      _other -> "execution_error"
+    end
+  end
+
+  defp error_type(_reason), do: "execution_error"
+
+  defp error_message(reason) do
+    reason
+    |> inspect(limit: 20, printable_limit: @max_error_length)
+    |> String.slice(0, @max_error_length)
+  end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+end

--- a/lib/aludel/runs/executor.ex
+++ b/lib/aludel/runs/executor.ex
@@ -8,6 +8,7 @@ defmodule Aludel.Runs.Executor do
   require Logger
 
   alias Aludel.Execution, as: AppExecution
+  alias Aludel.Execution.Artifact
   alias Aludel.Providers.Provider
   alias Aludel.PubSub
   alias Aludel.Runs.{Execution, Run, RunResult}
@@ -126,12 +127,38 @@ defmodule Aludel.Runs.Executor do
         {provider, outcome}
 
       {{provider, run_result}, {:exit, reason}} ->
-        {provider, create_error_result(run.id, run_result, provider, {:task_exit, reason})}
+        failure_reason = {:task_exit, reason}
+
+        artifacts =
+          run
+          |> execution_request(provider)
+          |> Artifact.start_unavailable(failure_reason)
+
+        {provider, create_error_result(run.id, run_result, provider, failure_reason, artifacts)}
     end)
   end
 
   defp execute_provider(run, run_result, provider) do
-    request = %{
+    request = execution_request(run, provider)
+
+    with {:ok, run_result} <- mark_run_result_running(run_result),
+         result <- AppExecution.execute_with_artifacts(request) do
+      case result do
+        {:ok, llm_result} ->
+          complete_run_result(run.id, run_result, provider, llm_result)
+
+        {:error, reason, artifacts} ->
+          create_error_result(run.id, run_result, provider, reason, artifacts)
+      end
+    else
+      {:error, changeset} ->
+        log_run_result_failure(run.id, provider.id, changeset)
+        {:error, provider_failure(provider, {:result_transition_failed, changeset.errors})}
+    end
+  end
+
+  defp execution_request(run, provider) do
+    %{
       kind: :run,
       prompt_version: run.prompt_version,
       variables: run.variable_values,
@@ -143,21 +170,6 @@ defmodule Aludel.Runs.Executor do
         prompt_version_id: run.prompt_version.id
       }
     }
-
-    with {:ok, run_result} <- mark_run_result_running(run_result),
-         result <- AppExecution.execute(request) do
-      case result do
-        {:ok, llm_result} ->
-          complete_run_result(run.id, run_result, provider, llm_result)
-
-        {:error, reason} ->
-          create_error_result(run.id, run_result, provider, reason)
-      end
-    else
-      {:error, changeset} ->
-        log_run_result_failure(run.id, provider.id, changeset)
-        {:error, provider_failure(provider, {:result_transition_failed, changeset.errors})}
-    end
   end
 
   defp complete_run_result(run_id, run_result, provider, result) do
@@ -168,6 +180,7 @@ defmodule Aludel.Runs.Executor do
            latency_ms: result.latency_ms,
            cost_usd: result.cost_usd,
            metadata: result.metadata,
+           artifacts: result.artifacts,
            status: :completed,
            completed_at: now(),
            error: nil
@@ -182,12 +195,13 @@ defmodule Aludel.Runs.Executor do
     end
   end
 
-  defp create_error_result(run_id, run_result, provider, reason) do
+  defp create_error_result(run_id, run_result, provider, reason, artifacts) do
     inspected_reason = inspect(reason)
 
     case persist_error_result(run_result, %{
            status: :error,
            error: inspected_reason,
+           artifacts: artifacts,
            completed_at: now()
          }) do
       {:ok, run_result} ->

--- a/lib/aludel/runs/run_result.ex
+++ b/lib/aludel/runs/run_result.ex
@@ -16,7 +16,7 @@ defmodule Aludel.Runs.RunResult do
   @type t :: %__MODULE__{}
 
   @required_fields ~w(run_id provider_id status)a
-  @optional_fields ~w(output input_tokens output_tokens latency_ms cost_usd metadata error started_at completed_at)a
+  @optional_fields ~w(output input_tokens output_tokens latency_ms cost_usd metadata artifacts error started_at completed_at)a
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
@@ -28,6 +28,7 @@ defmodule Aludel.Runs.RunResult do
     field :latency_ms, :integer
     field :cost_usd, :float
     field :metadata, :map
+    field :artifacts, :map
     field :status, Ecto.Enum, values: [:pending, :running, :completed, :error]
     field :error, :string
     field :started_at, :utc_datetime
@@ -50,6 +51,7 @@ defmodule Aludel.Runs.RunResult do
     |> cast(attrs, @required_fields ++ @optional_fields)
     |> validate_required(@required_fields)
     |> validate_change(:metadata, &validate_json_encodable_metadata/2)
+    |> validate_change(:artifacts, &validate_json_encodable_artifacts/2)
     |> foreign_key_constraint(:run_id)
     |> foreign_key_constraint(:provider_id)
   end
@@ -58,6 +60,13 @@ defmodule Aludel.Runs.RunResult do
     case Jason.encode(metadata) do
       {:ok, _encoded_metadata} -> []
       {:error, _reason} -> [metadata: "must be JSON-encodable"]
+    end
+  end
+
+  defp validate_json_encodable_artifacts(:artifacts, artifacts) do
+    case Jason.encode(artifacts) do
+      {:ok, _encoded_artifacts} -> []
+      {:error, _reason} -> [artifacts: "must be JSON-encodable"]
     end
   end
 end

--- a/lib/aludel/web/export_controller.ex
+++ b/lib/aludel/web/export_controller.ex
@@ -107,6 +107,7 @@ defmodule Aludel.Web.ExportController do
         latency_ms: result.latency_ms,
         cost_usd: result.cost_usd,
         metadata: result.metadata,
+        artifacts: result.artifacts,
         started_at: iso8601(result.started_at),
         completed_at: iso8601(result.completed_at),
         inserted_at: iso8601(result.inserted_at),
@@ -159,6 +160,7 @@ defmodule Aludel.Web.ExportController do
       latency_ms: result["latency_ms"],
       cost_usd: result["cost_usd"],
       metadata: result["metadata"],
+      artifacts: result["artifacts"],
       assertion_results: Map.get(result, "assertion_results", []),
       retry_count: result["retry_count"],
       retried_at: result["retried_at"]

--- a/priv/repo/migrations/20260830144810_add_artifacts_to_run_results.exs
+++ b/priv/repo/migrations/20260830144810_add_artifacts_to_run_results.exs
@@ -1,0 +1,9 @@
+defmodule Aludel.Repo.Migrations.AddArtifactsToRunResults do
+  use Ecto.Migration
+
+  def change do
+    alter table(:run_results) do
+      add :artifacts, :map
+    end
+  end
+end

--- a/test/aludel/evals_test.exs
+++ b/test/aludel/evals_test.exs
@@ -587,6 +587,13 @@ defmodule Aludel.EvalsTest do
       assert length(suite_run.results) == 2
 
       assert Enum.all?(suite_run.results, &(&1["passed"] == true))
+
+      Enum.each(suite_run.results, fn result ->
+        assert result["artifacts"]["schema_version"] == 1
+        assert [%{"status" => "completed", "metrics" => metrics}] = result["artifacts"]["steps"]
+        assert metrics["score"] == 100.0
+        assert [%{"reason" => "Output contains expected value"}] = metrics["results"]
+      end)
     end
 
     test "executes suite with failing test cases" do
@@ -1209,6 +1216,20 @@ defmodule Aludel.EvalsTest do
 
       assert [%{"output" => output}] = suite_run.results
       assert output == "Failed to load document crash.png: boom"
+
+      assert [
+               %{
+                 "artifacts" => %{
+                   "schema_version" => 1,
+                   "steps" => [
+                     %{
+                       "status" => "failed",
+                       "error" => %{"type" => "document_storage_error"}
+                     }
+                   ]
+                 }
+               }
+             ] = suite_run.results
     end
 
     test "returns a failed test case result when document loading times out" do

--- a/test/aludel/execution_test.exs
+++ b/test/aludel/execution_test.exs
@@ -51,6 +51,88 @@ defmodule Aludel.ExecutionTest do
     assert result.metadata == nil
   end
 
+  test "captures a normalized native artifact without provider configuration" do
+    Application.put_env(:aludel, :execution_mode, :native)
+
+    prompt = prompt_fixture()
+    {:ok, version} = Aludel.Prompts.create_prompt_version(prompt, "Return JSON for {{name}}")
+
+    provider =
+      provider_fixture(%{
+        provider: :openai,
+        model: "gpt-4o-mini",
+        config: %{"api_key" => "must-not-be-persisted"}
+      })
+
+    expect(HttpClientMock, :request, fn _model, "Return JSON for Alice", _opts ->
+      {:ok, %{content: ~s({"name":"Alice"}), input_tokens: 5, output_tokens: 7}}
+    end)
+
+    assert {:ok, result} =
+             Execution.execute_with_artifacts(%{
+               kind: :run,
+               prompt_version: version,
+               variables: %{"name" => "Alice"},
+               provider: provider,
+               documents: [],
+               metadata: %{run_id: Ecto.UUID.generate()}
+             })
+
+    assert result.artifacts["schema_version"] == 1
+    assert [step] = result.artifacts["steps"]
+    assert step["index"] == 0
+    assert step["mode"] == "native"
+    assert step["status"] == "completed"
+    assert step["input"]["rendered_prompt"] == "Return JSON for Alice"
+
+    assert step["input"]["provider"] == %{
+             "id" => provider.id,
+             "model" => "gpt-4o-mini",
+             "type" => "openai"
+           }
+
+    assert step["output"]["parsed"] == %{"name" => "Alice"}
+    assert step["output"]["raw"] == ~s({"name":"Alice"})
+    refute inspect(result.artifacts) =~ "must-not-be-persisted"
+    refute inspect(result.artifacts) =~ "config"
+  end
+
+  test "captures structured failure artifacts while preserving execute/1 compatibility" do
+    Application.put_env(:aludel, :execution_mode, :native)
+
+    prompt = prompt_fixture()
+    {:ok, version} = Aludel.Prompts.create_prompt_version(prompt, "Hello {{name}}")
+    provider = provider_fixture()
+
+    expect(HttpClientMock, :request, 2, fn _model, _prompt, _opts ->
+      {:error, "API timeout"}
+    end)
+
+    request = %{
+      kind: :run,
+      prompt_version: version,
+      variables: %{"name" => "Alice"},
+      provider: provider,
+      documents: [],
+      metadata: %{run_id: Ecto.UUID.generate()}
+    }
+
+    assert {:error, {:network_error, "API timeout"}, artifacts} =
+             Execution.execute_with_artifacts(request)
+
+    assert %{
+             "schema_version" => 1,
+             "steps" => [
+               %{
+                 "error" => %{"type" => "network_error"},
+                 "status" => "failed"
+               }
+             ]
+           } = artifacts
+
+    assert {:error, {:network_error, "API timeout"}} = Execution.execute(request)
+  end
+
   test "returns a structured error when callback mode is missing an executor" do
     Application.put_env(:aludel, :execution_mode, :callback)
     Application.delete_env(:aludel, :executor)
@@ -218,5 +300,10 @@ defmodule Aludel.ExecutionTest do
     assert result.latency_ms == 1234
     assert result.cost_usd == nil
     assert result.metadata == %{"trace_id" => "trace-123"}
+    assert [%{"mode" => "callback", "input" => artifact_input}] = result.artifacts["steps"]
+    assert artifact_input["prompt_version"]["template"] == "Ignored {{name}}"
+    assert [%{"name" => "policy.txt", "size_bytes" => 27}] = artifact_input["documents"]
+    refute inspect(result.artifacts) =~ "reset password instructions"
+    refute inspect(result.artifacts) =~ "config"
   end
 end

--- a/test/aludel/runs/executor_test.exs
+++ b/test/aludel/runs/executor_test.exs
@@ -165,6 +165,12 @@ defmodule Aludel.Runs.ExecutorTest do
       assert result.completed_at
       assert result.error =~ "task_exit"
       assert result.error =~ "boom"
+      assert result.artifacts["schema_version"] == 1
+
+      assert [%{"status" => "failed", "error" => %{"type" => "task_exit"}}] =
+               result.artifacts["steps"]
+
+      refute inspect(result.artifacts) =~ "config"
     end
 
     test "persists callback results with optional metrics and metadata", %{run: run} do

--- a/test/aludel/runs/run_result_test.exs
+++ b/test/aludel/runs/run_result_test.exs
@@ -204,6 +204,38 @@ defmodule Aludel.Runs.RunResultTest do
       assert changeset.changes.metadata == metadata
     end
 
+    test "accepts versioned execution artifacts", %{run: run, provider: provider} do
+      artifacts = %{
+        "schema_version" => 1,
+        "steps" => [%{"index" => 0, "mode" => "native", "status" => "completed"}]
+      }
+
+      changeset =
+        RunResult.changeset(%RunResult{}, %{
+          run_id: run.id,
+          provider_id: provider.id,
+          output: "Hello world",
+          status: :completed,
+          artifacts: artifacts
+        })
+
+      assert changeset.valid?
+      assert changeset.changes.artifacts == artifacts
+    end
+
+    test "rejects artifacts that cannot be encoded as JSON", %{run: run, provider: provider} do
+      changeset =
+        RunResult.changeset(%RunResult{}, %{
+          run_id: run.id,
+          provider_id: provider.id,
+          status: :completed,
+          artifacts: %{"pid" => self()}
+        })
+
+      refute changeset.valid?
+      assert %{artifacts: ["must be JSON-encodable"]} = errors_on(changeset)
+    end
+
     test "rejects metadata that cannot be encoded as JSON", %{run: run, provider: provider} do
       changeset =
         RunResult.changeset(%RunResult{}, %{

--- a/test/aludel/runs_test.exs
+++ b/test/aludel/runs_test.exs
@@ -330,6 +330,8 @@ defmodule Aludel.RunsTest do
       assert result.input_tokens > 0
       assert result.output_tokens > 0
       assert result.latency_ms >= 0
+      assert result.artifacts["schema_version"] == 1
+      assert [%{"status" => "completed"}] = result.artifacts["steps"]
     end
 
     test "executes run with multiple providers concurrently", %{
@@ -437,6 +439,10 @@ defmodule Aludel.RunsTest do
       assert hd(execution.run.run_results).status == :error
       assert hd(execution.run.run_results).started_at
       assert hd(execution.run.run_results).completed_at
+      assert hd(execution.run.run_results).artifacts["schema_version"] == 1
+
+      assert [%{"status" => "failed", "error" => %{"type" => "network_error"}}] =
+               hd(execution.run.run_results).artifacts["steps"]
     end
 
     test "marks execution as partially failed when some providers fail", %{run: run} do

--- a/test/aludel_web/export_controller_test.exs
+++ b/test/aludel_web/export_controller_test.exs
@@ -21,7 +21,11 @@ defmodule Aludel.Web.ExportControllerTest do
           output_tokens: nil,
           latency_ms: nil,
           cost_usd: nil,
-          metadata: %{"trace_id" => "trace-123"}
+          metadata: %{"trace_id" => "trace-123"},
+          artifacts: %{
+            "schema_version" => 1,
+            "steps" => [%{"index" => 0, "mode" => "callback", "status" => "completed"}]
+          }
         })
 
       conn = get(conn, "/runs/results/#{result.id}/export")
@@ -47,6 +51,7 @@ defmodule Aludel.Web.ExportControllerTest do
       assert payload["result"]["status"] == "completed"
       assert payload["result"]["output"] == "Callback output"
       assert payload["result"]["metadata"]["trace_id"] == "trace-123"
+      assert payload["result"]["artifacts"]["schema_version"] == 1
     end
   end
 
@@ -110,6 +115,10 @@ defmodule Aludel.Web.ExportControllerTest do
               "cost_usd" => 0.001,
               "latency_ms" => 250,
               "metadata" => %{"trace_id" => "suite-export-trace"},
+              "artifacts" => %{
+                "schema_version" => 1,
+                "steps" => [%{"index" => 0, "mode" => "callback", "status" => "completed"}]
+              },
               "retry_count" => 1,
               "retried_at" => "2026-04-26T13:00:00Z"
             }
@@ -173,6 +182,12 @@ defmodule Aludel.Web.ExportControllerTest do
                      }
                    }
                  ],
+                 "artifacts" => %{
+                   "schema_version" => 1,
+                   "steps" => [
+                     %{"index" => 0, "mode" => "callback", "status" => "completed"}
+                   ]
+                 },
                  "cost_usd" => 0.001,
                  "error" => nil,
                  "input_tokens" => 14,

--- a/test/support/migrations/20260830144810_add_artifacts_to_run_results.exs
+++ b/test/support/migrations/20260830144810_add_artifacts_to_run_results.exs
@@ -1,0 +1,9 @@
+defmodule Aludel.TestSupport.Migrations.AddArtifactsToRunResults do
+  use Ecto.Migration
+
+  def change do
+    alter table(:run_results) do
+      add :artifacts, :map
+    end
+  end
+end


### PR DESCRIPTION
## Motivation

Persist versioned, structured execution evidence so run and suite outcomes can be audited and inspected after execution. Native and callback paths now capture normalized inputs, ordered trace steps, raw and parsed outputs, metric explanations, and structured failures while excluding provider configuration and document bytes.

Artifacts are stored in an additive nullable field for run results and beside each embedded suite result, preserving compatibility with existing rows and future multi-step traces. Existing JSON exports include artifacts when present.

Closes #118

## Test Plan

- Covers native and callback inputs, structured output parsing, provider-secret exclusion, document-byte exclusion, success and failure persistence, task exits, suite metric evidence, JSON validation, and both export shapes.
- Full unit, formatting, static analysis, dependency, and security checks pass.
- The additive migration rolls back and reapplies cleanly.

## Next Steps

No follow-up is required for the v1 scope.