### PR TITLE
feat(analytics): add rolling dashboard comparisons

### DIFF
--- a/lib/aludel/evals.ex
+++ b/lib/aludel/evals.ex
@@ -652,8 +652,28 @@ defmodule Aludel.Evals do
       failed: failed,
       avg_cost_usd: average_cost(metrics),
       avg_latency_ms: average_latency(metrics),
-      avg_score: average_score(metrics)
+      avg_score: average_score(metrics),
+      total_cost_usd: total_cost(metrics),
+      cost_sample_count: metrics.cost_samples,
+      total_latency_ms: total_latency(metrics),
+      latency_sample_count: metrics.latency_samples
     }
+  end
+
+  defp total_cost(%{cost_samples: 0}) do
+    nil
+  end
+
+  defp total_cost(%{total_cost: total_cost}) do
+    total_cost
+  end
+
+  defp total_latency(%{latency_samples: 0}) do
+    nil
+  end
+
+  defp total_latency(%{total_latency: total_latency}) do
+    total_latency
   end
 
   defp decimal_from_number(number) when is_float(number), do: Decimal.from_float(number)

--- a/lib/aludel/evals/suite_run.ex
+++ b/lib/aludel/evals/suite_run.ex
@@ -18,7 +18,18 @@ defmodule Aludel.Evals.SuiteRun do
   @type t :: %__MODULE__{}
 
   @required_fields ~w(suite_id prompt_version_id provider_id)a
-  @optional_fields ~w(results passed failed avg_cost_usd avg_latency_ms avg_score)a
+  @optional_fields ~w(
+    results
+    passed
+    failed
+    avg_cost_usd
+    avg_latency_ms
+    avg_score
+    total_cost_usd
+    cost_sample_count
+    total_latency_ms
+    latency_sample_count
+  )a
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
@@ -30,6 +41,10 @@ defmodule Aludel.Evals.SuiteRun do
     field :avg_cost_usd, :decimal
     field :avg_latency_ms, :integer
     field :avg_score, :decimal
+    field :total_cost_usd, :decimal
+    field :cost_sample_count, :integer, default: 0
+    field :total_latency_ms, :integer
+    field :latency_sample_count, :integer, default: 0
 
     belongs_to(:suite, Suite)
     belongs_to(:prompt_version, PromptVersion)

--- a/lib/aludel/stats/overview.ex
+++ b/lib/aludel/stats/overview.ex
@@ -1,13 +1,88 @@
 defmodule Aludel.Stats.Overview do
   @moduledoc """
-  Top-line dashboard metrics and period comparisons.
+  Top-line dashboard metrics and bounded period comparisons.
   """
 
   import Ecto.Query
 
   alias Aludel.Evals.SuiteRun
   alias Aludel.Runs.{Run, RunResult}
-  alias Aludel.Stats.Shared
+  alias Aludel.Stats.{Shared, Signals}
+  alias Ecto.Adapters.SQL
+
+  @suite_period_sql """
+  WITH windows AS (
+    SELECT days,
+           $2::timestamptz - make_interval(days => days) AS current_start,
+           $2::timestamptz - make_interval(days => days * 2) AS previous_start
+    FROM unnest($1::integer[]) AS days
+  ), periods AS (
+    SELECT days, 'current' AS period, current_start AS starts_at, $2::timestamptz AS ends_at
+    FROM windows
+    UNION ALL
+    SELECT days, 'previous' AS period, previous_start AS starts_at, current_start AS ends_at
+    FROM windows
+  )
+  SELECT periods.days,
+         periods.period,
+         COUNT(suite_runs.id)::bigint AS suite_runs,
+         COALESCE(SUM(suite_runs.passed), 0)::bigint AS passed,
+         COALESCE(SUM(suite_runs.failed), 0)::bigint AS failed,
+         SUM(
+           COALESCE(
+             suite_runs.total_cost_usd,
+             suite_runs.avg_cost_usd * (suite_runs.passed + suite_runs.failed)
+           )
+         ) AS total_cost_usd,
+         SUM(
+           COALESCE(
+             suite_runs.total_latency_ms,
+             suite_runs.avg_latency_ms::bigint * (suite_runs.passed + suite_runs.failed)
+           )
+         ) AS total_latency_ms,
+         SUM(
+           CASE
+             WHEN suite_runs.latency_sample_count > 0 THEN suite_runs.latency_sample_count
+             WHEN suite_runs.avg_latency_ms IS NOT NULL THEN suite_runs.passed + suite_runs.failed
+             ELSE 0
+           END
+         )::bigint AS latency_sample_count,
+         STDDEV_POP(
+           100.0 * suite_runs.passed / NULLIF(suite_runs.passed + suite_runs.failed, 0)
+         ) AS pass_rate_stddev,
+         COUNT(suite_runs.id)
+           FILTER (WHERE suite_runs.passed + suite_runs.failed > 0)::bigint AS stability_sample_size
+  FROM periods
+  LEFT JOIN suite_runs
+    ON suite_runs.inserted_at >= periods.starts_at
+   AND suite_runs.inserted_at < periods.ends_at
+  GROUP BY periods.days, periods.period
+  ORDER BY periods.days, periods.period
+  """
+
+  @run_period_sql """
+  WITH windows AS (
+    SELECT days,
+           $2::timestamptz - make_interval(days => days) AS current_start,
+           $2::timestamptz - make_interval(days => days * 2) AS previous_start
+    FROM unnest($1::integer[]) AS days
+  ), periods AS (
+    SELECT days, 'current' AS period, current_start AS starts_at, $2::timestamptz AS ends_at
+    FROM windows
+    UNION ALL
+    SELECT days, 'previous' AS period, previous_start AS starts_at, current_start AS ends_at
+    FROM windows
+  )
+  SELECT periods.days,
+         periods.period,
+         COUNT(runs.id)::bigint AS prompt_runs
+  FROM periods
+  LEFT JOIN runs
+    ON runs.inserted_at >= periods.starts_at
+   AND runs.inserted_at < periods.ends_at
+  GROUP BY periods.days, periods.period
+  ORDER BY periods.days, periods.period
+  """
 
   @spec total_runs() :: integer()
   def total_runs do
@@ -40,20 +115,21 @@ defmodule Aludel.Stats.Overview do
     if total > 0, do: Float.round(passed / total * 100, 1), else: 0.0
   end
 
-  @spec comparison_stats(integer()) :: map()
+  @spec comparison_stats(pos_integer()) :: map()
   def comparison_stats(days \\ 7) do
-    now = DateTime.utc_now()
-    period_start = DateTime.add(now, -days, :day)
-    previous_start = DateTime.add(period_start, -days, :day)
+    comparison_stats(days, current_as_of())
+  end
 
