### PR TITLE
feat(prompts): add Pareto analysis and version comparison

### DIFF
--- a/lib/aludel/evals.ex
+++ b/lib/aludel/evals.ex
@@ -34,6 +34,17 @@ defmodule Aludel.Evals do
   end
 
   @doc """
+  Lists evaluation suites for one prompt, ordered by name.
+  """
+  @spec list_suites_for_prompt(binary()) :: [Suite.t()]
+  def list_suites_for_prompt(prompt_id) do
+    Suite
+    |> where([suite], suite.prompt_id == ^prompt_id)
+    |> order_by([suite], asc: suite.name)
+    |> repo().all()
+  end
+
+  @doc """
   Lists all suites with their associated prompt preloaded.
   """
   @spec list_suites_with_prompt() :: [Suite.t()]

--- a/lib/aludel/prompts/evolution.ex
+++ b/lib/aludel/prompts/evolution.ex
@@ -118,6 +118,7 @@ defmodule Aludel.Prompts.Evolution do
     |> join(:inner, [suite_run], provider in Provider, on: provider.id == suite_run.provider_id)
     |> where([suite_run], suite_run.prompt_version_id in ^version_ids)
     |> maybe_bound_runs(opts)
+    |> maybe_filter_suite(opts)
     |> select([suite_run, provider], %{
       prompt_version_id: suite_run.prompt_version_id,
       provider_id: suite_run.provider_id,
@@ -153,6 +154,16 @@ defmodule Aludel.Prompts.Evolution do
 
       _invalid ->
         raise ArgumentError, ":days must be a positive integer"
+    end
+  end
+
+  defp maybe_filter_suite(query, opts) do
+    case Keyword.get(opts, :suite_id) do
+      suite_id when is_binary(suite_id) and suite_id != "" ->
+        where(query, [suite_run], suite_run.suite_id == ^suite_id)
+
+      _suite_id ->
+        query
     end
   end
 

--- a/lib/aludel/prompts/optimization.ex
+++ b/lib/aludel/prompts/optimization.ex
@@ -1,0 +1,54 @@
+defmodule Aludel.Prompts.Optimization do
+  @moduledoc """
+  Multi-objective prompt analysis inspired by GEPA's Pareto selection.
+  """
+
+  @required_metrics [:avg_pass_rate, :cost_per_passed_test, :latency_per_passed_test]
+
+  @spec analyze([map()]) :: %{candidates: [map()], frontier: [map()]}
+  def analyze(metrics) do
+    candidates = Enum.map(metrics, &annotate_candidate(&1, metrics))
+
+    %{
+      candidates: candidates,
+      frontier: Enum.filter(candidates, &(&1.pareto_status == :frontier))
+    }
+  end
+
+  defp annotate_candidate(candidate, metrics) do
+    status =
+      cond do
+        not eligible?(candidate) ->
+          :insufficient
+
+        Enum.any?(metrics, &dominates?(&1, candidate)) ->
+          :dominated
+
+        true ->
+          :frontier
+      end
+
+    Map.put(candidate, :pareto_status, status)
+  end
+
+  defp eligible?(candidate) do
+    Enum.all?(@required_metrics, &is_number(Map.get(candidate, &1)))
+  end
+
+  defp dominates?(challenger, candidate) do
+    eligible?(challenger) and challenger != candidate and
+      no_worse?(challenger, candidate) and strictly_better?(challenger, candidate)
+  end
+
+  defp no_worse?(challenger, candidate) do
+    challenger.avg_pass_rate >= candidate.avg_pass_rate and
+      challenger.cost_per_passed_test <= candidate.cost_per_passed_test and
+      challenger.latency_per_passed_test <= candidate.latency_per_passed_test
+  end
+
+  defp strictly_better?(challenger, candidate) do
+    challenger.avg_pass_rate > candidate.avg_pass_rate or
+      challenger.cost_per_passed_test < candidate.cost_per_passed_test or
+      challenger.latency_per_passed_test < candidate.latency_per_passed_test
+  end
+end

--- a/lib/aludel/web/live/prompt_live/evolution.ex
+++ b/lib/aludel/web/live/prompt_live/evolution.ex
@@ -6,8 +6,9 @@ defmodule Aludel.Web.PromptLive.Evolution do
 
   use Aludel.Web, :live_view
 
+  alias Aludel.Evals
   alias Aludel.Prompts
-  alias Aludel.Prompts.Evolution
+  alias Aludel.Prompts.{Evolution, Optimization}
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
@@ -20,10 +21,14 @@ defmodule Aludel.Web.PromptLive.Evolution do
   end
 
   @impl Phoenix.LiveView
-  def handle_params(%{"id" => id}, _uri, socket) do
+  def handle_params(%{"id" => id} = params, _uri, socket) do
     prompt = Prompts.get_prompt!(id)
-    metrics = Prompts.get_evolution_metrics(id, days: 30)
+    suites = Evals.list_suites_for_prompt(id)
+    selected_suite = select_suite(suites, params["suite_id"])
+    metric_options = metric_options(selected_suite)
+    metrics = Prompts.get_evolution_metrics(id, metric_options)
     chart_data = Evolution.prepare_chart_data(metrics)
+    pareto_analysis = Optimization.analyze(metrics)
 
     # Reverse metrics for table display (descending order: newest first)
     reversed_metrics = Enum.reverse(metrics)
@@ -33,6 +38,9 @@ defmodule Aludel.Web.PromptLive.Evolution do
      |> assign(:page_title, "#{prompt.name} - Evolution")
      |> assign(:prompt, prompt)
      |> assign(:analysis_window, 30)
+     |> assign(:suites, suites)
+     |> assign(:selected_suite, selected_suite)
+     |> assign(:pareto_analysis, pareto_analysis)
      |> assign(:metrics, reversed_metrics)
      |> assign(:chart_data, chart_data)}
   end
@@ -73,6 +81,13 @@ defmodule Aludel.Web.PromptLive.Evolution do
 
   def handle_event("close_export_dropdown", _params, socket) do
     {:noreply, assign(socket, :show_export_dropdown, false)}
+  end
+
+  def handle_event("select_pareto_suite", %{"suite_id" => suite_id}, socket) do
+    {:noreply,
+     push_patch(socket,
+       to: aludel_path("prompts/#{socket.assigns.prompt.id}/evolution?suite_id=#{suite_id}")
+     )}
   end
 
   defp efficiency_state(%{efficiency_status: :no_passes}) do
@@ -119,5 +134,21 @@ defmodule Aludel.Web.PromptLive.Evolution do
     stability
     |> Atom.to_string()
     |> String.capitalize()
+  end
+
+  defp select_suite([], _suite_id) do
+    nil
+  end
+
+  defp select_suite(suites, suite_id) do
+    Enum.find(suites, &(&1.id == suite_id)) || List.first(suites)
+  end
+
+  defp metric_options(nil) do
+    [days: 30]
+  end
+
+  defp metric_options(suite) do
+    [days: 30, suite_id: suite.id]
   end
 end

--- a/lib/aludel/web/live/prompt_live/evolution.html.heex
+++ b/lib/aludel/web/live/prompt_live/evolution.html.heex
@@ -89,6 +89,55 @@
         </div>
       </div>
     <% else %>
+      <section
+        id="pareto-frontier"
+        class="aludel-card"
+        style="margin-bottom: 24px; padding: 20px;"
+      >
+        <div style="display: flex; justify-content: space-between; align-items: start; gap: 16px; margin-bottom: 16px;">
+          <div>
+            <h2 style="margin: 0; font-size: 18px; font-weight: 600;">Pareto frontier</h2>
+            <p class="text-sm text-secondary" style="margin: 4px 0 0;">
+              Non-dominated quality, cost, and latency trade-offs
+            </p>
+          </div>
+          <form :if={@suites != []} id="pareto-suite-form" phx-change="select_pareto_suite">
+            <label for="pareto-suite" class="text-sm text-secondary">Evaluation suite</label>
+            <select id="pareto-suite" name="suite_id" style="display: block; margin-top: 4px;">
+              <option
+                :for={suite <- @suites}
+                value={suite.id}
+                selected={@selected_suite && suite.id == @selected_suite.id}
+              >
+                {suite.name}
+              </option>
+            </select>
+          </form>
+        </div>
+        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: 12px;">
+          <article
+            :for={candidate <- @pareto_analysis.candidates}
+            id={"pareto-version-#{candidate.version_number}"}
+            data-pareto-status={candidate.pareto_status}
+            style="padding: 14px; border: 1px solid var(--border); border-radius: 8px; background: var(--bg-secondary);"
+          >
+            <div style="display: flex; justify-content: space-between; gap: 8px;">
+              <strong>v{candidate.version_number}</strong>
+              <span class="tag">
+                {if candidate.pareto_status == :frontier,
+                  do: "Frontier",
+                  else: candidate.pareto_status}
+              </span>
+            </div>
+            <div class="text-sm text-secondary" style="margin-top: 10px;">
+              <div>Pass rate: {candidate.avg_pass_rate || "Unavailable"}%</div>
+              <div>Cost / pass: {format_cost_per_pass(candidate)}</div>
+              <div>Latency / pass: {format_latency_per_pass(candidate)}</div>
+            </div>
+          </article>
+        </div>
+      </section>
+
       <div class="aludel-card" style="margin-bottom: 24px;">
         <div style="padding: 20px; border-bottom: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center;">
           <div style="display: flex; align-items: center; gap: 10px;">

--- a/lib/aludel/web/live/prompt_live/show.ex
+++ b/lib/aludel/web/live/prompt_live/show.ex
@@ -29,6 +29,25 @@ defmodule Aludel.Web.PromptLive.Show do
     {:noreply, select_version(socket, socket.assigns.prompt, version_id)}
   end
 
+  def handle_event(
+        "select_comparison_version",
+        %{"comparison" => %{"version_id" => comparison_version_id}},
+        socket
+      ) do
+    {:noreply,
+     socket
+     |> assign(:comparison_version_id, comparison_version_id)
+     |> assign(
+       :version_comparison,
+       version_comparison(
+         socket.assigns.prompt.versions,
+         socket.assigns.selected_version_id,
+         comparison_version_id
+       )
+     )
+     |> assign(:show_version_diff, false)}
+  end
+
   def handle_event("show_version_diff", _params, socket) do
     if socket.assigns.version_comparison do
       {:noreply, assign(socket, :show_version_diff, true)}
@@ -42,39 +61,50 @@ defmodule Aludel.Web.PromptLive.Show do
   end
 
   defp select_version(socket, prompt, version_id) do
+    comparison_version_id = default_comparison_version_id(prompt.versions, version_id)
+
     socket
     |> assign(:selected_version_id, version_id)
-    |> assign(:version_comparison, version_comparison(prompt.versions, version_id))
+    |> assign(:comparison_version_id, comparison_version_id)
+    |> assign(
+      :version_comparison,
+      version_comparison(prompt.versions, version_id, comparison_version_id)
+    )
     |> assign(:show_version_diff, false)
   end
 
-  defp version_comparison(versions, selected_version_id) do
-    case Enum.find_index(versions, &(&1.id == selected_version_id)) do
-      nil ->
-        nil
+  defp version_comparison(versions, selected_version_id, comparison_version_id) do
+    current_version = Enum.find(versions, &(&1.id == selected_version_id))
+    comparison_version = Enum.find(versions, &(&1.id == comparison_version_id))
+    build_version_comparison(comparison_version, current_version)
+  end
 
-      index ->
-        current_version = Enum.at(versions, index)
-        previous_version = Enum.at(versions, index + 1)
-        build_version_comparison(previous_version, current_version)
-    end
+  defp default_comparison_version_id(versions, selected_version_id) do
+    selected_index = Enum.find_index(versions, &(&1.id == selected_version_id))
+    adjacent_older = selected_index && Enum.at(versions, selected_index + 1)
+    fallback = Enum.find(versions, &(&1.id != selected_version_id))
+    (adjacent_older || fallback) && (adjacent_older || fallback).id
   end
 
   defp build_version_comparison(nil, _current_version) do
     nil
   end
 
-  defp build_version_comparison(previous_version, current_version) do
+  defp build_version_comparison(_comparison_version, nil) do
+    nil
+  end
+
+  defp build_version_comparison(comparison_version, current_version) do
     %{
       current_version: current_version,
-      previous_version: previous_version,
+      previous_version: comparison_version,
       template_diff:
         List.myers_difference(
-          String.split(previous_version.template, "\n"),
+          String.split(comparison_version.template, "\n"),
           String.split(current_version.template, "\n")
         ),
-      added_variables: current_version.variables -- previous_version.variables,
-      removed_variables: previous_version.variables -- current_version.variables
+      added_variables: current_version.variables -- comparison_version.variables,
+      removed_variables: comparison_version.variables -- current_version.variables
     }
   end
 end

--- a/lib/aludel/web/live/prompt_live/show.html.heex
+++ b/lib/aludel/web/live/prompt_live/show.html.heex
@@ -69,17 +69,39 @@
               Previous version: v{@version_comparison.previous_version.version}
             </p>
           </div>
-          <button
-            :if={@version_comparison && !@show_version_diff}
-            id="compare-version-button"
-            type="button"
-            phx-click="show_version_diff"
-            class={["button-secondary"]}
-            style="display: inline-flex; align-items: center; gap: 6px; padding: 8px 12px; font-size: 13px;"
+          <div
+            :if={length(@prompt.versions) > 1}
+            style="display: flex; align-items: end; gap: 8px;"
           >
-            <.icon name="hero-arrows-right-left" class="size-4" />
-            Compare with v{@version_comparison.previous_version.version}
-          </button>
+            <form id="comparison-version-form" phx-change="select_comparison_version">
+              <label for="comparison-version" class="text-sm text-secondary">Compare against</label>
+              <select
+                id="comparison-version"
+                name="comparison[version_id]"
+                style="display: block; margin-top: 4px;"
+              >
+                <option
+                  :for={version <- @prompt.versions}
+                  :if={version.id != @selected_version_id}
+                  value={version.id}
+                  selected={version.id == @comparison_version_id}
+                >
+                  v{version.version}
+                </option>
+              </select>
+            </form>
+            <button
+              :if={@version_comparison && !@show_version_diff}
+              id="compare-version-button"
+              type="button"
+              phx-click="show_version_diff"
+              class={["button-secondary"]}
+              style="display: inline-flex; align-items: center; gap: 6px; padding: 8px 12px; font-size: 13px;"
+            >
+              <.icon name="hero-arrows-right-left" class="size-4" />
+              Compare with v{@version_comparison.previous_version.version}
+            </button>
+          </div>
         </div>
 
         <% selected_version = Enum.find(@prompt.versions, &(&1.id == @selected_version_id)) %>

--- a/test/aludel/prompts/evolution_test.exs
+++ b/test/aludel/prompts/evolution_test.exs
@@ -307,6 +307,35 @@ defmodule Aludel.Prompts.EvolutionTest do
       assert v2_metric.signals.stability == :volatile
       assert v2_metric.signals.regressions == [:quality, :cost, :latency]
     end
+
+    test "scopes metrics to one evaluation suite" do
+      prompt = prompt_fixture()
+      provider = provider_fixture()
+      {:ok, version} = Prompts.create_prompt_version(prompt, "Version 1")
+      selected_suite = suite_fixture(%{prompt_id: prompt.id})
+      other_suite = suite_fixture(%{prompt_id: prompt.id})
+
+      for {suite, passed, failed} <- [
+            {selected_suite, 9, 1},
+            {other_suite, 0, 10}
+          ] do
+        {:ok, _suite_run} =
+          Evals.create_suite_run(%{
+            suite_id: suite.id,
+            prompt_version_id: version.id,
+            provider_id: provider.id,
+            passed: passed,
+            failed: failed,
+            avg_cost_usd: Decimal.new("0.01"),
+            avg_latency_ms: 200
+          })
+      end
+
+      [metric] = Evolution.get_metrics(prompt.id, suite_id: selected_suite.id)
+
+      assert metric.total_runs == 1
+      assert metric.avg_pass_rate == 90.0
+    end
   end
 
   describe "calculate_avg_cost from suite_runs" do

--- a/test/aludel/prompts/optimization_test.exs
+++ b/test/aludel/prompts/optimization_test.exs
@@ -1,0 +1,40 @@
+defmodule Aludel.Prompts.OptimizationTest do
+  use ExUnit.Case, async: true
+
+  alias Aludel.Prompts.Optimization
+
+  test "keeps non-dominated trade-offs on the Pareto frontier" do
+    metrics = [
+      metric(1, 90.0, 0.02, 300.0),
+      metric(2, 90.0, 0.01, 250.0),
+      metric(3, 95.0, 0.03, 400.0),
+      metric(4, 80.0, nil, 200.0)
+    ]
+
+    analysis = Optimization.analyze(metrics)
+
+    assert Enum.map(analysis.frontier, & &1.version_number) == [2, 3]
+    assert Enum.find(analysis.candidates, &(&1.version_number == 1)).pareto_status == :dominated
+
+    assert Enum.find(analysis.candidates, &(&1.version_number == 4)).pareto_status ==
+             :insufficient
+  end
+
+  test "requires at least one strict improvement to dominate a candidate" do
+    metrics = [
+      metric(1, 90.0, 0.01, 250.0),
+      metric(2, 90.0, 0.01, 250.0)
+    ]
+
+    assert Optimization.analyze(metrics).frontier |> Enum.map(& &1.version_number) == [1, 2]
+  end
+
+  defp metric(version, pass_rate, cost_per_pass, latency_per_pass) do
+    %{
+      version_number: version,
+      avg_pass_rate: pass_rate,
+      cost_per_passed_test: cost_per_pass,
+      latency_per_passed_test: latency_per_pass
+    }
+  end
+end

--- a/test/aludel_web/live/prompt_live/evolution_test.exs
+++ b/test/aludel_web/live/prompt_live/evolution_test.exs
@@ -243,6 +243,37 @@ defmodule Aludel.Web.PromptLive.EvolutionTest do
                "No passing tests"
              )
     end
