### PR TITLE
feat(datasets): add reusable multi-turn corpus

### DIFF
--- a/lib/aludel/datasets.ex
+++ b/lib/aludel/datasets.ex
@@ -1,0 +1,188 @@
+defmodule Aludel.Datasets do
+  @moduledoc """
+  Context for reusable evaluation datasets and suite population.
+  """
+
+  import Ecto.Query
+
+  alias Aludel.Datasets.{Dataset, DatasetEntry}
+  alias Aludel.Evals.{Suite, TestCase}
+  alias Ecto.Changeset
+
+  @spec list_datasets() :: [Dataset.t()]
+  def list_datasets do
+    Dataset
+    |> order_by([dataset], asc: dataset.name)
+    |> repo().all()
+  end
+
+  @spec get_dataset!(binary()) :: Dataset.t()
+  def get_dataset!(id) do
+    repo().get!(Dataset, id)
+  end
+
+  @spec list_entries(Dataset.t(), keyword()) :: [DatasetEntry.t()]
+  def list_entries(%Dataset{} = dataset, opts \\ []) do
+    DatasetEntry
+    |> where([entry], entry.dataset_id == ^dataset.id)
+    |> filter_entries_by_metadata(Keyword.get(opts, :metadata, %{}))
+    |> order_by([entry], asc: entry.position, asc: entry.inserted_at)
+    |> repo().all()
+  end
+
+  @spec get_dataset_with_entries!(binary()) :: Dataset.t()
+  def get_dataset_with_entries!(id) do
+    entries = from entry in DatasetEntry, order_by: [asc: entry.position, asc: entry.inserted_at]
+
+    Dataset
+    |> repo().get!(id)
+    |> repo().preload(entries: entries)
+  end
+
+  @spec create_dataset(map()) :: {:ok, Dataset.t()} | {:error, Changeset.t()}
+  def create_dataset(attrs) do
+    %Dataset{}
+    |> Dataset.changeset(attrs)
+    |> repo().insert()
+  end
+
+  @spec update_dataset(Dataset.t(), map()) :: {:ok, Dataset.t()} | {:error, Changeset.t()}
+  def update_dataset(%Dataset{} = dataset, attrs) do
+    dataset
+    |> Dataset.changeset(attrs)
+    |> repo().update()
+  end
+
+  @spec delete_dataset(Dataset.t()) :: {:ok, Dataset.t()} | {:error, Changeset.t()}
+  def delete_dataset(%Dataset{} = dataset) do
+    repo().delete(dataset)
+  end
+
+  @spec change_dataset(Dataset.t(), map()) :: Changeset.t()
+  def change_dataset(%Dataset{} = dataset, attrs \\ %{}) do
+    Dataset.changeset(dataset, attrs)
+  end
+
+  @spec create_entry(Dataset.t(), map()) ::
+          {:ok, DatasetEntry.t()} | {:error, Changeset.t()}
+  def create_entry(%Dataset{} = dataset, attrs) do
+    repo().transaction(fn ->
+      lock_dataset!(dataset.id)
+      position = entry_position(attrs, next_position(dataset.id))
+
+      %DatasetEntry{dataset_id: dataset.id}
+      |> DatasetEntry.changeset(Map.put(attrs, :position, position))
+      |> repo().insert()
+      |> case do
+        {:ok, entry} -> entry
+        {:error, changeset} -> repo().rollback(changeset)
+      end
+    end)
+  end
+
+  @spec update_entry(DatasetEntry.t(), map()) ::
+          {:ok, DatasetEntry.t()} | {:error, Changeset.t()}
+  def update_entry(%DatasetEntry{} = entry, attrs) do
+    entry
+    |> DatasetEntry.changeset(Map.drop(attrs, [:dataset_id, "dataset_id"]))
+    |> repo().update()
+  end
+
+  @spec delete_entry(DatasetEntry.t()) ::
+          {:ok, DatasetEntry.t()} | {:error, Changeset.t()}
+  def delete_entry(%DatasetEntry{} = entry) do
+    repo().delete(entry)
+  end
+
+  @spec change_entry(DatasetEntry.t(), map()) :: Changeset.t()
+  def change_entry(%DatasetEntry{} = entry, attrs \\ %{}) do
+    DatasetEntry.changeset(entry, attrs)
+  end
+
+  @spec populate_suite(Dataset.t(), Suite.t()) ::
+          {:ok, [TestCase.t()]} | {:error, term()}
+  def populate_suite(%Dataset{} = dataset, %Suite{} = suite) do
+    repo().transaction(fn ->
+      lock_suite!(suite.id)
+
+      dataset.id
+      |> dataset_entries_not_in_suite(suite.id)
+      |> Enum.map(&insert_dataset_entry_copy(&1, suite.id))
+    end)
+  end
+
+  defp dataset_entries_not_in_suite(dataset_id, suite_id) do
+    imported_entry_ids =
+      from(test_case in TestCase,
+        where:
+          test_case.suite_id == ^suite_id and
+            not is_nil(test_case.source_dataset_entry_id),
+        select: test_case.source_dataset_entry_id
+      )
+
+    from(entry in DatasetEntry,
+      where: entry.dataset_id == ^dataset_id and entry.id not in subquery(imported_entry_ids),
+      order_by: [asc: entry.position, asc: entry.inserted_at]
+    )
+    |> repo().all()
+  end
+
+  defp filter_entries_by_metadata(query, metadata) when map_size(metadata) == 0 do
+    query
+  end
+
+  defp filter_entries_by_metadata(query, metadata) do
+    where(query, [entry], fragment("? @> ?", entry.metadata, ^metadata))
+  end
+
+  defp lock_dataset!(dataset_id) do
+    Dataset
+    |> where([dataset], dataset.id == ^dataset_id)
+    |> lock("FOR UPDATE")
+    |> repo().one!()
+  end
+
+  defp lock_suite!(suite_id) do
+    Suite
+    |> where([suite], suite.id == ^suite_id)
+    |> lock("FOR UPDATE")
+    |> repo().one!()
+  end
+
+  defp insert_dataset_entry_copy(entry, suite_id) do
+    attrs = %{
+      variable_values: entry.variable_values,
+      messages: entry.messages,
+      assertions: entry.assertions,
+      metadata: entry.metadata
+    }
+
+    %TestCase{suite_id: suite_id, source_dataset_entry_id: entry.id}
+    |> TestCase.changeset(attrs)
+    |> repo().insert()
+    |> case do
+      {:ok, test_case} -> test_case
+      {:error, changeset} -> repo().rollback(changeset)
+    end
+  end
+
+  defp next_position(dataset_id) do
+    from(entry in DatasetEntry,
+      where: entry.dataset_id == ^dataset_id,
+      select: max(entry.position)
+    )
+    |> repo().one()
+    |> case do
+      nil -> 0
+      position -> position + 1
+    end
+  end
+
+  defp entry_position(attrs, default) do
+    Map.get(attrs, :position) || Map.get(attrs, "position") || default
+  end
+
+  defp repo do
+    Aludel.Repo.get()
+  end
+end

