### PR TITLE
feat(analytics): add bounded evolution signals

### DIFF
--- a/lib/aludel/prompts.ex
+++ b/lib/aludel/prompts.ex
@@ -228,9 +228,9 @@ defmodule Aludel.Prompts do
 
   Includes pass rates, cost, latency, and per-provider breakdown.
   """
-  @spec get_evolution_metrics(binary()) :: [map()]
-  def get_evolution_metrics(prompt_id) do
-    Evolution.get_metrics(prompt_id)
+  @spec get_evolution_metrics(binary(), keyword()) :: [map()]
+  def get_evolution_metrics(prompt_id, opts \\ []) do
+    Evolution.get_metrics(prompt_id, opts)
   end
 
   # Private functions

--- a/lib/aludel/prompts/evolution.ex
+++ b/lib/aludel/prompts/evolution.ex
@@ -1,7 +1,6 @@
 defmodule Aludel.Prompts.Evolution do
   @moduledoc """
-  Functions for analyzing prompt version evolution and performance
-  metrics.
+  Functions for analyzing prompt version evolution and performance metrics.
   """
 
   import Ecto.Query
@@ -14,29 +13,26 @@ defmodule Aludel.Prompts.Evolution do
   @doc """
   Returns aggregated metrics for all versions of a prompt.
 
-  Returns list of maps with structure:
-  - version_id: binary_id
-  - version_number: integer
-  - created_at: datetime
-  - total_runs: integer (suite runs only)
-  - avg_pass_rate: float | nil
-  - avg_score: Decimal.t() | nil
-  - avg_cost_usd: Decimal.t() | nil
-  - avg_latency_ms: integer | nil
-  - provider_breakdown: list of provider-specific metrics
+  The optional `:days` and `:as_of` values bound suite-run analysis while
+  retaining every prompt version in the result.
   """
-  @spec get_metrics(binary()) :: [map()]
-  def get_metrics(prompt_id) do
-    prompt_id
-    |> get_versions()
-    |> Enum.map(&build_version_metrics/1)
+  @spec get_metrics(binary(), keyword()) :: [map()]
+  def get_metrics(prompt_id, opts \\ []) do
+    versions = get_versions(prompt_id)
+    runs_by_version = get_suite_runs(versions, opts)
+
+    versions
+    |> Enum.map(fn version ->
+      build_version_metrics(version, Map.get(runs_by_version, version.id, []))
+    end)
     |> Deltas.annotate()
   end
 
   @doc false
-  def calculate_avg_cost([]), do: nil
+  def calculate_avg_cost([]) do
+    nil
+  end
 
-  @doc false
   def calculate_avg_cost(suite_runs) do
     costs =
       suite_runs
@@ -46,16 +42,18 @@ defmodule Aludel.Prompts.Evolution do
     if Enum.empty?(costs) do
       nil
     else
-      avg = Enum.reduce(costs, Decimal.new("0"), &Decimal.add/2)
-      avg = Decimal.div(avg, Decimal.new(length(costs)))
-      Decimal.round(avg, 4)
+      costs
+      |> Enum.reduce(Decimal.new("0"), &Decimal.add/2)
+      |> Decimal.div(Decimal.new(length(costs)))
+      |> Decimal.round(4)
     end
   end
 
   @doc false
-  def calculate_avg_latency([]), do: nil
+  def calculate_avg_latency([]) do
+    nil
+  end
 
-  @doc false
   def calculate_avg_latency(suite_runs) do
     latencies =
       suite_runs
@@ -70,9 +68,10 @@ defmodule Aludel.Prompts.Evolution do
   end
 
   @doc false
-  def calculate_avg_score([]), do: nil
+  def calculate_avg_score([]) do
+    nil
+  end
 
-  @doc false
   def calculate_avg_score(suite_runs) do
     scores =
       suite_runs
@@ -82,19 +81,15 @@ defmodule Aludel.Prompts.Evolution do
     if Enum.empty?(scores) do
       nil
     else
-      avg = Enum.reduce(scores, Decimal.new("0"), &Decimal.add/2)
-      avg = Decimal.div(avg, Decimal.new(length(scores)))
-      Decimal.round(avg, 1)
+      scores
+      |> Enum.reduce(Decimal.new("0"), &Decimal.add/2)
+      |> Decimal.div(Decimal.new(length(scores)))
+      |> Decimal.round(1)
     end
   end
 
   @doc """
   Prepares metrics data for Chart.js visualization.