-    current = period_stats(period_start, now)
-    previous = period_stats(previous_start, period_start)
+  @spec comparison_stats(pos_integer(), DateTime.t()) :: map()
+  def comparison_stats(days, %DateTime{} = as_of) when is_integer(days) and days > 0 do
+    [days]
+    |> comparisons(as_of)
+    |> Map.fetch!(days)
+  end
 
-    %{
-      current: current,
-      previous: previous,
-      trends: calculate_trends(current, previous)
-    }
+  @spec rolling_comparisons(DateTime.t()) :: %{pos_integer() => map()}
+  def rolling_comparisons(as_of \\ current_as_of()) do
+    comparisons([7, 30], as_of)
   end
 
   @spec avg_latency() :: number()
@@ -78,26 +154,152 @@ defmodule Aludel.Stats.Overview do
     end
   end
 
-  defp period_stats(start_time, end_time) do
-    suite_runs =
-      from(sr in SuiteRun, where: sr.inserted_at >= ^start_time and sr.inserted_at < ^end_time)
-      |> Shared.repo().aggregate(:count)
+  defp comparisons(days, as_of) do
+    normalized_as_of = DateTime.truncate(as_of, :second)
+    suite_rows = query_suite_rows([days, normalized_as_of])
+    run_rows = query_run_rows([days, normalized_as_of])
+    run_counts = index_run_counts(run_rows)
 
-    prompt_runs =
-      from(r in Run, where: r.inserted_at >= ^start_time and r.inserted_at < ^end_time)
-      |> Shared.repo().aggregate(:count)
+    suite_rows
+    |> Enum.map(&build_period(&1, run_counts))
+    |> Enum.group_by(& &1.days)
+    |> Map.new(fn {period_days, periods} ->
+      current = Enum.find(periods, &(&1.period == "current")).stats
+      previous = Enum.find(periods, &(&1.period == "previous")).stats
 
-    %{total_runs: suite_runs + prompt_runs}
+      {period_days,
+       %{
+         current: current,
+         previous: previous,
+         comparison: Signals.compare(current, previous),
+         trends: %{total_runs: trend_direction(current.total_runs, previous.total_runs)}
+       }}
+    end)
   end
 
-  defp calculate_trends(current, previous) do
-    %{
-      total_runs: trend_direction(current.total_runs, previous.total_runs)
+  defp query_suite_rows(params) do
+    Shared.repo()
+    |> SQL.query!(@suite_period_sql, params)
+    |> rows_to_maps()
+  end
+
+  defp query_run_rows(params) do
+    Shared.repo()
+    |> SQL.query!(@run_period_sql, params)
+    |> rows_to_maps()
+  end
+
+  defp rows_to_maps(%{columns: columns, rows: rows}) do
+    Enum.map(rows, fn row ->
+      columns
+      |> Enum.zip(row)
+      |> Map.new()
+    end)
+  end
+
+  defp index_run_counts(rows) do
+    Map.new(rows, fn row ->
+      {{row["days"], row["period"]}, row["prompt_runs"]}
+    end)
+  end
+
+  defp build_period(row, run_counts) do
+    passed = row["passed"]
+    failed = row["failed"]
+    total_tests = passed + failed
+    total_cost = decimal_to_float(row["total_cost_usd"])
+    total_latency = decimal_to_float(row["total_latency_ms"])
+    latency_samples = row["latency_sample_count"]
+    prompt_runs = Map.fetch!(run_counts, {row["days"], row["period"]})
+
+    stats = %{
+      suite_runs: row["suite_runs"],
+      prompt_runs: prompt_runs,
+      total_runs: row["suite_runs"] + prompt_runs,
+      passed: passed,
+      failed: failed,
+      pass_rate: ratio(passed * 100.0, total_tests),
+      total_cost_usd: rounded(total_cost, 8),
+      avg_latency_ms: ratio(total_latency, latency_samples),
+      cost_per_passed_test: ratio(total_cost, passed),
+      latency_per_passed_test: ratio(total_latency, passed),
+      pass_rate_stddev: rounded(decimal_to_float(row["pass_rate_stddev"]), 2),
+      stability_sample_size: row["stability_sample_size"],
+      efficiency_status: efficiency_status(total_tests, passed)
     }
+
+    %{days: row["days"], period: row["period"], stats: stats}
   end
 
-  defp trend_direction(current, previous) when previous == 0 and current > 0, do: :up
-  defp trend_direction(current, previous) when current > previous, do: :up
-  defp trend_direction(current, previous) when current < previous, do: :down
-  defp trend_direction(_current, _previous), do: :stable
+  defp efficiency_status(0, _passed) do
+    :no_tests
+  end
+
+  defp efficiency_status(_total_tests, 0) do
+    :no_passes
+  end
+
+  defp efficiency_status(_total_tests, _passed) do
+    :available
+  end
+
+  defp ratio(nil, _denominator) do
+    nil
+  end
+
+  defp ratio(_numerator, denominator) when denominator in [nil, 0] do
+    nil
+  end
+
+  defp ratio(numerator, denominator) do
+    numerator
+    |> Kernel./(denominator)
+    |> Float.round(4)
+  end
+
+  defp rounded(nil, _places) do
+    nil
+  end
+
+  defp rounded(value, places) do
+    Float.round(value, places)
+  end
+
+  defp decimal_to_float(nil) do
+    nil
+  end
+
+  defp decimal_to_float(%Decimal{} = value) do
+    Decimal.to_float(value)
+  end
+
+  defp decimal_to_float(value) when is_integer(value) do
+    value * 1.0
+  end
+
+  defp decimal_to_float(value) do
+    value
+  end
+
+  defp trend_direction(current, previous) when previous == 0 and current > 0 do
+    :up
+  end
+
+  defp trend_direction(current, previous) when current > previous do
+    :up
+  end
+
+  defp trend_direction(current, previous) when current < previous do
+    :down
+  end
+
+  defp trend_direction(_current, _previous) do
+    :stable
+  end
+
+  defp current_as_of do
+    DateTime.utc_now()
+    |> DateTime.truncate(:second)
+    |> DateTime.add(1, :second)
+  end
 end

--- a/lib/aludel/stats/signals.ex
+++ b/lib/aludel/stats/signals.ex
@@ -1,0 +1,93 @@
+defmodule Aludel.Stats.Signals do
+  @moduledoc false
+
+  @quality_regression_threshold -5.0
+  @efficiency_regression_threshold 20.0
+
+  @spec compare(map(), map()) :: map()
+  def compare(current, previous) do
+    deltas = %{
+      pass_rate: absolute_delta(current[:pass_rate], previous[:pass_rate]),
+      cost_per_passed_test:
+        relative_delta(current[:cost_per_passed_test], previous[:cost_per_passed_test]),
+      avg_latency_ms: relative_delta(current[:avg_latency_ms], previous[:avg_latency_ms])
+    }
+
+    %{
+      deltas: deltas,
+      regressions: regressions(deltas),
+      stability: stability(current)
+    }
+  end
+
+  defp regressions(deltas) do
+    []
+    |> maybe_add(:quality, regression?(deltas.pass_rate, :quality))
+    |> maybe_add(:cost, regression?(deltas.cost_per_passed_test, :efficiency))
+    |> maybe_add(:latency, regression?(deltas.avg_latency_ms, :efficiency))
+  end
+
+  defp regression?(value, :quality) when is_number(value) do
+    value <= @quality_regression_threshold
+  end
+
+  defp regression?(value, :efficiency) when is_number(value) do
+    value >= @efficiency_regression_threshold
+  end
+
+  defp regression?(_value, _kind) do
+    false
+  end
+
+  defp maybe_add(items, item, true) do
+    items ++ [item]
+  end
+
+  defp maybe_add(items, _item, false) do
+    items
+  end
+
+  defp stability(%{stability_sample_size: sample_size}) when sample_size < 2 do
+    :insufficient_data
+  end
+
+  defp stability(%{pass_rate_stddev: stddev}) when is_number(stddev) and stddev < 5 do
+    :stable
+  end
+
+  defp stability(%{pass_rate_stddev: stddev}) when is_number(stddev) and stddev < 15 do
+    :variable
+  end
+
+  defp stability(%{pass_rate_stddev: stddev}) when is_number(stddev) do
+    :volatile
+  end
+
+  defp stability(_current) do
+    :insufficient_data
+  end
+
+  defp absolute_delta(current, previous)
+       when is_number(current) and is_number(previous) do
+    current
+    |> Kernel.-(previous)
+    |> Float.round(2)
+  end
+
+  defp absolute_delta(_current, _previous) do
+    nil
+  end
+
+  defp relative_delta(current, previous)
+       when is_number(current) and is_number(previous) and previous > 0 do
+    current
+    |> Kernel.-(previous)
+    |> Kernel./(previous)
+    |> Kernel.*(100)
+    |> Float.round(2)
+  end
+
+  defp relative_delta(_current, _previous) do
+    nil
+  end
+end

--- a/lib/aludel/web/live/dashboard_live.ex
+++ b/lib/aludel/web/live/dashboard_live.ex
@@ -40,7 +40,8 @@ defmodule Aludel.Web.DashboardLive do
     total_cost = Runs.total_cost()
     # Calculate cost_per_run here to avoid redundant DB queries
     cost_per_run = if total_runs > 0, do: total_cost / total_runs, else: 0.0
-    trends = Overview.comparison_stats(7)
+    rolling_windows = Overview.rolling_comparisons()
+    trends = Map.fetch!(rolling_windows, 7)
 
     # Breakdown stats
     cost_by_provider = Costs.cost_by_provider()
@@ -66,6 +67,7 @@ defmodule Aludel.Web.DashboardLive do
       |> assign(:total_cost, total_cost)
       |> assign(:cost_per_run, cost_per_run)
       |> assign(:trends, trends)
+      |> assign(:rolling_windows, rolling_windows)
       |> assign(:cost_by_provider, cost_by_provider)
       |> assign(:cost_by_prompt, cost_by_prompt)
       |> assign(:latency_by_provider, latency_by_provider)
@@ -143,5 +145,59 @@ defmodule Aludel.Web.DashboardLive do
         0
       end
     end)