--- a/lib/aludel/datasets/dataset.ex
+++ b/lib/aludel/datasets/dataset.ex
@@ -1,0 +1,46 @@
+defmodule Aludel.Datasets.Dataset do
+  @moduledoc """
+  A reusable collection of ordered evaluation examples.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Aludel.Datasets.DatasetEntry
+  alias Ecto.Changeset
+
+  @type t :: %__MODULE__{}
+
+  @fields ~w(name description metadata)a
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  schema "datasets" do
+    field :name, :string
+    field :description, :string
+    field :metadata, :map, default: %{}
+
+    has_many :entries, DatasetEntry
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @spec changeset(t(), map()) :: Changeset.t()
+  def changeset(dataset, attrs) do
+    dataset
+    |> cast(attrs, @fields)
+    |> validate_required([:name, :metadata])
+    |> validate_length(:name, max: 200)
+    |> validate_json(:metadata)
+  end
+
+  defp validate_json(changeset, field) do
+    validate_change(changeset, field, fn ^field, value ->
+      case Jason.encode(value) do
+        {:ok, _encoded} -> []
+        {:error, _reason} -> [{field, "must be JSON-encodable"}]
+      end
+    end)
+  end
+end

--- a/lib/aludel/datasets/dataset_entry.ex
+++ b/lib/aludel/datasets/dataset_entry.ex
@@ -1,0 +1,103 @@
+defmodule Aludel.Datasets.DatasetEntry do
+  @moduledoc """
+  An ordered single-turn or multi-turn example in a dataset.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Aludel.Datasets.Dataset
+  alias Aludel.Evals.{AssertionParser, MessageValidator}
+  alias Ecto.Changeset
+
+  @type t :: %__MODULE__{}
+
+  @fields ~w(name variable_values messages assertions metadata position)a
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  schema "dataset_entries" do
+    field :name, :string
+    field :variable_values, :map, default: %{}
+    field :messages, {:array, :map}, default: []
+    field :assertions, {:array, :map}, default: []
+    field :metadata, :map, default: %{}
+    field :position, :integer
+
+    belongs_to :dataset, Dataset
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @spec changeset(t(), map()) :: Changeset.t()
+  def changeset(entry, attrs) do
+    entry
+    |> cast(attrs, @fields)
+    |> validate_required([
+      :dataset_id,
+      :name,
+      :variable_values,
+      :messages,
+      :assertions,
+      :metadata,
+      :position
+    ])
+    |> validate_length(:name, max: 200)
+    |> validate_number(:position, greater_than_or_equal_to: 0)
+    |> validate_messages()
+    |> validate_assertions()
+    |> validate_json(:variable_values)
+    |> validate_json(:metadata)
+    |> validate_payload()
+    |> foreign_key_constraint(:dataset_id)
+    |> unique_constraint(:position, name: :dataset_entries_dataset_id_position_index)
+  end
+
+  @spec conversation_kind(t()) :: :single_turn | :multi_turn
+  def conversation_kind(%__MODULE__{messages: messages}) when length(messages) > 1 do
+    :multi_turn
+  end
+
+  def conversation_kind(%__MODULE__{}) do
+    :single_turn
+  end
+
+  defp validate_messages(changeset) do
+    validate_change(changeset, :messages, fn :messages, messages ->
+      case MessageValidator.validate(messages) do
+        :ok -> []
+        {:error, message} -> [messages: message]
+      end
+    end)
+  end
+
+  defp validate_assertions(changeset) do
+    validate_change(changeset, :assertions, fn :assertions, assertions ->
+      case AssertionParser.validate(assertions) do
+        {:ok, _assertions} -> []
+        {:error, message} -> [assertions: message]
+      end
+    end)
+  end
+
+  defp validate_json(changeset, field) do
+    validate_change(changeset, field, fn ^field, value ->
+      case Jason.encode(value) do
+        {:ok, _encoded} -> []
+        {:error, _reason} -> [{field, "must be JSON-encodable"}]
+      end
+    end)
+  end
+
+  defp validate_payload(changeset) do
+    variable_values = get_field(changeset, :variable_values) || %{}
+    messages = get_field(changeset, :messages) || []
+
+    if variable_values == %{} and messages == [] do
+      add_error(changeset, :variable_values, "must include variables or messages")
+    else
+      changeset
+    end
+  end
+end