-
-  Returns map with structure:
-  - versions: list of version numbers
-  - overall: aggregated metrics across all providers
-  - by_provider: metrics grouped by provider name
   """
   @spec prepare_chart_data([map()]) :: map()
   def prepare_chart_data(metrics) do
@@ -105,93 +100,206 @@ defmodule Aludel.Prompts.Evolution do
     }
   end
 
-  # Private functions
-
   defp get_versions(prompt_id) do
     PromptVersion
-    |> where([v], v.prompt_id == ^prompt_id)
-    |> order_by([v], asc: v.version)
+    |> where([version], version.prompt_id == ^prompt_id)
+    |> order_by([version], asc: version.version)
     |> repo().all()
   end
 
-  defp build_version_metrics(version) do
-    suite_runs = get_suite_runs(version.id)
-
-    %{
-      version_id: version.id,
-      version_number: version.version,
-      created_at: version.inserted_at,
-      total_runs: length(suite_runs),
-      avg_pass_rate: calculate_avg_pass_rate(suite_runs),
-      avg_score: calculate_avg_score(suite_runs),
-      avg_cost_usd: calculate_avg_cost(suite_runs),
-      avg_latency_ms: calculate_avg_latency(suite_runs),
-      provider_breakdown: build_provider_breakdown(suite_runs)
-    }
+  defp get_suite_runs([], _opts) do
+    %{}
   end
 
-  defp get_suite_runs(version_id) do
+  defp get_suite_runs(versions, opts) do
+    version_ids = Enum.map(versions, & &1.id)
+
     SuiteRun
-    |> where([sr], sr.prompt_version_id == ^version_id)
+    |> join(:inner, [suite_run], provider in Provider, on: provider.id == suite_run.provider_id)
+    |> where([suite_run], suite_run.prompt_version_id in ^version_ids)
+    |> maybe_bound_runs(opts)
+    |> select([suite_run, provider], %{
+      prompt_version_id: suite_run.prompt_version_id,
+      provider_id: suite_run.provider_id,
+      provider_name: provider.name,
+      passed: suite_run.passed,
+      failed: suite_run.failed,
+      avg_cost_usd: suite_run.avg_cost_usd,
+      avg_latency_ms: suite_run.avg_latency_ms,
+      avg_score: suite_run.avg_score,
+      total_cost_usd: suite_run.total_cost_usd,
+      cost_sample_count: suite_run.cost_sample_count,
+      total_latency_ms: suite_run.total_latency_ms,
+      latency_sample_count: suite_run.latency_sample_count
+    })
     |> repo().all()
+    |> Enum.group_by(& &1.prompt_version_id)
   end
 
-  defp calculate_avg_pass_rate([]), do: nil
+  defp maybe_bound_runs(query, opts) do
+    case Keyword.get(opts, :days) do
+      days when is_integer(days) and days > 0 ->
+        as_of = opts |> Keyword.get(:as_of, current_as_of()) |> DateTime.truncate(:second)
+        starts_at = DateTime.add(as_of, -days, :day)
 
-  defp calculate_avg_pass_rate(suite_runs) do
-    total_tests =
-      Enum.reduce(suite_runs, 0, fn sr, acc ->
-        acc + sr.passed + sr.failed
-      end)
+        where(
+          query,
+          [suite_run],
+          suite_run.inserted_at >= ^starts_at and suite_run.inserted_at < ^as_of
+        )
 
-    if total_tests == 0 do
-      nil
-    else
-      total_passed = Enum.reduce(suite_runs, 0, fn sr, acc -> acc + sr.passed end)
-      Float.round(total_passed / total_tests * 100, 2)
+      nil ->
+        query
+
+      _invalid ->
+        raise ArgumentError, ":days must be a positive integer"
     end
   end
 
-  defp build_provider_breakdown([]), do: []
+  defp build_version_metrics(version, suite_runs) do
+    suite_runs
+    |> aggregate_metrics()
+    |> Map.merge(%{
+      version_id: version.id,
+      version_number: version.version,
+      created_at: version.inserted_at,
+      provider_breakdown: build_provider_breakdown(suite_runs)
+    })
+  end
+
+  defp aggregate_metrics(suite_runs) do
+    passed = Enum.sum(Enum.map(suite_runs, & &1.passed))
+    failed = Enum.sum(Enum.map(suite_runs, & &1.failed))
+    total_tests = passed + failed
+    total_cost = Enum.reduce(suite_runs, nil, &sum_optional(exact_cost(&1), &2))
+    total_latency = Enum.reduce(suite_runs, nil, &sum_optional(exact_latency(&1), &2))
+
+    %{
+      total_runs: length(suite_runs),
+      avg_pass_rate: percentage(passed, total_tests),
+      avg_score: calculate_avg_score(suite_runs),
+      avg_cost_usd: calculate_avg_cost(suite_runs),
+      avg_latency_ms: calculate_avg_latency(suite_runs),
+      cost_per_passed_test: ratio(total_cost, passed),
+      latency_per_passed_test: ratio(total_latency, passed),
+      efficiency_status: efficiency_status(total_tests, passed),
+      pass_rate_stddev: pass_rate_stddev(suite_runs),
+      stability_sample_size: Enum.count(suite_runs, &(test_count(&1) > 0))
+    }
+  end
+
+  defp build_provider_breakdown([]) do
+    []
+  end
 
   defp build_provider_breakdown(suite_runs) do
-    provider_ids =
-      suite_runs
-      |> Enum.map(& &1.provider_id)
-      |> Enum.uniq()
-
-    providers =
-      Provider
-      |> where([p], p.id in ^provider_ids)
-      |> repo().all()
-      |> Map.new(&{&1.id, &1})
-
     suite_runs
     |> Enum.group_by(& &1.provider_id)
     |> Enum.map(fn {provider_id, runs} ->
-      provider = Map.fetch!(providers, provider_id)
-
-      total_tests = Enum.reduce(runs, 0, fn sr, acc -> acc + sr.passed + sr.failed end)
-      total_passed = Enum.reduce(runs, 0, fn sr, acc -> acc + sr.passed end)
-
-      avg_pass_rate =
-        if total_tests == 0 do
-          nil
-        else
-          Float.round(total_passed / total_tests * 100, 2)
-        end
-
-      %{
+      runs
+      |> aggregate_metrics()
+      |> Map.merge(%{
         provider_id: provider_id,
-        provider_name: provider.name,
-        runs: length(runs),
-        avg_pass_rate: avg_pass_rate,
-        avg_score: calculate_avg_score(runs),
-        avg_cost_usd: calculate_avg_cost(runs),
-        avg_latency_ms: calculate_avg_latency(runs)
-      }
+        provider_name: List.first(runs).provider_name,
+        runs: length(runs)
+      })
     end)
     |> Enum.sort_by(& &1.provider_name)
+  end
+
+  defp exact_cost(%{total_cost_usd: %Decimal{}, cost_sample_count: samples} = run)
+       when samples > 0 do
+    Decimal.to_float(run.total_cost_usd)
+  end
+
+  defp exact_cost(%{avg_cost_usd: %Decimal{} = average} = run) do
+    Decimal.to_float(average) * test_count(run)
+  end
+
+  defp exact_cost(_run) do
+    nil
+  end
+
+  defp exact_latency(%{total_latency_ms: total, latency_sample_count: samples})
+       when is_integer(total) and samples > 0 do
+    total * 1.0
+  end
+
+  defp exact_latency(%{avg_latency_ms: average} = run) when is_integer(average) do
+    average * test_count(run) * 1.0
+  end
+
+  defp exact_latency(_run) do
+    nil
+  end
+
+  defp test_count(run) do
+    run.passed + run.failed
+  end
+
+  defp percentage(_numerator, 0) do
+    nil
+  end
+
+  defp percentage(numerator, denominator) do
+    Float.round(numerator / denominator * 100, 2)
+  end
+
+  defp ratio(nil, _denominator) do
+    nil
+  end
+
+  defp ratio(_numerator, 0) do
+    nil
+  end
+
+  defp ratio(numerator, denominator) do
+    Float.round(numerator / denominator, 4)
+  end
+
+  defp efficiency_status(0, _passed) do
+    :no_tests
+  end
+
+  defp efficiency_status(_total_tests, 0) do
+    :no_passes
+  end
+
+  defp efficiency_status(_total_tests, _passed) do
+    :available
+  end
+
+  defp pass_rate_stddev(suite_runs) do
+    rates =
+      suite_runs
+      |> Enum.filter(&(test_count(&1) > 0))
+      |> Enum.map(&percentage(&1.passed, test_count(&1)))
+
+    case rates do
+      [] ->
+        nil
+
+      _rates ->
+        mean = Enum.sum(rates) / length(rates)
+        variance = Enum.sum(Enum.map(rates, &:math.pow(&1 - mean, 2))) / length(rates)
+        Float.round(:math.sqrt(variance), 2)
+    end
+  end
+
+  defp sum_optional(nil, nil) do
+    nil
+  end
+
+  defp sum_optional(nil, total) do
+    total
+  end
+
+  defp sum_optional(value, nil) do
+    value
+  end
+
+  defp sum_optional(value, total) do
+    value + total
   end
 
   defp extract_versions(metrics) do
@@ -214,49 +322,45 @@ defmodule Aludel.Prompts.Evolution do
         {breakdown.provider_name, metric.version_number, breakdown}
       end)
     end)
-    |> Enum.group_by(fn {provider_name, _version, _breakdown} ->
-      provider_name
-    end)
-    |> Enum.map(fn {provider_name, entries} ->
-      # Sort by version to maintain order
-      sorted_entries =
-        entries
-        |> Enum.sort_by(fn {_name, version, _breakdown} -> version end)
-
-      pass_rates =
-        Enum.map(sorted_entries, fn {_name, _version, breakdown} ->
-          breakdown.avg_pass_rate
-        end)
-
-      scores =
-        Enum.map(sorted_entries, fn {_name, _version, breakdown} ->
-          decimal_to_float(breakdown.avg_score)
-        end)
-
-      costs =
-        Enum.map(sorted_entries, fn {_name, _version, breakdown} ->
-          decimal_to_float(breakdown.avg_cost_usd)
-        end)
-
-      latencies =
-        Enum.map(sorted_entries, fn {_name, _version, breakdown} ->
-          breakdown.avg_latency_ms
-        end)
+    |> Enum.group_by(fn {provider_name, _version, _breakdown} -> provider_name end)
+    |> Map.new(fn {provider_name, entries} ->
+      sorted_entries = Enum.sort_by(entries, fn {_name, version, _breakdown} -> version end)
 
       {provider_name,
        %{
-         pass_rates: pass_rates,
-         scores: scores,
-         costs: costs,
-         latencies: latencies
+         pass_rates: extract_provider_values(sorted_entries, :avg_pass_rate),
+         scores: extract_provider_values(sorted_entries, :avg_score, &decimal_to_float/1),
+         costs: extract_provider_values(sorted_entries, :avg_cost_usd, &decimal_to_float/1),
+         latencies: extract_provider_values(sorted_entries, :avg_latency_ms)
        }}
     end)
-    |> Map.new()
   end
 
-  defp decimal_to_float(nil), do: nil
-  defp decimal_to_float(%Decimal{} = value), do: Decimal.to_float(value)
-  defp decimal_to_float(value), do: value
+  defp extract_provider_values(entries, key, transform \\ &Function.identity/1) do
+    Enum.map(entries, fn {_name, _version, breakdown} ->
+      breakdown |> Map.fetch!(key) |> transform.()
+    end)
+  end
 
-  defp repo, do: Aludel.Repo.get()
+  defp decimal_to_float(nil) do
+    nil
+  end
+
+  defp decimal_to_float(%Decimal{} = value) do
+    Decimal.to_float(value)
+  end
+
+  defp decimal_to_float(value) do
+    value
+  end
+
+  defp repo do
+    Aludel.Repo.get()
+  end
+
+  defp current_as_of do
+    DateTime.utc_now()
+    |> DateTime.truncate(:second)
+    |> DateTime.add(1, :second)
+  end
 end

--- a/lib/aludel/prompts/evolution/deltas.ex
+++ b/lib/aludel/prompts/evolution/deltas.ex
@@ -1,6 +1,8 @@
 defmodule Aludel.Prompts.Evolution.Deltas do
   @moduledoc false
 
+  alias Aludel.Stats.Signals
+
   @delta_keys [:pass_rate, :cost_usd, :latency_ms]
 
   @spec annotate([map()]) :: [map()]
@@ -24,12 +26,34 @@ defmodule Aludel.Prompts.Evolution.Deltas do
       |> provider_breakdown()
       |> Enum.map(fn provider_metrics ->
         previous_provider = Map.get(previous_providers, provider_metrics.provider_id)
-        Map.put(provider_metrics, :deltas, build_deltas(provider_metrics, previous_provider))
+
+        provider_metrics
+        |> Map.put(:deltas, build_deltas(provider_metrics, previous_provider))
+        |> Map.put(:signals, build_signals(provider_metrics, previous_provider))
       end)
 
     metric
     |> Map.put(:deltas, build_deltas(metric, previous_metric))
+    |> Map.put(:signals, build_signals(metric, previous_metric))
     |> Map.put(:provider_breakdown, provider_breakdown)
+  end
+
+  defp build_signals(current, previous) do
+    Signals.compare(signal_metrics(current), signal_metrics(previous))
+  end
+
+  defp signal_metrics(nil) do
+    %{}
+  end
+
+  defp signal_metrics(metric) do
+    %{
+      pass_rate: metric[:avg_pass_rate],
+      cost_per_passed_test: metric[:cost_per_passed_test],
+      avg_latency_ms: metric[:avg_latency_ms],
+      pass_rate_stddev: metric[:pass_rate_stddev],
+      stability_sample_size: metric[:stability_sample_size]
+    }
   end
 
   defp build_deltas(_current, nil) do

--- a/lib/aludel/web/live/prompt_live/evolution.ex
+++ b/lib/aludel/web/live/prompt_live/evolution.ex
@@ -22,7 +22,7 @@ defmodule Aludel.Web.PromptLive.Evolution do
   @impl Phoenix.LiveView
   def handle_params(%{"id" => id}, _uri, socket) do
     prompt = Prompts.get_prompt!(id)
-    metrics = Prompts.get_evolution_metrics(id)
+    metrics = Prompts.get_evolution_metrics(id, days: 30)
     chart_data = Evolution.prepare_chart_data(metrics)
 
     # Reverse metrics for table display (descending order: newest first)
@@ -32,6 +32,7 @@ defmodule Aludel.Web.PromptLive.Evolution do
      socket
      |> assign(:page_title, "#{prompt.name} - Evolution")
      |> assign(:prompt, prompt)
+     |> assign(:analysis_window, 30)
      |> assign(:metrics, reversed_metrics)
      |> assign(:chart_data, chart_data)}
   end
@@ -72,5 +73,51 @@ defmodule Aludel.Web.PromptLive.Evolution do
 
   def handle_event("close_export_dropdown", _params, socket) do
     {:noreply, assign(socket, :show_export_dropdown, false)}
+  end
+
+  defp efficiency_state(%{efficiency_status: :no_passes}) do
+    "no-passes"
+  end
+
+  defp efficiency_state(%{efficiency_status: :no_tests}) do
+    "no-tests"
+  end
+
+  defp efficiency_state(_metric) do
+    "available"
+  end
+
+  defp format_cost_per_pass(%{efficiency_status: :no_passes}) do
+    "No passing tests"
+  end
+
+  defp format_cost_per_pass(%{cost_per_passed_test: nil}) do
+    "Unavailable"
+  end
+
+  defp format_cost_per_pass(metric) do
+    "$#{:erlang.float_to_binary(metric.cost_per_passed_test, decimals: 4)}"
+  end
+
+  defp format_latency_per_pass(%{efficiency_status: :no_passes}) do
+    "No passing tests"
+  end
+
+  defp format_latency_per_pass(%{latency_per_passed_test: nil}) do
+    "Unavailable"
+  end
+
+  defp format_latency_per_pass(metric) do
+    "#{round(metric.latency_per_passed_test)}ms"
+  end
+
+  defp stability_label(:insufficient_data) do
+    "Needs more runs"
+  end
+
+  defp stability_label(stability) do
+    stability
+    |> Atom.to_string()
+    |> String.capitalize()
   end
 end

--- a/lib/aludel/web/live/prompt_live/evolution.html.heex
+++ b/lib/aludel/web/live/prompt_live/evolution.html.heex
@@ -1,5 +1,5 @@
 <Layouts.app flash={@flash} current_path={@current_path}>
-  <div class="page-container-wide">
+  <div id="prompt-evolution" class="page-container-wide">
     <div style="margin-bottom: 32px; padding-bottom: 20px; border-bottom: 1px solid var(--border);">
       <div style="display: flex; justify-content: space-between; align-items: start; margin-bottom: 12px;">
         <div style="flex: 1;">
@@ -91,7 +91,10 @@
     <% else %>
       <div class="aludel-card" style="margin-bottom: 24px;">
         <div style="padding: 20px; border-bottom: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center;">
-          <h2 style="margin: 0; font-size: 18px; font-weight: 600;">Evolution Trends</h2>
+          <div style="display: flex; align-items: center; gap: 10px;">
+            <h2 style="margin: 0; font-size: 18px; font-weight: 600;">Evolution Trends</h2>
+            <span id="evolution-window" class="tag">Last {@analysis_window} days</span>
+          </div>
           <button
             type="button"
             phx-click="toggle_view_mode"
@@ -181,6 +184,12 @@
                 <th style="padding: 16px; text-align: left; font-size: 13px; font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.05em;">
                   Avg Latency
                 </th>
+                <th style="padding: 16px; text-align: left; font-size: 13px; font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.05em;">
+                  Cost / Pass
+                </th>
+                <th style="padding: 16px; text-align: left; font-size: 13px; font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.05em;">
+                  Latency / Pass
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -191,6 +200,12 @@
                 >
                   <td style="padding: 16px; font-weight: 600; color: var(--text-primary);">
                     v{metric.version_number}
+                    <div
+                      id={"evolution-stability-#{metric.version_number}"}
+                      style="margin-top: 4px; font-size: 11px; font-weight: 500; color: var(--text-secondary);"
+                    >
+                      {stability_label(metric.signals.stability)}
+                    </div>
                   </td>
                   <td style="padding: 16px; color: var(--text-secondary); font-size: 14px;">
                     {Calendar.strftime(metric.created_at, "%b %d, %Y")}
@@ -260,6 +275,20 @@
                       metric={:latency_ms}
                       delta={metric.deltas.latency_ms}
                     />
+                  </td>
+                  <td
+                    id={"evolution-cost-per-pass-#{metric.version_number}"}
+                    data-state={efficiency_state(metric)}
+                    style="padding: 16px; font-size: 14px; color: var(--text-secondary);"
+                  >
+                    {format_cost_per_pass(metric)}
+                  </td>
+                  <td
+                    id={"evolution-latency-per-pass-#{metric.version_number}"}
+                    data-state={efficiency_state(metric)}
+                    style="padding: 16px; font-size: 14px; color: var(--text-secondary);"
+                  >
+                    {format_latency_per_pass(metric)}
                   </td>
                 </tr>
               <% end %>

--- a/test/aludel/prompts/evolution_test.exs
+++ b/test/aludel/prompts/evolution_test.exs
@@ -224,6 +224,89 @@ defmodule Aludel.Prompts.EvolutionTest do
       assert anthropic.avg_latency_ms == 420
       assert Decimal.equal?(anthropic.avg_score, Decimal.new("95.0"))
     end
+
+    test "computes outcome-weighted efficiency overall and by provider" do
+      prompt = prompt_fixture()
+      provider = provider_fixture(%{name: "Efficient Provider"})
+      {:ok, version} = Prompts.create_prompt_version(prompt, "Test {{var}}")
+      suite = suite_fixture(%{prompt_id: prompt.id})
+
+      {:ok, _suite_run} =
+        Evals.create_suite_run(%{
+          suite_id: suite.id,
+          prompt_version_id: version.id,
+          provider_id: provider.id,
+          passed: 5,
+          failed: 5,
+          avg_cost_usd: Decimal.new("0.01"),
+          avg_latency_ms: 200
+        })
+
+      [metric] = Evolution.get_metrics(prompt.id)
+      [breakdown] = metric.provider_breakdown
+
+      assert metric.cost_per_passed_test == 0.02
+      assert metric.latency_per_passed_test == 400.0
+      assert metric.efficiency_status == :available
+      assert breakdown.cost_per_passed_test == 0.02
+      assert breakdown.latency_per_passed_test == 400.0
+    end
+
+    test "marks zero-pass efficiency as unavailable" do
+      prompt = prompt_fixture()
+      provider = provider_fixture()
+      {:ok, version} = Prompts.create_prompt_version(prompt, "Test {{var}}")
+      suite = suite_fixture(%{prompt_id: prompt.id})
+
+      {:ok, _suite_run} =
+        Evals.create_suite_run(%{
+          suite_id: suite.id,
+          prompt_version_id: version.id,
+          provider_id: provider.id,
+          passed: 0,
+          failed: 5,
+          avg_cost_usd: Decimal.new("0.01"),
+          avg_latency_ms: 200
+        })
+
+      [metric] = Evolution.get_metrics(prompt.id)
+
+      assert metric.efficiency_status == :no_passes
+      assert metric.cost_per_passed_test == nil
+      assert metric.latency_per_passed_test == nil
+    end
+
+    test "adds stability and adjacent-version regression signals" do
+      prompt = prompt_fixture()
+      provider = provider_fixture()
+      {:ok, v1} = Prompts.create_prompt_version(prompt, "Version 1")
+      {:ok, v2} = Prompts.create_prompt_version(prompt, "Version 2")
+      suite = suite_fixture(%{prompt_id: prompt.id})
+
+      for {version, passed, failed, cost, latency} <- [
+            {v1, 10, 0, "0.01", 100},
+            {v1, 10, 0, "0.01", 100},
+            {v2, 10, 0, "0.02", 130},
+            {v2, 0, 10, "0.02", 130}
+          ] do
+        {:ok, _suite_run} =
+          Evals.create_suite_run(%{
+            suite_id: suite.id,
+            prompt_version_id: version.id,
+            provider_id: provider.id,
+            passed: passed,
+            failed: failed,
+            avg_cost_usd: Decimal.new(cost),
+            avg_latency_ms: latency
+          })
+      end
+
+      [_v1_metric, v2_metric] = Evolution.get_metrics(prompt.id)
+
+      assert v2_metric.pass_rate_stddev == 50.0
+      assert v2_metric.signals.stability == :volatile
+      assert v2_metric.signals.regressions == [:quality, :cost, :latency]
+    end
   end
 
   describe "calculate_avg_cost from suite_runs" do

--- a/test/aludel_web/live/prompt_live/evolution_test.exs
+++ b/test/aludel_web/live/prompt_live/evolution_test.exs
@@ -190,6 +190,59 @@ defmodule Aludel.Web.PromptLive.EvolutionTest do
       assert Decimal.equal?(metric.avg_score, Decimal.new("82.5"))
       assert socket.assigns.chart_data.overall.scores == [82.5]
     end
+
+    test "renders efficiency and stability signals for recent version metrics", %{conn: conn} do
+      prompt = prompt_fixture()
+      provider = provider_fixture()
+      {:ok, version} = Prompts.create_prompt_version(prompt, "Test {{var}}")
+      suite = suite_fixture(%{prompt_id: prompt.id})
+
+      for {passed, failed} <- [{5, 0}, {0, 5}] do
+        {:ok, _suite_run} =
+          Aludel.Evals.create_suite_run(%{
+            suite_id: suite.id,
+            prompt_version_id: version.id,
+            provider_id: provider.id,
+            passed: passed,
+            failed: failed,
+            avg_cost_usd: Decimal.new("0.01"),
+            avg_latency_ms: 200
+          })
+      end
+
+      {:ok, view, _html} = live(conn, "/prompts/#{prompt.id}/evolution")
+
+      assert has_element?(view, "#evolution-window", "Last 30 days")
+      assert has_element?(view, "#evolution-stability-1", "Volatile")
+      assert has_element?(view, "#evolution-cost-per-pass-1", "$0.0200")
+      assert has_element?(view, "#evolution-latency-per-pass-1", "400ms")
+    end
+
+    test "renders explicit zero-pass efficiency state", %{conn: conn} do
+      prompt = prompt_fixture()
+      provider = provider_fixture()
+      {:ok, version} = Prompts.create_prompt_version(prompt, "Test {{var}}")
+      suite = suite_fixture(%{prompt_id: prompt.id})
+
+      {:ok, _suite_run} =
+        Aludel.Evals.create_suite_run(%{
+          suite_id: suite.id,
+          prompt_version_id: version.id,
+          provider_id: provider.id,
+          passed: 0,
+          failed: 5,
+          avg_cost_usd: Decimal.new("0.01"),
+          avg_latency_ms: 200
+        })
+
+      {:ok, view, _html} = live(conn, "/prompts/#{prompt.id}/evolution")
+
+      assert has_element?(
+               view,
+               "#evolution-cost-per-pass-1[data-state='no-passes']",
+               "No passing tests"
+             )
+    end
   end
 
   describe "edge cases" do


### PR DESCRIPTION
## Motivation

Make prompt evolution useful for quality and efficiency decisions without unbounded query growth. Evolution analysis now reads the most recent 30 days in two constant-count queries, keeps all versions visible, computes weighted pass rates and outcome-based cost and latency per passing test, and classifies stability and adjacent-version regressions overall and per provider.

The LiveView labels its analysis window, displays stability plus efficiency metrics, and renders explicit no-tests and no-passing-tests states instead of misleading ratios.

Closes #79.
Closes #81.

## Test Plan

- Covers bounded version aggregation, provider breakdowns, weighted efficiency, zero-pass behavior, stability classes, and adjacent-version quality, cost, and latency regressions.
- Covers the LiveView analysis-window label, exact efficiency values, volatile stability, and explicit zero-pass rendering.
- Full compile, formatting, static analysis, security scan, and test suite pass.

## Next Steps

The GEPA workflow will build its Pareto and reflection experiences on these bounded evolution metrics.