+
+    test "renders a suite-scoped Pareto frontier with trade-offs", %{conn: conn} do
+      prompt = prompt_fixture()
+      provider = provider_fixture()
+      {:ok, v1} = Prompts.create_prompt_version(prompt, "Version 1")
+      {:ok, v2} = Prompts.create_prompt_version(prompt, "Version 2")
+      suite = suite_fixture(%{prompt_id: prompt.id, name: "Regression Suite"})
+
+      for {version, passed, failed, cost, latency} <- [
+            {v1, 8, 2, "0.02", 300},
+            {v2, 9, 1, "0.01", 250}
+          ] do
+        {:ok, _suite_run} =
+          Aludel.Evals.create_suite_run(%{
+            suite_id: suite.id,
+            prompt_version_id: version.id,
+            provider_id: provider.id,
+            passed: passed,
+            failed: failed,
+            avg_cost_usd: Decimal.new(cost),
+            avg_latency_ms: latency
+          })
+      end
+
+      {:ok, view, _html} = live(conn, "/prompts/#{prompt.id}/evolution")
+
+      assert has_element?(view, "#pareto-suite", "Regression Suite")
+      assert has_element?(view, "#pareto-frontier")
+      assert has_element?(view, "#pareto-version-2[data-pareto-status='frontier']")
+      assert has_element?(view, "#pareto-version-1[data-pareto-status='dominated']")
+    end
   end
 
   describe "edge cases" do

