### PR TITLE
chore: release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-08-30
+
+### Added
+- Pluggable evaluation metrics and persisted structured execution artifacts
+- Reusable single-turn and multi-turn datasets with CSV and JSON imports, provenance, idempotent suite imports, filtering, deletion, and complete LiveView workflows
+- Rolling 7-day and 30-day dashboard comparisons with weighted quality, exact cost and latency efficiency, pass-rate stability, and bounded regression signals
+- Suite-scoped Pareto frontier analysis across quality, cost, and latency trade-offs
+- Arbitrary side-by-side prompt version comparisons
+- Failure-grounded prompt reflections with variable preservation, explicit human acceptance or dismissal, and immutable accepted versions
+
+### Changed
+- Prompt evolution now uses bounded, constant-count queries and reports efficiency and regression signals overall and by provider
+- Suite runs now persist exact cost and latency totals plus sample counts, including backfills and retry-safe recalculation
+- Updated Phoenix to 1.8.12, Phoenix LiveView to 1.2.10, Req to 0.7.3, and related transitive dependencies
+
 ## [0.4.2] - 2026-08-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Aludel depends on PostgreSQL-specific features, including `JSONB`, `percentile_d
 ```elixir
 def deps do
   [
-    {:aludel, "~> 0.4.2"}
+    {:aludel, "~> 0.5.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Aludel.MixProject do
   def project do
     [
       app: :aludel,
-      version: "0.4.2",
+      version: "0.5.0",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Motivation

Prepare Aludel 0.5.0 as a backward-compatible minor release containing pluggable metrics, execution artifacts, reusable datasets and LiveViews, bounded analytics, Pareto prompt analysis, arbitrary version comparison, and the human-approved reflection workflow.

This updates the package version, installation snippet, and publication-ready changelog.

## Test Plan

- Full compile, formatting, Credo, Sobelow, and 722-test suite pass.
- Hex package dry run succeeds for version 0.5.0 and includes the new schemas, analytics modules, LiveViews, and migrations.
- GitHub and Hex.pm confirm that 0.5.0 does not already exist.

## Next Steps

After merge, create tag v0.5.0, publish the GitHub release, and publish package and docs to Hex.pm.