+  end
+
+  defp efficiency_state(%{efficiency_status: :no_passes}) do
+    "no-passes"
+  end
+
+  defp efficiency_state(%{efficiency_status: :no_tests}) do
+    "no-tests"
+  end
+
+  defp efficiency_state(_stats) do
+    "available"
+  end
+
+  defp format_pass_rate(nil) do
+    "No tests"
+  end
+
+  defp format_pass_rate(value) do
+    "#{:erlang.float_to_binary(value * 1.0, decimals: 1)}%"
+  end
+
+  defp format_cost_per_pass(%{efficiency_status: :no_passes}) do
+    "No passing tests"
+  end
+
+  defp format_cost_per_pass(%{cost_per_passed_test: nil}) do
+    "Unavailable"
+  end
+
+  defp format_cost_per_pass(stats) do
+    "$#{:erlang.float_to_binary(stats.cost_per_passed_test, decimals: 4)}"
+  end
+
+  defp format_latency_per_pass(%{efficiency_status: :no_passes}) do
+    "No passing tests"
+  end
+
+  defp format_latency_per_pass(%{latency_per_passed_test: nil}) do
+    "Unavailable"
+  end
+
+  defp format_latency_per_pass(stats) do
+    "#{round(stats.latency_per_passed_test)}ms"
+  end
+
+  defp stability_label(:insufficient_data) do
+    "Needs more runs"
+  end
+
+  defp stability_label(stability) do
+    stability
+    |> Atom.to_string()
+    |> String.capitalize()
   end
 end

--- a/lib/aludel/web/live/dashboard_live.html.heex
+++ b/lib/aludel/web/live/dashboard_live.html.heex
@@ -14,151 +14,211 @@
       </div>
     </div>
 
-    <div class="stats-grid">
-      <div class="aludel-card p-md">
-        <div class="stat-card-header">
-          <.icon name="hero-play" class="size-5 text-muted" />
-          <div class="stat-info-tooltip">
-            <.icon name="hero-information-circle" class="size-4 stat-info-icon" />
-            <div class="stat-info-tooltip-content">
-              Combined total of individual prompt runs and complete suite runs executed
-            </div>
-          </div>
+    <section id="rolling-analytics" style="margin-bottom: 32px;">
+      <div style="display: flex; justify-content: space-between; align-items: end; margin-bottom: 12px;">
+        <div>
+          <h2 style="margin: 0; font-size: 18px; font-weight: 600;">Recent performance</h2>
+          <p class="text-sm text-secondary" style="margin: 4px 0 0;">
+            Compared with the matching previous period
+          </p>
         </div>