--- a/test/aludel_web/live/prompt_live/show_test.exs
+++ b/test/aludel_web/live/prompt_live/show_test.exs
@@ -151,7 +151,7 @@ defmodule Aludel.Web.PromptLive.ShowTest do
       refute has_element?(view, "#prompt-version-diff")
     end
 
-    test "does not offer a comparison for the oldest version", %{conn: conn} do
+    test "offers an arbitrary comparison for the oldest version", %{conn: conn} do
       prompt = prompt_fixture(%{name: "Oldest Prompt"})
       {:ok, oldest_version} = Prompts.create_prompt_version(prompt, "Original")
       {:ok, _latest_version} = Prompts.create_prompt_version(prompt, "Updated")
@@ -162,7 +162,30 @@ defmodule Aludel.Web.PromptLive.ShowTest do
       |> element("#prompt-version-#{oldest_version.id}")
       |> render_click()
 
-      refute has_element?(view, "#compare-version-button")
+      assert has_element?(view, "#compare-version-button", "Compare with v2")
+    end
+
+    test "compares arbitrary non-adjacent versions", %{conn: conn} do
+      prompt = prompt_fixture(%{name: "Long-lived Prompt"})
+      {:ok, v1} = Prompts.create_prompt_version(prompt, "Original {{name}}")
+      {:ok, _v2} = Prompts.create_prompt_version(prompt, "Middle {{name}}")
+      {:ok, _v3} = Prompts.create_prompt_version(prompt, "Latest {{name}} and {{topic}}")
+
+      {:ok, view, _html} = live(conn, "/prompts/#{prompt.id}")
+
+      view
+      |> form("#comparison-version-form", comparison: %{version_id: v1.id})
+      |> render_change()
+
+      assert has_element?(view, "#compare-version-button", "Compare with v1")
+
+      view
+      |> element("#compare-version-button")
+      |> render_click()
+
+      assert has_element?(view, "#prompt-version-diff", "v1 to v3")
+      assert has_element?(view, "#template-diff-lines [data-diff-kind='del']", "Original")
+      assert has_element?(view, "#template-diff-lines [data-diff-kind='ins']", "Latest")
     end
   end
 end


### PR DESCRIPTION
## Motivation

Introduce the multi-objective selection and historical-comparison foundation for GEPA-style prompt development. Evolution can now be scoped to a specific evaluation suite and marks prompt versions as Pareto-frontier, dominated, or insufficient based on pass rate, cost per passing test, and latency per passing test.

Prompt history now supports arbitrary non-adjacent version comparisons while preserving the existing line and variable diffs.

Part of #12.

## Test Plan

- Covers Pareto dominance, strict-improvement requirements, trade-off preservation, and insufficient telemetry.
- Covers suite-scoped aggregation and LiveView rendering of frontier and dominated candidates.
- Covers arbitrary non-adjacent and oldest-version comparisons in the prompt LiveView.
- Full compile, formatting, static analysis, security scan, and test suite pass.

## Next Steps

Add persisted failure-grounded reflection suggestions with explicit accept and dismiss actions; acceptance creates a new immutable prompt version.