--- a/lib/aludel/evals.ex
+++ b/lib/aludel/evals.ex
@@ -478,6 +478,7 @@ defmodule Aludel.Evals do
       kind: :suite,
       prompt_version: version,
       variables: test_case.variable_values,
+      messages: test_case.messages,
       provider: provider,
       documents: test_case.documents,
       metadata: %{

--- a/lib/aludel/evals/message_validator.ex
+++ b/lib/aludel/evals/message_validator.ex
@@ -1,0 +1,69 @@
+defmodule Aludel.Evals.MessageValidator do
+  @moduledoc false
+
+  @roles ~w(assistant system user)
+
+  @spec validate(term()) :: :ok | {:error, String.t()}
+  def validate(messages) when is_list(messages) do
+    case validate_messages(messages) do
+      :ok -> validate_final_turn(messages)
+      error -> error
+    end
+  end
+
+  def validate(_messages) do
+    {:error, "must be a list of messages"}
+  end
+
+  defp validate_messages(messages) do
+    Enum.reduce_while(messages, :ok, fn message, :ok ->
+      case validate_message(message) do
+        :ok -> {:cont, :ok}
+        error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp validate_message(%{"role" => role, "content" => content} = message) do
+    cond do
+      role not in @roles ->
+        {:error, "contains an unsupported role"}
+
+      not is_binary(content) or String.trim(content) == "" ->
+        {:error, "contains blank content"}
+
+      invalid_metadata?(Map.get(message, "metadata")) ->
+        {:error, "contains invalid metadata"}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp validate_message(_message) do
+    {:error, "must contain role and content"}
+  end
+
+  defp validate_final_turn([]) do
+    :ok
+  end
+
+  defp validate_final_turn(messages) do
+    case List.last(messages) do
+      %{"role" => "user"} -> :ok
+      _message -> {:error, "must end with a user turn"}
+    end
+  end
+
+  defp invalid_metadata?(nil) do
+    false
+  end
+
+  defp invalid_metadata?(metadata) when not is_map(metadata) do
+    true
+  end
+
+  defp invalid_metadata?(metadata) do
+    match?({:error, _reason}, Jason.encode(metadata))
+  end
+end

--- a/lib/aludel/evals/test_case.ex
+++ b/lib/aludel/evals/test_case.ex
@@ -15,13 +15,14 @@ defmodule Aludel.Evals.TestCase do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Aludel.Evals.{AssertionParser, Suite, TestCaseDocument}
+  alias Aludel.Datasets.DatasetEntry
+  alias Aludel.Evals.{AssertionParser, MessageValidator, Suite, TestCaseDocument}
   alias Ecto.Changeset
 
   @type t :: %__MODULE__{}
 
   @required_fields ~w(suite_id variable_values assertions)a
-  @optional_fields ~w()a
+  @optional_fields ~w(messages metadata)a
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
@@ -29,8 +30,11 @@ defmodule Aludel.Evals.TestCase do
   schema "test_cases" do
     field :variable_values, :map
     field :assertions, {:array, :map}
+    field :messages, {:array, :map}, default: []
+    field :metadata, :map, default: %{}
 
     belongs_to(:suite, Suite)
+    belongs_to(:source_dataset_entry, DatasetEntry)
     has_many(:documents, TestCaseDocument, on_delete: :delete_all)
 
     timestamps(type: :utc_datetime)
@@ -46,9 +50,16 @@ defmodule Aludel.Evals.TestCase do
   def changeset(test_case, attrs) do
     test_case
     |> cast(attrs, @required_fields ++ @optional_fields)
-    |> validate_required(@required_fields)
+    |> validate_required(@required_fields ++ [:messages, :metadata])
+    |> validate_messages()
     |> validate_assertions()
+    |> validate_json(:variable_values)
+    |> validate_json(:metadata)
     |> foreign_key_constraint(:suite_id)
+    |> foreign_key_constraint(:source_dataset_entry_id)
+    |> unique_constraint(:source_dataset_entry_id,
+      name: :test_cases_suite_id_source_dataset_entry_id_index
+    )
   end
 
   defp validate_assertions(%Changeset{} = changeset) do
@@ -56,6 +67,24 @@ defmodule Aludel.Evals.TestCase do
       case AssertionParser.validate(assertions) do
         {:ok, _assertions} -> []
         {:error, message} -> [assertions: message]
+      end
+    end)
+  end
+
+  defp validate_messages(%Changeset{} = changeset) do
+    validate_change(changeset, :messages, fn :messages, messages ->
+      case MessageValidator.validate(messages) do
+        :ok -> []
+        {:error, message} -> [messages: message]
+      end
+    end)
+  end
+
+  defp validate_json(changeset, field) do
+    validate_change(changeset, field, fn ^field, value ->
+      case Jason.encode(value) do
+        {:ok, _encoded} -> []
+        {:error, _reason} -> [{field, "must be JSON-encodable"}]
       end
     end)
   end

--- a/lib/aludel/execution.ex
+++ b/lib/aludel/execution.ex
@@ -3,6 +3,7 @@ defmodule Aludel.Execution do
   Shared execution boundary for native provider calls and host-app callbacks.
   """
 
+  alias Aludel.Evals.MessageValidator
   alias Aludel.Evals.TestCaseDocument
   alias Aludel.Execution.Artifact
   alias Aludel.Executor
@@ -15,12 +16,13 @@ defmodule Aludel.Execution do
   @default_document_load_timeout_ms 30_000
 
   @type request :: %{
+          optional(:documents) => [TestCaseDocument.t()],
+          optional(:messages) => [map()],
+          optional(:metadata) => map(),
           kind: :run | :suite,
           prompt_version: PromptVersion.t(),
           variables: map(),
-          provider: Provider.t(),
-          documents: [TestCaseDocument.t()],
-          metadata: map()
+          provider: Provider.t()
         }
 
   @type result :: %{
@@ -61,9 +63,13 @@ defmodule Aludel.Execution do
       )
       when kind in [:run, :suite] and is_map(variables) do
     documents = Map.get(request, :documents, [])
+    messages = Map.get(request, :messages, [])
     metadata = Map.get(request, :metadata, %{})
 
-    with {:ok, loaded_documents} <- load_documents(documents),
+    with :ok <- validate_messages(messages),
+         rendered_messages = render_messages(messages, variables),
+         request = Map.put(request, :messages, rendered_messages),
+         {:ok, loaded_documents} <- load_documents(documents),
          {:ok, execution_mode} <- Executor.configured_execution_mode() do
       case execution_mode do
         :callback ->
@@ -96,7 +102,9 @@ defmodule Aludel.Execution do
 
     opts = if llm_documents == [], do: [], else: [documents: llm_documents]
 
-    case LLM.call(provider, rendered_prompt, opts) do
+    prompt_input = native_prompt_input(rendered_prompt, Map.get(request, :messages, []))
+
+    case LLM.call(provider, prompt_input, opts) do
       {:ok, result} ->
         {:ok,
          %{
@@ -123,7 +131,17 @@ defmodule Aludel.Execution do
          documents,
          metadata
        ) do
-    input = callback_input(kind, prompt_version, variables, provider, documents, metadata)
+    input =
+      callback_input(
+        kind,
+        prompt_version,
+        variables,
+        Map.get(request, :messages, []),
+        provider,
+        documents,
+        metadata
+      )
+
     artifacts = Artifact.start_callback(request, input)
 
     with {:ok, executor} <- Executor.configured_executor(),
@@ -176,7 +194,15 @@ defmodule Aludel.Execution do
   defp normalize_callback_result({:error, reason}), do: {:error, reason}
   defp normalize_callback_result(other), do: {:error, {:invalid_executor_response, other}}
 
-  defp callback_input(kind, prompt_version, variables, provider, documents, metadata) do
+  defp callback_input(
+         kind,
+         prompt_version,
+         variables,
+         messages,
+         provider,
+         documents,
+         metadata
+       ) do
     %{
       kind: kind,
       prompt_version: %{
@@ -185,6 +211,7 @@ defmodule Aludel.Execution do
         version: prompt_version.version
       },
       variables: variables,
+      messages: messages,
       documents: documents,
       provider: %{
         id: provider.id,
@@ -271,6 +298,43 @@ defmodule Aludel.Execution do
     Enum.reduce(variables, template, fn {key, value}, acc ->
       String.replace(acc, "{{#{key}}}", to_string(value))
     end)
+  end
+
+  defp render_messages(messages, variables) do
+    Enum.map(messages, fn message ->
+      Map.update(message, "content", "", &render_template(&1, variables))
+    end)
+  end
+
+  defp native_prompt_input(rendered_prompt, []) do
+    rendered_prompt
+  end
+
+  defp native_prompt_input(rendered_prompt, messages) do
+    [%{role: :system, content: rendered_prompt} | Enum.map(messages, &native_message/1)]
+  end
+
+  defp native_message(%{"role" => role, "content" => content}) do
+    %{role: role_atom(role), content: content}
+  end
+
+  defp role_atom("system") do
+    :system
+  end
+
+  defp role_atom("assistant") do
+    :assistant
+  end
+
+  defp role_atom("user") do
+    :user
+  end
+
+  defp validate_messages(messages) do
+    case MessageValidator.validate(messages) do
+      :ok -> :ok
+      {:error, message} -> {:error, {:invalid_messages, message}}
+    end
   end
 
   defp document_load_timeout_ms do

--- a/lib/aludel/execution/artifact.ex
+++ b/lib/aludel/execution/artifact.ex
@@ -95,6 +95,7 @@ defmodule Aludel.Execution.Artifact do
       "kind" => request.kind |> Atom.to_string(),
       "prompt_version" => normalize_prompt_version(request.prompt_version, false),
       "variables" => normalize_json(request.variables),
+      "messages" => normalize_json(Map.get(request, :messages, [])),
       "provider" => normalize_provider(request.provider),
       "documents" => Enum.map(documents, &normalize_document/1),
       "metadata" => normalize_json(Map.get(request, :metadata, %{}))

--- a/lib/aludel/executor.ex
+++ b/lib/aludel/executor.ex
@@ -26,6 +26,7 @@ defmodule Aludel.Executor do
           kind: :run | :suite,
           prompt_version: prompt_version_input(),
           variables: map(),
+          messages: [map()],
           documents: [document_input()],
           provider: provider_input() | nil,
           metadata: map() | nil

--- a/lib/aludel/interfaces/llm.ex
+++ b/lib/aludel/interfaces/llm.ex
@@ -74,7 +74,7 @@ defmodule Aludel.LLM do
       iex> is_binary(result.output)
       true
   """
-  @spec call(Provider.t(), String.t(), keyword()) ::
+  @spec call(Provider.t(), String.t() | [map()], keyword()) ::
           {:ok, llm_result()} | {:error, error_reason()}
   def call(%Provider{} = provider, prompt, opts \\ []) do
     start_time = System.monotonic_time(:millisecond)

--- a/lib/aludel/interfaces/llm/behaviour.ex
+++ b/lib/aludel/interfaces/llm/behaviour.ex
@@ -25,7 +25,7 @@ defmodule Aludel.Interfaces.LLM.Behaviour do
 
   ## Parameters
     - model: Model identifier (e.g., "gpt-4o", "claude-3-5-sonnet")
-    - prompt: Text prompt to send to the model
+    - prompt: Text prompt or normalized conversation messages to send to the model
     - config: Provider configuration (API keys, temperature, etc.)
     - opts: Additional options (e.g., documents for vision models)
 
@@ -35,7 +35,7 @@ defmodule Aludel.Interfaces.LLM.Behaviour do
   """
   @callback generate(
               model :: String.t(),
-              prompt :: String.t(),
+              prompt :: String.t() | [map()],
               config :: map(),
               opts :: keyword()
             ) ::

--- a/priv/repo/migrations/20260830150132_create_datasets_and_add_test_case_provenance.exs
+++ b/priv/repo/migrations/20260830150132_create_datasets_and_add_test_case_provenance.exs
@@ -1,0 +1,41 @@
+defmodule Aludel.Repo.Migrations.CreateDatasetsAndAddTestCaseProvenance do
+  use Ecto.Migration
+
+  def change do
+    create table(:datasets, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :name, :string, null: false
+      add :description, :text
+      add :metadata, :map, null: false, default: %{}
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create table(:dataset_entries, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :dataset_id, references(:datasets, type: :binary_id, on_delete: :delete_all),
+        null: false
+
+      add :name, :string, null: false
+      add :variable_values, :map, null: false, default: %{}
+      add :messages, {:array, :map}, null: false, default: []
+      add :assertions, {:array, :map}, null: false, default: []
+      add :metadata, :map, null: false, default: %{}
+      add :position, :integer, null: false
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:dataset_entries, [:dataset_id])
+    create unique_index(:dataset_entries, [:dataset_id, :position])
+
+    alter table(:test_cases) do
+      add :source_dataset_entry_id,
+          references(:dataset_entries, type: :binary_id, on_delete: :nilify_all)
+
+      add :messages, {:array, :map}, null: false, default: []
+      add :metadata, :map, null: false, default: %{}
+    end
+  end
+end

--- a/priv/repo/migrations/20260830150604_add_dataset_provenance_indexes.exs
+++ b/priv/repo/migrations/20260830150604_add_dataset_provenance_indexes.exs
@@ -1,0 +1,15 @@
+defmodule Aludel.Repo.Migrations.AddDatasetProvenanceIndexes do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change do
+    create index(:test_cases, [:source_dataset_entry_id], concurrently: true)
+
+    create unique_index(:test_cases, [:suite_id, :source_dataset_entry_id],
+             concurrently: true,
+             where: "source_dataset_entry_id IS NOT NULL"
+           )
+  end
+end

--- a/test/aludel/datasets_test.exs
+++ b/test/aludel/datasets_test.exs
@@ -1,0 +1,157 @@
+defmodule Aludel.DatasetsTest do
+  use Aludel.DataCase, async: true
+
+  alias Aludel.Datasets
+  alias Aludel.Datasets.{Dataset, DatasetEntry}
+  alias Aludel.Evals
+
+  describe "datasets" do
+    test "creates and lists first-class datasets with metadata" do
+      assert {:ok, %Dataset{} = dataset} =
+               Datasets.create_dataset(%{
+                 name: "Support conversations",
+                 description: "Reusable support evaluation corpus",
+                 metadata: %{"team" => "support", "locale" => "en"}
+               })
+
+      assert dataset.name == "Support conversations"
+      assert dataset.metadata["team"] == "support"
+      assert Datasets.list_datasets() == [dataset]
+    end
+
+    test "validates required names and JSON metadata" do
+      assert {:error, changeset} = Datasets.create_dataset(%{name: ""})
+      assert "can't be blank" in errors_on(changeset).name
+
+      assert {:error, changeset} =
+               Datasets.create_dataset(%{name: "Invalid", metadata: %{"pid" => self()}})
+
+      assert "must be JSON-encodable" in errors_on(changeset).metadata
+    end
+  end
+
+  describe "dataset entries" do
+    setup do
+      {:ok, dataset} = Datasets.create_dataset(%{name: "Conversation set"})
+      %{dataset: dataset}
+    end
+
+    test "assigns stable positions and loads entries in order", %{dataset: dataset} do
+      assert {:ok, first} =
+               Datasets.create_entry(dataset, %{
+                 name: "Single turn",
+                 variable_values: %{"question" => "Hello"},
+                 assertions: [%{"type" => "contains", "value" => "Hi"}]
+               })
+
+      assert {:ok, second} =
+               Datasets.create_entry(dataset, %{
+                 name: "Multi turn",
+                 messages: [
+                   %{"role" => "user", "content" => "I forgot my password"},
+                   %{"role" => "assistant", "content" => "I can help with that"},
+                   %{"role" => "user", "content" => "Send the reset steps"}
+                 ],
+                 assertions: [%{"type" => "contains", "value" => "reset"}],
+                 metadata: %{"intent" => "password_reset"}
+               })
+
+      assert first.position == 0
+      assert second.position == 1
+      assert DatasetEntry.conversation_kind(first) == :single_turn
+      assert DatasetEntry.conversation_kind(second) == :multi_turn
+
+      loaded = Datasets.get_dataset_with_entries!(dataset.id)
+      assert Enum.map(loaded.entries, & &1.id) == [first.id, second.id]
+
+      assert Datasets.list_entries(dataset, metadata: %{"intent" => "password_reset"}) == [
+               second
+             ]
+    end
+
+    test "validates message roles, content, final user turn, and entry payload", %{
+      dataset: dataset
+    } do
+      assert {:error, changeset} =
+               Datasets.create_entry(dataset, %{
+                 name: "Invalid role",
+                 messages: [%{"role" => "tool", "content" => "result"}]
+               })
+
+      assert "contains an unsupported role" in errors_on(changeset).messages
+
+      assert {:error, changeset} =
+               Datasets.create_entry(dataset, %{
+                 name: "Blank content",
+                 messages: [%{"role" => "user", "content" => " "}]
+               })
+
+      assert "contains blank content" in errors_on(changeset).messages
+
+      assert {:error, changeset} =
+               Datasets.create_entry(dataset, %{
+                 name: "Assistant final turn",
+                 messages: [
+                   %{"role" => "user", "content" => "Hello"},
+                   %{"role" => "assistant", "content" => "Hi"}
+                 ]
+               })
+
+      assert "must end with a user turn" in errors_on(changeset).messages
+
+      assert {:error, changeset} =
+               Datasets.create_entry(dataset, %{name: "Empty example"})
+
+      assert "must include variables or messages" in errors_on(changeset).variable_values
+    end
+  end
+
+  describe "populate_suite/2" do
+    test "copies ordered entries with provenance without creating synchronization" do
+      {:ok, dataset} = Datasets.create_dataset(%{name: "Reusable corpus"})
+
+      {:ok, first} =
+        Datasets.create_entry(dataset, %{
+          name: "First",
+          variable_values: %{"input" => "original"},
+          assertions: [%{"type" => "contains", "value" => "first"}],
+          metadata: %{"segment" => "a"}
+        })
+
+      {:ok, second} =
+        Datasets.create_entry(dataset, %{
+          name: "Second",
+          messages: [%{"role" => "user", "content" => "Second question"}],
+          assertions: [%{"type" => "contains", "value" => "second"}],
+          metadata: %{"segment" => "b"}
+        })
+
+      suite = suite_fixture()
+
+      assert {:ok, imported} = Datasets.populate_suite(dataset, suite)
+      assert Enum.map(imported, & &1.source_dataset_entry_id) == [first.id, second.id]
+      assert Enum.at(imported, 0).variable_values == %{"input" => "original"}
+
+      assert Enum.at(imported, 1).messages == [
+               %{"role" => "user", "content" => "Second question"}
+             ]
+
+      assert Enum.at(imported, 1).metadata == %{"segment" => "b"}
+
+      assert {:ok, []} = Datasets.populate_suite(dataset, suite)
+      assert length(Evals.get_suite_with_test_cases!(suite.id).test_cases) == 2
+
+      assert {:ok, _entry} =
+               Datasets.update_entry(first, %{variable_values: %{"input" => "changed"}})
+
+      imported_first = Evals.get_test_case!(Enum.at(imported, 0).id)
+      assert imported_first.variable_values == %{"input" => "original"}
+
+      assert {:ok, _dataset} = Datasets.delete_dataset(dataset)
+
+      retained = Evals.get_test_case!(imported_first.id)
+      assert retained.source_dataset_entry_id == nil
+      assert retained.variable_values == %{"input" => "original"}
+    end
+  end
+end

--- a/test/aludel/evals/test_case_test.exs
+++ b/test/aludel/evals/test_case_test.exs
@@ -111,6 +111,42 @@ defmodule Aludel.Evals.TestCaseTest do
       assert {"Assertion at index 1: contains type requires a non-blank 'value' field", []} =
                changeset.errors[:assertions]
     end
+
+    test "accepts multi-turn messages and metadata" do
+      suite = suite_fixture()
+
+      changeset =
+        TestCase.changeset(%TestCase{}, %{
+          suite_id: suite.id,
+          variable_values: %{},
+          messages: [
+            %{"role" => "user", "content" => "Hello"},
+            %{"role" => "assistant", "content" => "Hi"},
+            %{"role" => "user", "content" => "Can you help?"}
+          ],
+          assertions: [],
+          metadata: %{"segment" => "support"}
+        })
+
+      assert changeset.valid?
+    end
+
+    test "rejects invalid messages and non-JSON metadata" do
+      suite = suite_fixture()
+
+      changeset =
+        TestCase.changeset(%TestCase{}, %{
+          suite_id: suite.id,
+          variable_values: %{},
+          messages: [%{"role" => "assistant", "content" => "No user turn"}],
+          assertions: [],
+          metadata: %{"pid" => self()}
+        })
+
+      refute changeset.valid?
+      assert "must end with a user turn" in errors_on(changeset).messages
+      assert "must be JSON-encodable" in errors_on(changeset).metadata
+    end
   end
 
   describe "associations" do

--- a/test/aludel/evals_test.exs
+++ b/test/aludel/evals_test.exs
@@ -478,6 +478,46 @@ defmodule Aludel.EvalsTest do
   end
 
   describe "execute_suite/3" do
+    test "executes multi-turn cases with the rendered prompt as system context" do
+      expect(HttpClientMock, :request, fn _model, messages, _opts ->
+        assert messages == [
+                 %{role: :system, content: "Answer in a calm tone"},
+                 %{role: :user, content: "My name is Alice"},
+                 %{role: :assistant, content: "Hello Alice"},
+                 %{role: :user, content: "What is my name?"}
+               ]
+
+        {:ok, build_mock_response("Your name is Alice", 12, 5)}
+      end)
+
+      suite = suite_fixture()
+      prompt = prompt_fixture()
+      {:ok, version} = Aludel.Prompts.create_prompt_version(prompt, "Answer in a {{tone}} tone")
+      provider = provider_fixture()
+
+      _test_case =
+        test_case_fixture(%{
+          suite_id: suite.id,
+          variable_values: %{"tone" => "calm", "name" => "Alice"},
+          messages: [
+            %{"role" => "user", "content" => "My name is {{name}}"},
+            %{"role" => "assistant", "content" => "Hello {{name}}"},
+            %{"role" => "user", "content" => "What is my name?"}
+          ],
+          assertions: [%{"type" => "contains", "value" => "Alice"}]
+        })
+
+      assert {:ok, suite_run} = Evals.execute_suite(suite, version, provider)
+      assert suite_run.passed == 1
+      assert [result] = suite_run.results
+
+      assert result["artifacts"]["steps"] |> hd() |> get_in(["input", "messages"]) == [
+               %{"role" => "user", "content" => "My name is Alice"},
+               %{"role" => "assistant", "content" => "Hello Alice"},
+               %{"role" => "user", "content" => "What is my name?"}
+             ]
+    end
+
     test "execute_suite captures avg_cost_usd and avg_latency_ms" do
       mock_response = build_mock_response("Mock response", 5, 10)
 

--- a/test/aludel/execution_test.exs
+++ b/test/aludel/execution_test.exs
@@ -133,6 +133,20 @@ defmodule Aludel.ExecutionTest do
     assert {:error, {:network_error, "API timeout"}} = Execution.execute(request)
   end
 
+  test "rejects invalid messages at the execution boundary" do
+    prompt = prompt_fixture()
+    {:ok, version} = Aludel.Prompts.create_prompt_version(prompt, "Hello")
+
+    assert {:error, {:invalid_messages, "contains an unsupported role"}} =
+             Execution.execute(%{
+               kind: :suite,
+               prompt_version: version,
+               variables: %{},
+               messages: [%{"role" => "tool", "content" => "unsafe"}],
+               provider: provider_fixture()
+             })
+  end
+
   test "returns a structured error when callback mode is missing an executor" do
     Application.put_env(:aludel, :execution_mode, :callback)
     Application.delete_env(:aludel, :executor)
@@ -305,5 +319,44 @@ defmodule Aludel.ExecutionTest do
     assert [%{"name" => "policy.txt", "size_bytes" => 27}] = artifact_input["documents"]
     refute inspect(result.artifacts) =~ "reset password instructions"
     refute inspect(result.artifacts) =~ "config"
+  end
+
+  test "renders and passes multi-turn messages to callback executors" do
+    Application.put_env(:aludel, :execution_mode, :callback)
+    Application.put_env(:aludel, :executor, Aludel.ExecutorMock)
+
+    prompt = prompt_fixture()
+    {:ok, version} = Aludel.Prompts.create_prompt_version(prompt, "System {{tone}}")
+    provider = provider_fixture()
+
+    expect(Aludel.ExecutorMock, :run, fn input ->
+      assert input.messages == [
+               %{"role" => "user", "content" => "Hello Alice"},
+               %{"role" => "assistant", "content" => "Hi Alice"},
+               %{"role" => "user", "content" => "Use a calm tone"}
+             ]
+
+      {:ok, %{output: "Certainly", metadata: %{}}}
+    end)
+
+    assert {:ok, result} =
+             Execution.execute(%{
+               kind: :suite,
+               prompt_version: version,
+               variables: %{"name" => "Alice", "tone" => "calm"},
+               messages: [
+                 %{"role" => "user", "content" => "Hello {{name}}"},
+                 %{"role" => "assistant", "content" => "Hi {{name}}"},
+                 %{"role" => "user", "content" => "Use a {{tone}} tone"}
+               ],
+               provider: provider,
+               documents: []
+             })
+
+    assert result.artifacts["steps"] |> hd() |> get_in(["input", "messages"]) == [
+             %{"role" => "user", "content" => "Hello Alice"},
+             %{"role" => "assistant", "content" => "Hi Alice"},
+             %{"role" => "user", "content" => "Use a calm tone"}
+           ]
   end
 end

--- a/test/support/migrations/20260830150132_create_datasets_and_add_test_case_provenance.exs
+++ b/test/support/migrations/20260830150132_create_datasets_and_add_test_case_provenance.exs
@@ -1,0 +1,41 @@
+defmodule Aludel.TestSupport.Migrations.CreateDatasetsAndAddTestCaseProvenance do
+  use Ecto.Migration
+
+  def change do
+    create table(:datasets, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :name, :string, null: false
+      add :description, :text
+      add :metadata, :map, null: false, default: %{}
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create table(:dataset_entries, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :dataset_id, references(:datasets, type: :binary_id, on_delete: :delete_all),
+        null: false
+
+      add :name, :string, null: false
+      add :variable_values, :map, null: false, default: %{}
+      add :messages, {:array, :map}, null: false, default: []
+      add :assertions, {:array, :map}, null: false, default: []
+      add :metadata, :map, null: false, default: %{}
+      add :position, :integer, null: false
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:dataset_entries, [:dataset_id])
+    create unique_index(:dataset_entries, [:dataset_id, :position])
+
+    alter table(:test_cases) do
+      add :source_dataset_entry_id,
+          references(:dataset_entries, type: :binary_id, on_delete: :nilify_all)
+
+      add :messages, {:array, :map}, null: false, default: []
+      add :metadata, :map, null: false, default: %{}
+    end
+  end
+end

--- a/test/support/migrations/20260830150604_add_dataset_provenance_indexes.exs
+++ b/test/support/migrations/20260830150604_add_dataset_provenance_indexes.exs
@@ -1,0 +1,15 @@
+defmodule Aludel.TestSupport.Migrations.AddDatasetProvenanceIndexes do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change do
+    create index(:test_cases, [:source_dataset_entry_id], concurrently: true)
+
+    create unique_index(:test_cases, [:suite_id, :source_dataset_entry_id],
+             concurrently: true,
+             where: "source_dataset_entry_id IS NOT NULL"
+           )
+  end
+end


### PR DESCRIPTION
## Motivation

Introduce datasets as reusable, ordered evaluation corpora separate from suites. Entries support variable-driven single-turn cases and validated multi-turn conversations, searchable metadata, assertions, and stable positions.

Suite population copies entries transactionally with nullable provenance. Imported cases remain independent snapshots, repeated imports are idempotent, and deleting a dataset preserves copied suite cases. Native execution sends the rendered prompt as system context before conversation turns; callback execution receives normalized rendered messages.

```mermaid
flowchart LR
  D[Dataset] --> E[Ordered entries]
  E -->|transactional copy| T[Suite test cases]
  T --> X[Native or callback execution]
  E -. nullable provenance .-> T
  D -->|delete| P[Copied cases preserved]
```

Part of #119

## Test Plan

- Covers dataset CRUD, metadata validation and filtering, ordered single-turn and multi-turn entries, invalid message shapes, idempotent imports, copy independence, provenance nullification, and transaction boundaries.
- Covers native and callback multi-turn rendering, execution-boundary rejection, and trace persistence.
- Full unit, formatting, static analysis, dependency, and security checks pass; Dialyzer is clean.
- Both schema migrations roll back and reapply cleanly, including concurrent indexes on existing test-case rows.

## Next Steps

Add dataset management and suite population LiveViews with focused UI coverage, completing #119.