### PR TITLE
chore: release 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - 2026-08-30
+
+### Fixed
+- Kept prompt version history in a dedicated right-hand rail beside prompt details on tablet and desktop layouts
+
 ## [0.5.1] - 2026-08-30
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Aludel depends on PostgreSQL-specific features, including `JSONB`, `percentile_d
 ```elixir
 def deps do
   [
-    {:aludel, "~> 0.5.1"}
+    {:aludel, "~> 0.5.2"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Aludel.MixProject do
   def project do
     [
       app: :aludel,
-      version: "0.5.1",
+      version: "0.5.2",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Motivation

Prepare the 0.5.2 patch release for the merged prompt-details layout correction. This updates the package version, installation snippet, and release notes.

## Test Plan

- Full project verification passed with 723 tests and no failures
- Hex publish dry run and unpacked package-content validation completed successfully
- HexDocs built successfully during package validation
- The underlying UI fix PR passed all 11 GitHub checks

## Next Steps

After merge, create tag v0.5.2, publish the GitHub release from the changelog notes, and publish aludel 0.5.2 to Hex.