### PR TITLE
chore: release 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2026-08-30
+
+### Security
+- Updated the standalone dependency lock to Postgrex 0.22.4, Req 0.7.4, Mint 1.9.3, and Tesla 1.21.2, including compatible Finch and DBConnection updates
+- Extended automated dependency scanning to cover the standalone Mix project and frontend npm dependencies
+
+### Changed
+- Moved CI and container asset builds from end-of-life Node.js 20 to Node.js 24 LTS
+- Rebuilt committed frontend bundles from the current sources
+
 ## [0.5.0] - 2026-08-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Aludel depends on PostgreSQL-specific features, including `JSONB`, `percentile_d
 ```elixir
 def deps do
   [
-    {:aludel, "~> 0.5.0"}
+    {:aludel, "~> 0.5.1"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Aludel.MixProject do
   def project do
     [
       app: :aludel,
-      version: "0.5.0",
+      version: "0.5.1",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Motivation

Prepare the 0.5.1 patch release for the merged dependency security remediation. This updates the package version, installation snippet, and curated release notes.

## Test Plan

- Full project verification passed with 722 tests and no failures
- Hex publish dry run and package-content validation completed successfully
- HexDocs built with warnings treated as errors
- The underlying security PR passed all CI, dependency, container, CodeQL, Trivy, secret-scanning, and Dialyzer checks

## Next Steps

After merge, create tag v0.5.1, publish the GitHub release from the changelog notes, and publish aludel 0.5.1 to Hex.