-        <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 4px;">
-          <div class="stat-value">{@total_runs}</div>
-          <%= if @trends.trends.total_runs == :up do %>
-            <.icon name="hero-arrow-trending-up" class="size-5 text-green-600" />
-          <% end %>
-          <%= if @trends.trends.total_runs == :down do %>
-            <.icon name="hero-arrow-trending-down" class="size-5 text-red-600" />
-          <% end %>
-        </div>
-        <div class="stat-label text-sm font-medium">Total Runs</div>
-        <div class="stat-description mt-xs">Evaluations executed</div>
-        <%= if @daily_activity != [] && Enum.any?(@daily_activity, & &1.total > 0) do %>
-          <div style="display: flex; justify-content: flex-end; margin-top: 10px;">
-            <button
-              phx-click="toggle_activity_chart"
-              style="background-color: var(--bg-secondary); border: 1px solid var(--border); padding: 4px 10px; font-size: 11px; color: var(--text-primary); cursor: pointer; display: flex; align-items: center; gap: 4px; border-radius: 5px; transition: all 0.15s ease; font-weight: 500;"
-              onmouseover="this.style.borderColor='var(--accent)'; this.style.color='var(--accent)'"
-              onmouseout="this.style.borderColor='var(--border)'; this.style.color='var(--text-primary)'"
-            >
-              <span>{if @show_activity_chart, do: "Hide chart", else: "Show chart"}</span>
-              <.icon
-                name={if @show_activity_chart, do: "hero-chevron-up", else: "hero-chevron-down"}
-                class="size-3"
-              />
-            </button>
-          </div>
-        <% end %>
       </div>
-
-      <div class="aludel-card p-md">
-        <div class="stat-card-header">
-          <.icon name="hero-check-circle" class="size-5 text-muted" />
-          <div class="stat-info-tooltip">
-            <.icon name="hero-information-circle" class="size-4 stat-info-icon" />
-            <div class="stat-info-tooltip-content">
-              Success rate across all test assertions in suite runs (excludes individual prompt runs)
+      <div style="display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px;">
+        <%= for days <- [7, 30] do %>
+          <% window = Map.fetch!(@rolling_windows, days) %>
+          <% stats = window.current %>
+          <article id={"rolling-window-#{days}"} class="aludel-card p-md">
+            <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px;">
+              <h3 style="margin: 0; font-size: 15px; font-weight: 600;">Last {days} days</h3>
+              <span class="text-sm text-secondary">{stats.total_runs} runs</span>
             </div>
-          </div>
-        </div>
-        <div class="stat-value mb-xs">{@success_rate}%</div>
-        <div class="stat-label text-sm font-medium">Success Rate</div>
-        <div class="stat-description mt-xs">
-          {@total_passed} passed, {@total_failed} failed
-        </div>
-        <%= if @pass_rates != [] do %>
-          <div style="display: flex; justify-content: flex-end; margin-top: 10px;">
-            <button
-              phx-click="toggle_pass_rates"
-              style="background-color: var(--bg-secondary); border: 1px solid var(--border); padding: 4px 10px; font-size: 11px; color: var(--text-primary); cursor: pointer; display: flex; align-items: center; gap: 4px; border-radius: 5px; transition: all 0.15s ease; font-weight: 500;"
-              onmouseover="this.style.borderColor='var(--accent)'; this.style.color='var(--accent)'"
-              onmouseout="this.style.borderColor='var(--border)'; this.style.color='var(--text-primary)'"
-            >
-              <span>{if @show_pass_rates, do: "Hide by prompt", else: "View by prompt"}</span>
-              <.icon
-                name={if @show_pass_rates, do: "hero-chevron-up", else: "hero-chevron-down"}
-                class="size-3"
-              />
-            </button>
-          </div>
-        <% end %>
-      </div>
-
-      <div class="aludel-card p-md">
-        <div class="stat-card-header">
-          <.icon name="hero-clock" class="size-5 text-muted" />
-          <div class="stat-info-tooltip">
-            <.icon name="hero-information-circle" class="size-4 stat-info-icon" />
-            <div class="stat-info-tooltip-content">
-              Average response time per individual run with percentile distributions (P50 = 50th percentile, P95 = 95th percentile)
+            <div style="display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px;">
+              <div>
+                <div class="stat-label text-sm">Pass rate</div>
+                <div id={"rolling-window-#{days}-pass-rate"} class="font-medium">
+                  {format_pass_rate(stats.pass_rate)}
+                </div>
+              </div>
+              <div>
+                <div class="stat-label text-sm">Cost / pass</div>
+                <div
+                  id={"rolling-window-#{days}-cost-per-pass"}
+                  data-state={efficiency_state(stats)}
+                  class="font-medium"
+                >
+                  {format_cost_per_pass(stats)}
+                </div>
+              </div>
+              <div>
+                <div class="stat-label text-sm">Latency / pass</div>
+                <div
+                  id={"rolling-window-#{days}-latency-per-pass"}
+                  data-state={efficiency_state(stats)}
+                  class="font-medium"
+                >
+                  {format_latency_per_pass(stats)}
+                </div>
+              </div>
             </div>
-          </div>
-        </div>
-        <div class="stat-value mb-xs">{trunc(@avg_latency)}ms</div>
-        <div class="stat-label text-sm font-medium">Avg Latency</div>
-        <div class="stat-description mt-xs">
-          Per run · P50: {trunc(@latency_p50)}ms, P95: {trunc(@latency_p95)}ms
-        </div>
-        <%= if @latency_by_provider != [] do %>
-          <div style="display: flex; justify-content: flex-end; margin-top: 10px;">
-            <button
-              phx-click="toggle_latency_breakdown"
-              style="background-color: var(--bg-secondary); border: 1px solid var(--border); padding: 4px 10px; font-size: 11px; color: var(--text-primary); cursor: pointer; display: flex; align-items: center; gap: 4px; border-radius: 5px; transition: all 0.15s ease; font-weight: 500;"
-              onmouseover="this.style.borderColor='var(--accent)'; this.style.color='var(--accent)'"
-              onmouseout="this.style.borderColor='var(--border)'; this.style.color='var(--text-primary)'"
-            >
-              <span>
-                {if @show_latency_breakdown, do: "Hide breakdown", else: "View breakdown"}
+            <div style="display: flex; gap: 8px; align-items: center; margin-top: 16px; font-size: 12px; color: var(--text-secondary);">
+              <span>{stability_label(window.comparison.stability)} stability</span>
+              <span :for={regression <- window.comparison.regressions} class="tag">
+                {regression} regression
               </span>
-              <.icon
-                name={
-                  if @show_latency_breakdown, do: "hero-chevron-up", else: "hero-chevron-down"
-                }
-                class="size-3"
-              />
-            </button>
-          </div>
+            </div>
+          </article>
         <% end %>
       </div>
+    </section>
 
-      <div id="cost-summary" class="aludel-card p-md">
-        <div class="stat-card-header">
-          <.icon name="hero-currency-dollar" class="size-5 text-muted" />
-          <div class="stat-info-tooltip">
-            <.icon name="hero-information-circle" class="size-4 stat-info-icon" />
-            <div class="stat-info-tooltip-content">
-              Combined costs across all prompt runs and suite executions, with average cost per execution
+    <section id="lifetime-summary">
+      <h2 style="margin: 0 0 12px; font-size: 18px; font-weight: 600;">Lifetime context</h2>
+      <div class="stats-grid">
+        <div class="aludel-card p-md">
+          <div class="stat-card-header">
+            <.icon name="hero-play" class="size-5 text-muted" />
+            <div class="stat-info-tooltip">
+              <.icon name="hero-information-circle" class="size-4 stat-info-icon" />
+              <div class="stat-info-tooltip-content">
+                Combined total of individual prompt runs and complete suite runs executed
+              </div>
             </div>
           </div>
