### PR TITLE
fix(prompts): place version history beside details

### DIFF
--- a/lib/aludel/web/live/prompt_live/show.html.heex
+++ b/lib/aludel/web/live/prompt_live/show.html.heex
@@ -50,9 +50,13 @@
       </div>
     </div>
 
-    <div :if={@prompt.versions != []} class={["relative flex flex-col gap-6 lg:flex-row"]}>
+    <div
+      :if={@prompt.versions != []}
+      id="prompt-details-layout"
+      class={["relative grid gap-6 md:grid-cols-[minmax(0,1fr)_20rem]"]}
+    >
       <%!-- Main content area --%>
-      <div class={["min-w-0 flex-1"]}>
+      <div id="prompt-details-content" class={["min-w-0 md:col-start-1 md:row-start-1"]}>
         <div style="display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: 16px; margin-bottom: 20px;">
           <div>
             <h2 style="margin: 0; font-size: 18px; font-weight: 600;">
@@ -236,10 +240,13 @@
       </div>
 
       <%!-- Timeline sidebar --%>
-      <div class={[
-        "w-full shrink-0 border-t border-[var(--border)] pt-6",
-        "lg:w-80 lg:border-t-0 lg:border-l lg:pt-0 lg:pl-6"
-      ]}>
+      <div
+        id="prompt-version-history"
+        class={[
+          "w-full shrink-0 border-t border-[var(--border)] pt-6",
+          "md:col-start-2 md:row-start-1 md:w-auto md:border-t-0 md:border-l md:pt-0 md:pl-6"
+        ]}
+      >
         <h3 style="margin: 0 0 16px 0; font-size: 12px; font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.08em; display: flex; align-items: center; gap: 6px;">
           <.icon name="hero-clock" class="size-3" /> History
         </h3>

--- a/priv/static/app.css
+++ b/priv/static/app.css
@@ -2009,6 +2009,9 @@
   .flex {
     display: flex;
   }
+  .grid {
+    display: grid;
+  }
   .hidden {
     display: none;
   }
@@ -2121,9 +2124,6 @@
       outline: 2px solid currentColor;
       outline-offset: 2px;
     }
-  }
-  .flex-col {
-    flex-direction: column;
   }
   .flex-row {
     flex-direction: row;
@@ -2433,35 +2433,50 @@
       scale: var(--tw-scale-x) var(--tw-scale-y);
     }
   }
-  .lg\:w-80 {
-    @media (width >= 64rem) {
-      width: calc(var(--spacing) * 80);
+  .md\:col-start-1 {
+    @media (width >= 48rem) {
+      grid-column-start: 1;
     }
   }
-  .lg\:flex-row {
-    @media (width >= 64rem) {
-      flex-direction: row;
+  .md\:col-start-2 {
+    @media (width >= 48rem) {
+      grid-column-start: 2;
     }
   }
-  .lg\:border-t-0 {
-    @media (width >= 64rem) {
+  .md\:row-start-1 {
+    @media (width >= 48rem) {
+      grid-row-start: 1;
+    }
+  }
+  .md\:w-auto {
+    @media (width >= 48rem) {
+      width: auto;
+    }
+  }
+  .md\:grid-cols-\[minmax\(0\,1fr\)_20rem\] {
+    @media (width >= 48rem) {
+      grid-template-columns: minmax(0,1fr) 20rem;
+    }
+  }
+  .md\:border-t-0 {
+    @media (width >= 48rem) {
       border-top-style: var(--tw-border-style);
       border-top-width: 0px;
     }
   }
-  .lg\:border-l {
-    @media (width >= 64rem) {
+  .md\:border-l {
+    @media (width >= 48rem) {
       border-left-style: var(--tw-border-style);
       border-left-width: 1px;
     }
   }
-  .lg\:pt-0 {
-    @media (width >= 64rem) {
+  .md\:pt-0 {
+    @media (width >= 48rem) {
       padding-top: calc(var(--spacing) * 0);
     }
   }
-  .lg\:pl-6 {
-    @media (width >= 64rem) {
+  .md\:pl-6 {
+    @media (width >= 48rem) {
       padding-left: calc(var(--spacing) * 6);
     }
   }

--- a/test/aludel_web/live/prompt_live/show_test.exs
+++ b/test/aludel_web/live/prompt_live/show_test.exs
@@ -42,6 +42,16 @@ defmodule Aludel.Web.PromptLive.ShowTest do
       assert html =~ "v#{v3.version}"
     end
 
+    test "places version history to the right of prompt details on desktop", %{conn: conn} do
+      prompt = prompt_fixture(%{name: "Versioned Prompt"})
+      {:ok, _version} = Prompts.create_prompt_version(prompt, "Version template")
+
+      {:ok, view, _html} = live(conn, "/prompts/#{prompt.id}")
+
+      assert has_element?(view, "#prompt-details-content[class~='md:col-start-1']")
+      assert has_element?(view, "#prompt-version-history[class~='md:col-start-2']")
+    end
+
     test "displays version variables", %{conn: conn} do
       prompt = prompt_fixture(%{name: "Variable Test"})
 


### PR DESCRIPTION
## Motivation

Keep prompt version history in a dedicated right-hand rail beside the selected prompt content on tablet and desktop widths. The layout remains stacked on narrow phone screens.

## Test Plan

- Added focused LiveView coverage for the two-column placement contract
- Rebuilt committed frontend assets
- Full precommit suite passes: 723 tests, 0 failures

## Next Steps

None.