-        </div>
-        <div class="stat-value" style="margin-bottom: 2px;">
-          ${:erlang.float_to_binary(@total_cost, decimals: 4)}
-        </div>
-        <div class="stat-label" style="font-size: 13px; font-weight: 500;">Total Cost</div>
-        <div class="stat-description" style="margin-top: 2px;">
-          ${:erlang.float_to_binary(@cost_per_run, decimals: 4)} per execution
-        </div>
-        <%= if @cost_by_provider != [] || @cost_by_prompt != [] do %>
-          <div style="display: flex; justify-content: flex-end; margin-top: 10px;">
-            <button
-              phx-click="toggle_cost_breakdown"
-              style="background-color: var(--bg-secondary); border: 1px solid var(--border); padding: 4px 10px; font-size: 11px; color: var(--text-primary); cursor: pointer; display: flex; align-items: center; gap: 4px; border-radius: 5px; transition: all 0.15s ease; font-weight: 500;"
-              onmouseover="this.style.borderColor='var(--accent)'; this.style.color='var(--accent)'"
-              onmouseout="this.style.borderColor='var(--border)'; this.style.color='var(--text-primary)'"
-            >
-              <span>{if @show_cost_breakdown, do: "Hide breakdown", else: "View breakdown"}</span>
-              <.icon
-                name={if @show_cost_breakdown, do: "hero-chevron-up", else: "hero-chevron-down"}
-                class="size-3"
-              />
-            </button>
+          <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 4px;">
+            <div class="stat-value">{@total_runs}</div>
+            <%= if @trends.trends.total_runs == :up do %>
+              <.icon name="hero-arrow-trending-up" class="size-5 text-green-600" />
+            <% end %>
+            <%= if @trends.trends.total_runs == :down do %>
+              <.icon name="hero-arrow-trending-down" class="size-5 text-red-600" />
+            <% end %>
           </div>
-        <% end %>
+          <div class="stat-label text-sm font-medium">Total Runs</div>
+          <div class="stat-description mt-xs">Evaluations executed</div>
+          <%= if @daily_activity != [] && Enum.any?(@daily_activity, & &1.total > 0) do %>
+            <div style="display: flex; justify-content: flex-end; margin-top: 10px;">
+              <button
+                phx-click="toggle_activity_chart"
+                style="background-color: var(--bg-secondary); border: 1px solid var(--border); padding: 4px 10px; font-size: 11px; color: var(--text-primary); cursor: pointer; display: flex; align-items: center; gap: 4px; border-radius: 5px; transition: all 0.15s ease; font-weight: 500;"
+                onmouseover="this.style.borderColor='var(--accent)'; this.style.color='var(--accent)'"
+                onmouseout="this.style.borderColor='var(--border)'; this.style.color='var(--text-primary)'"
+              >
+                <span>{if @show_activity_chart, do: "Hide chart", else: "Show chart"}</span>
+                <.icon
+                  name={if @show_activity_chart, do: "hero-chevron-up", else: "hero-chevron-down"}
+                  class="size-3"
+                />
+              </button>
+            </div>
+          <% end %>
+        </div>
+
+        <div class="aludel-card p-md">
+          <div class="stat-card-header">
+            <.icon name="hero-check-circle" class="size-5 text-muted" />
+            <div class="stat-info-tooltip">
+              <.icon name="hero-information-circle" class="size-4 stat-info-icon" />
+              <div class="stat-info-tooltip-content">
+                Success rate across all test assertions in suite runs (excludes individual prompt runs)
+              </div>
+            </div>
+          </div>
+          <div class="stat-value mb-xs">{@success_rate}%</div>
+          <div class="stat-label text-sm font-medium">Success Rate</div>
+          <div class="stat-description mt-xs">
+            {@total_passed} passed, {@total_failed} failed
+          </div>
+          <%= if @pass_rates != [] do %>
+            <div style="display: flex; justify-content: flex-end; margin-top: 10px;">
+              <button
+                phx-click="toggle_pass_rates"
+                style="background-color: var(--bg-secondary); border: 1px solid var(--border); padding: 4px 10px; font-size: 11px; color: var(--text-primary); cursor: pointer; display: flex; align-items: center; gap: 4px; border-radius: 5px; transition: all 0.15s ease; font-weight: 500;"
+                onmouseover="this.style.borderColor='var(--accent)'; this.style.color='var(--accent)'"
+                onmouseout="this.style.borderColor='var(--border)'; this.style.color='var(--text-primary)'"
+              >
+                <span>{if @show_pass_rates, do: "Hide by prompt", else: "View by prompt"}</span>
+                <.icon
+                  name={if @show_pass_rates, do: "hero-chevron-up", else: "hero-chevron-down"}
+                  class="size-3"
+                />
+              </button>
+            </div>
+          <% end %>
+        </div>
+
+        <div class="aludel-card p-md">
+          <div class="stat-card-header">
+            <.icon name="hero-clock" class="size-5 text-muted" />
+            <div class="stat-info-tooltip">
+              <.icon name="hero-information-circle" class="size-4 stat-info-icon" />
+              <div class="stat-info-tooltip-content">
+                Average response time per individual run with percentile distributions (P50 = 50th percentile, P95 = 95th percentile)
+              </div>
+            </div>
+          </div>
+          <div class="stat-value mb-xs">{trunc(@avg_latency)}ms</div>
+          <div class="stat-label text-sm font-medium">Avg Latency</div>
+          <div class="stat-description mt-xs">
+            Per run · P50: {trunc(@latency_p50)}ms, P95: {trunc(@latency_p95)}ms
+          </div>
+          <%= if @latency_by_provider != [] do %>
+            <div style="display: flex; justify-content: flex-end; margin-top: 10px;">
+              <button
+                phx-click="toggle_latency_breakdown"
+                style="background-color: var(--bg-secondary); border: 1px solid var(--border); padding: 4px 10px; font-size: 11px; color: var(--text-primary); cursor: pointer; display: flex; align-items: center; gap: 4px; border-radius: 5px; transition: all 0.15s ease; font-weight: 500;"
+                onmouseover="this.style.borderColor='var(--accent)'; this.style.color='var(--accent)'"
+                onmouseout="this.style.borderColor='var(--border)'; this.style.color='var(--text-primary)'"
+              >
+                <span>
+                  {if @show_latency_breakdown, do: "Hide breakdown", else: "View breakdown"}
+                </span>
+                <.icon
+                  name={
+                    if @show_latency_breakdown, do: "hero-chevron-up", else: "hero-chevron-down"
+                  }
+                  class="size-3"
+                />
+              </button>
+            </div>
+          <% end %>
+        </div>
+
+        <div id="cost-summary" class="aludel-card p-md">
+          <div class="stat-card-header">
+            <.icon name="hero-currency-dollar" class="size-5 text-muted" />
+            <div class="stat-info-tooltip">
+              <.icon name="hero-information-circle" class="size-4 stat-info-icon" />
+              <div class="stat-info-tooltip-content">
+                Combined costs across all prompt runs and suite executions, with average cost per execution
+              </div>
+            </div>
+          </div>
+          <div class="stat-value" style="margin-bottom: 2px;">
+            ${:erlang.float_to_binary(@total_cost, decimals: 4)}
+          </div>
+          <div class="stat-label" style="font-size: 13px; font-weight: 500;">Total Cost</div>
+          <div class="stat-description" style="margin-top: 2px;">
+            ${:erlang.float_to_binary(@cost_per_run, decimals: 4)} per execution
+          </div>
+          <%= if @cost_by_provider != [] || @cost_by_prompt != [] do %>
+            <div style="display: flex; justify-content: flex-end; margin-top: 10px;">
+              <button
+                phx-click="toggle_cost_breakdown"
+                style="background-color: var(--bg-secondary); border: 1px solid var(--border); padding: 4px 10px; font-size: 11px; color: var(--text-primary); cursor: pointer; display: flex; align-items: center; gap: 4px; border-radius: 5px; transition: all 0.15s ease; font-weight: 500;"
+                onmouseover="this.style.borderColor='var(--accent)'; this.style.color='var(--accent)'"
+                onmouseout="this.style.borderColor='var(--border)'; this.style.color='var(--text-primary)'"
+              >
+                <span>{if @show_cost_breakdown, do: "Hide breakdown", else: "View breakdown"}</span>
+                <.icon
+                  name={if @show_cost_breakdown, do: "hero-chevron-up", else: "hero-chevron-down"}
+                  class="size-3"
+                />
+              </button>
+            </div>
+          <% end %>
+        </div>
       </div>
-    </div>
+    </section>
 
     <%!-- Expandable breakdowns appear here after stat cards --%>
     <%= if @show_activity_chart && @daily_activity != [] && Enum.any?(@daily_activity, & &1.total > 0) do %>

--- a/lib/aludel/web/live/dataset_live/show.ex
+++ b/lib/aludel/web/live/dataset_live/show.ex
@@ -5,6 +5,8 @@ defmodule Aludel.Web.DatasetLive.Show do
 
   use Aludel.Web, :live_view
 
+  alias Aludel.Web.CoreComponents
+
   alias Aludel.Datasets
   alias Aludel.Datasets.Params
 
@@ -164,6 +166,6 @@ defmodule Aludel.Web.DatasetLive.Show do
   end
 
   defp error_text(errors) do
-    Enum.map_join(errors, ", ", &Aludel.Web.CoreComponents.translate_error/1)
+    Enum.map_join(errors, ", ", &CoreComponents.translate_error/1)
   end
 end

--- a/priv/repo/migrations/20260830161000_add_suite_run_analytics_totals.exs
+++ b/priv/repo/migrations/20260830161000_add_suite_run_analytics_totals.exs
@@ -1,0 +1,44 @@
+defmodule Aludel.Repo.Migrations.AddSuiteRunAnalyticsTotals do
+  use Ecto.Migration
+
+  def up do
+    alter table(:suite_runs) do
+      add :total_cost_usd, :decimal, precision: 18, scale: 8
+      add :cost_sample_count, :integer, null: false, default: 0
+      add :total_latency_ms, :bigint
+      add :latency_sample_count, :integer, null: false, default: 0
+    end
+
+    execute("""
+    UPDATE suite_runs AS suite_run
+    SET total_cost_usd = summary.total_cost_usd,
+        cost_sample_count = summary.cost_sample_count,
+        total_latency_ms = summary.total_latency_ms,
+        latency_sample_count = summary.latency_sample_count
+    FROM (
+      SELECT suite_runs.id,
+             SUM((result.value->>'cost_usd')::numeric)
+               FILTER (WHERE jsonb_typeof(result.value->'cost_usd') = 'number') AS total_cost_usd,
+             COUNT(*)
+               FILTER (WHERE jsonb_typeof(result.value->'cost_usd') = 'number')::integer AS cost_sample_count,
+             ROUND(SUM((result.value->>'latency_ms')::numeric)
+               FILTER (WHERE jsonb_typeof(result.value->'latency_ms') = 'number'))::bigint AS total_latency_ms,
+             COUNT(*)
+               FILTER (WHERE jsonb_typeof(result.value->'latency_ms') = 'number')::integer AS latency_sample_count
+      FROM suite_runs
+      LEFT JOIN LATERAL jsonb_array_elements(suite_runs.results) AS result(value) ON TRUE
+      GROUP BY suite_runs.id
+    ) AS summary
+    WHERE suite_run.id = summary.id
+    """)
+  end
+
+  def down do
+    alter table(:suite_runs) do
+      remove :latency_sample_count
+      remove :total_latency_ms
+      remove :cost_sample_count
+      remove :total_cost_usd
+    end
+  end
+end

--- a/priv/repo/migrations/20260830161100_add_analytics_window_indexes.exs
+++ b/priv/repo/migrations/20260830161100_add_analytics_window_indexes.exs
@@ -1,0 +1,18 @@
+defmodule Aludel.Repo.Migrations.AddAnalyticsWindowIndexes do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    create index(:runs, [:inserted_at], concurrently: true)
+    create index(:suite_runs, [:inserted_at], concurrently: true)
+    create index(:suite_runs, [:prompt_version_id, :inserted_at], concurrently: true)
+  end
+
+  def down do
+    drop index(:suite_runs, [:prompt_version_id, :inserted_at], concurrently: true)
+    drop index(:suite_runs, [:inserted_at], concurrently: true)
+    drop index(:runs, [:inserted_at], concurrently: true)
+  end
+end

--- a/test/aludel/evals_test.exs
+++ b/test/aludel/evals_test.exs
@@ -467,6 +467,10 @@ defmodule Aludel.EvalsTest do
       assert updated_suite_run.failed == 0
       assert Decimal.compare(updated_suite_run.avg_cost_usd, Decimal.new("0")) == :gt
       assert updated_suite_run.avg_latency_ms >= 0
+      assert updated_suite_run.cost_sample_count == 2
+      assert updated_suite_run.latency_sample_count == 2
+      assert Decimal.compare(updated_suite_run.total_cost_usd, Decimal.new("0")) == :gt
+      assert updated_suite_run.total_latency_ms >= 0
 
       reloaded_suite_run = Evals.get_suite_run!(suite_run.id)
 
@@ -552,6 +556,10 @@ defmodule Aludel.EvalsTest do
       assert suite_run.avg_latency_ms != nil
       assert Decimal.compare(suite_run.avg_cost_usd, Decimal.new("0")) == :gt
       assert suite_run.avg_latency_ms >= 0
+      assert suite_run.cost_sample_count == 2
+      assert suite_run.latency_sample_count == 2
+      assert Decimal.compare(suite_run.total_cost_usd, Decimal.new("0")) == :gt
+      assert suite_run.total_latency_ms >= 0
     end
 
     test "execute_suite handles partial failures in metrics" do

--- a/test/aludel/stats/overview_test.exs
+++ b/test/aludel/stats/overview_test.exs
@@ -2,7 +2,10 @@ defmodule Aludel.Stats.OverviewTest do
   use Aludel.DataCase
 
   import Aludel.PromptsFixtures
+  import Aludel.EvalsFixtures
+  import Aludel.ProvidersFixtures
 
+  alias Aludel.Evals.SuiteRun
   alias Aludel.Runs.Run
   alias Aludel.Stats.Overview
 
@@ -84,5 +87,88 @@ defmodule Aludel.Stats.OverviewTest do
       assert stats.current.total_runs == 1
       assert stats.trends.total_runs == :stable
     end
+  end
+
+  describe "bounded quality and efficiency comparisons" do
+    test "compares quality, cost, latency, efficiency, and stability in matching periods" do
+      now = ~U[2026-08-30 12:00:00Z]
+      prompt = prompt_fixture()
+      {:ok, version} = Aludel.Prompts.create_prompt_version(prompt, "Template")
+      suite = suite_fixture(%{prompt_id: prompt.id})
+      provider = provider_fixture()
+
+      insert_suite_run_at(suite, version, provider, DateTime.add(now, -2, :day), %{
+        passed: 10,
+        failed: 0,
+        avg_cost_usd: Decimal.new("0.01"),
+        avg_latency_ms: 200
+      })
+
+      insert_suite_run_at(suite, version, provider, DateTime.add(now, -3, :day), %{
+        passed: 0,
+        failed: 10,
+        avg_cost_usd: Decimal.new("0.01"),
+        avg_latency_ms: 200
+      })
+
+      insert_suite_run_at(suite, version, provider, DateTime.add(now, -10, :day), %{
+        passed: 10,
+        failed: 0,
+        avg_cost_usd: Decimal.new("0.01"),
+        avg_latency_ms: 100
+      })
+
+      stats = Overview.comparison_stats(7, now)
+
+      assert stats.current.suite_runs == 2
+      assert stats.current.pass_rate == 50.0
+      assert stats.current.total_cost_usd == 0.2
+      assert stats.current.avg_latency_ms == 200.0
+      assert stats.current.cost_per_passed_test == 0.02
+      assert stats.current.latency_per_passed_test == 400.0
+      assert stats.current.pass_rate_stddev == 50.0
+      assert stats.current.stability_sample_size == 2
+
+      assert stats.previous.pass_rate == 100.0
+      assert stats.previous.cost_per_passed_test == 0.01
+      assert stats.previous.latency_per_passed_test == 100.0
+      assert stats.comparison.regressions == [:quality, :cost, :latency]
+      assert stats.comparison.stability == :volatile
+    end
+
+    test "represents zero-pass efficiency as unavailable" do
+      now = ~U[2026-08-30 12:00:00Z]
+      prompt = prompt_fixture()
+      {:ok, version} = Aludel.Prompts.create_prompt_version(prompt, "Template")
+      suite = suite_fixture(%{prompt_id: prompt.id})
+      provider = provider_fixture()
+
+      insert_suite_run_at(suite, version, provider, DateTime.add(now, -1, :day), %{
+        passed: 0,
+        failed: 4,
+        avg_cost_usd: Decimal.new("0.02"),
+        avg_latency_ms: 250
+      })
+
+      stats = Overview.comparison_stats(7, now)
+
+      assert stats.current.efficiency_status == :no_passes
+      assert stats.current.cost_per_passed_test == nil
+      assert stats.current.latency_per_passed_test == nil
+    end
+  end
+
+  defp insert_suite_run_at(suite, version, provider, inserted_at, attrs) do
+    %SuiteRun{}
+    |> SuiteRun.changeset(
+      Map.merge(attrs, %{
+        suite_id: suite.id,
+        prompt_version_id: version.id,
+        provider_id: provider.id
+      })
+    )
+    |> Ecto.Changeset.put_change(:inserted_at, inserted_at)
+    |> Ecto.Changeset.put_change(:updated_at, inserted_at)
+    |> Repo.insert!()
   end
 end

--- a/test/aludel/stats/signals_test.exs
+++ b/test/aludel/stats/signals_test.exs
@@ -1,0 +1,52 @@
+defmodule Aludel.Stats.SignalsTest do
+  use ExUnit.Case, async: true
+
+  alias Aludel.Stats.Signals
+
+  test "flags bounded quality, cost, and latency regressions" do
+    previous = %{
+      pass_rate: 100.0,
+      cost_per_passed_test: 0.01,
+      avg_latency_ms: 100.0
+    }
+
+    current = %{
+      pass_rate: 50.0,
+      cost_per_passed_test: 0.02,
+      avg_latency_ms: 130.0,
+      pass_rate_stddev: 50.0,
+      stability_sample_size: 2
+    }
+
+    comparison = Signals.compare(current, previous)
+
+    assert comparison.deltas.pass_rate == -50.0
+    assert comparison.deltas.cost_per_passed_test == 100.0
+    assert comparison.deltas.avg_latency_ms == 30.0
+    assert comparison.regressions == [:quality, :cost, :latency]
+    assert comparison.stability == :volatile
+  end
+
+  test "requires enough samples for a stability classification" do
+    comparison =
+      Signals.compare(
+        %{pass_rate_stddev: 0.0, stability_sample_size: 1},
+        %{}
+      )
+
+    assert comparison.stability == :insufficient_data
+    assert comparison.regressions == []
+  end
+
+  test "does not manufacture ratios when a previous metric is zero or missing" do
+    comparison =
+      Signals.compare(
+        %{cost_per_passed_test: 0.02, avg_latency_ms: nil},
+        %{cost_per_passed_test: 0.0, avg_latency_ms: 100.0}
+      )
+
+    assert comparison.deltas.cost_per_passed_test == nil
+    assert comparison.deltas.avg_latency_ms == nil
+    assert comparison.regressions == []
+  end
+end

--- a/test/aludel_web/live/dashboard_live_test.exs
+++ b/test/aludel_web/live/dashboard_live_test.exs
@@ -122,4 +122,47 @@ defmodule Aludel.Web.DashboardLiveTest do
     # Total Cost tooltip
     assert html =~ "Combined costs across all prompt runs and suite executions"
   end
+
+  test "renders 7-day and 30-day rolling comparison cards before lifetime context", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/")
+
+    assert has_element?(view, "#rolling-window-7")
+    assert has_element?(view, "#rolling-window-30")
+    assert has_element?(view, "#rolling-window-7-pass-rate")
+    assert has_element?(view, "#rolling-window-7-cost-per-pass")
+    assert has_element?(view, "#rolling-window-7-latency-per-pass")
+    assert has_element?(view, "#lifetime-summary")
+  end
+
+  test "renders zero-pass efficiency without a misleading ratio", %{conn: conn} do
+    prompt = prompt_fixture()
+    {:ok, version} = Aludel.Prompts.create_prompt_version(prompt, "Template")
+    suite = suite_fixture(%{prompt_id: prompt.id})
+    provider = Aludel.ProvidersFixtures.provider_fixture()
+
+    _suite_run =
+      suite_run_fixture(%{
+        suite_id: suite.id,
+        prompt_version_id: version.id,
+        provider_id: provider.id,
+        passed: 0,
+        failed: 5,
+        avg_cost_usd: Decimal.new("0.01"),
+        avg_latency_ms: 200
+      })
+
+    {:ok, view, _html} = live(conn, "/")
+
+    assert has_element?(
+             view,
+             "#rolling-window-7-cost-per-pass[data-state='no-passes']",
+             "No passing tests"
+           )
+
+    assert has_element?(
+             view,
+             "#rolling-window-7-latency-per-pass[data-state='no-passes']",
+             "No passing tests"
+           )
+  end
 end

--- a/test/aludel_web/live/suite_live/show_test.exs
+++ b/test/aludel_web/live/suite_live/show_test.exs
@@ -9,8 +9,8 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
   import Aludel.ProvidersFixtures
   import Mox
 
-  alias Aludel.Evals
   alias Aludel.Datasets
+  alias Aludel.Evals
   alias Aludel.Interfaces.HttpClientMock
 
   test "displays suite details", %{conn: conn} do

--- a/test/support/migrations/20260830161000_add_suite_run_analytics_totals.exs
+++ b/test/support/migrations/20260830161000_add_suite_run_analytics_totals.exs
@@ -1,0 +1,44 @@
+defmodule Aludel.TestRepo.Migrations.AddSuiteRunAnalyticsTotals do
+  use Ecto.Migration
+
+  def up do
+    alter table(:suite_runs) do
+      add :total_cost_usd, :decimal, precision: 18, scale: 8
+      add :cost_sample_count, :integer, null: false, default: 0
+      add :total_latency_ms, :bigint
+      add :latency_sample_count, :integer, null: false, default: 0
+    end
+
+    execute("""
+    UPDATE suite_runs AS suite_run
+    SET total_cost_usd = summary.total_cost_usd,
+        cost_sample_count = summary.cost_sample_count,
+        total_latency_ms = summary.total_latency_ms,
+        latency_sample_count = summary.latency_sample_count
+    FROM (
+      SELECT suite_runs.id,
+             SUM((result.value->>'cost_usd')::numeric)
+               FILTER (WHERE jsonb_typeof(result.value->'cost_usd') = 'number') AS total_cost_usd,
+             COUNT(*)
+               FILTER (WHERE jsonb_typeof(result.value->'cost_usd') = 'number')::integer AS cost_sample_count,
+             ROUND(SUM((result.value->>'latency_ms')::numeric)
+               FILTER (WHERE jsonb_typeof(result.value->'latency_ms') = 'number'))::bigint AS total_latency_ms,
+             COUNT(*)
+               FILTER (WHERE jsonb_typeof(result.value->'latency_ms') = 'number')::integer AS latency_sample_count
+      FROM suite_runs
+      LEFT JOIN LATERAL jsonb_array_elements(suite_runs.results) AS result(value) ON TRUE
+      GROUP BY suite_runs.id
+    ) AS summary
+    WHERE suite_run.id = summary.id
+    """)
+  end
+
+  def down do
+    alter table(:suite_runs) do
+      remove :latency_sample_count
+      remove :total_latency_ms
+      remove :cost_sample_count
+      remove :total_cost_usd
+    end
+  end
+end

--- a/test/support/migrations/20260830161100_add_analytics_window_indexes.exs
+++ b/test/support/migrations/20260830161100_add_analytics_window_indexes.exs
@@ -1,0 +1,18 @@
+defmodule Aludel.TestRepo.Migrations.AddAnalyticsWindowIndexes do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    create index(:runs, [:inserted_at], concurrently: true)
+    create index(:suite_runs, [:inserted_at], concurrently: true)
+    create index(:suite_runs, [:prompt_version_id, :inserted_at], concurrently: true)
+  end
+
+  def down do
+    drop index(:suite_runs, [:prompt_version_id, :inserted_at], concurrently: true)
+    drop index(:suite_runs, [:inserted_at], concurrently: true)
+    drop index(:runs, [:inserted_at], concurrently: true)
+  end
+end


### PR DESCRIPTION
## Motivation

Give the dashboard decision-useful recent context instead of relying on lifetime totals. The dashboard now compares rolling 7-day and 30-day periods with their matching previous periods, reports pass rate and exact efficiency per passing test, classifies pass-rate stability, and flags bounded quality, cost, and latency regressions.

Suite runs persist exact telemetry totals and sample counts so retries and partial telemetry remain mathematically correct. Existing result-bearing records are backfilled, legacy average-only records retain a compatibility fallback, and concurrent indexes support bounded time-window reads.

Closes #78.

## Test Plan

- Covers matching current and previous period boundaries, weighted pass rates, exact cost and latency efficiency, stability, regression thresholds, and zero-pass states.
- Covers normal suite execution and retries persisting exact totals and sample counts.
- Covers the 7-day and 30-day LiveView cards, lifetime context, and explicit no-passing-tests rendering.
- Full compile, formatting, static analysis, security scan, and test suite pass.

## Next Steps

Prompt evolution will consume the same persisted aggregates in the follow-up for #79 and #81.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recent performance comparisons for 7-day and 30-day periods.
  * Dashboard now shows run counts, pass rates, cost per pass, latency per pass, stability, and regression indicators.
  * Added lifetime context for total runs, success rate, average latency, and total cost.
  * Added aggregate cost and latency tracking for suite runs.

* **Bug Fixes**
  * Cost-per-pass and latency-per-pass now clearly show “No passing tests” when applicable.
  * Comparisons avoid displaying misleading ratios when data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->