### PR TITLE
feat(evals): add contextual metric inputs

### DIFF
--- a/lib/aludel/evals.ex
+++ b/lib/aludel/evals.ex
@@ -14,6 +14,7 @@ defmodule Aludel.Evals do
     TestCaseDocument
   }
 
+  alias Aludel.Evals.Metric.Context
   alias Aludel.Execution
   alias Aludel.Execution.Artifact
   alias Aludel.Prompts.PromptVersion
@@ -504,7 +505,8 @@ defmodule Aludel.Evals do
 
     case Execution.execute_with_artifacts(request) do
       {:ok, result} ->
-        assertion_results = build_assertion_results(test_case.assertions, result.output)
+        metric_context = build_metric_context(test_case, version, provider, result)
+        assertion_results = build_assertion_results(test_case.assertions, metric_context)
         passed = Enum.all?(assertion_results, & &1["passed"])
         score = AssertionEvaluator.score_for_results(assertion_results)
         artifacts = Artifact.put_metrics(result.artifacts, assertion_results, score)
@@ -523,8 +525,45 @@ defmodule Aludel.Evals do
     end
   end
 
-  defp build_assertion_results(assertions, output) do
-    Enum.map(assertions, &AssertionEvaluator.evaluate(output, &1))
+  defp build_assertion_results(assertions, metric_context) do
+    Enum.map(assertions, &AssertionEvaluator.evaluate(metric_context, &1))
+  end
+
+  defp build_metric_context(test_case, version, provider, result) do
+    input = result.artifacts |> first_artifact_step() |> Map.get("input", %{})
+
+    Context.new(result.output,
+      rendered_input: input["rendered_prompt"],
+      prompt_template: version.template,
+      variables: test_case.variable_values,
+      messages: Map.get(input, "messages", test_case.messages),
+      documents: Map.get(input, "documents", []),
+      metadata: test_case.metadata,
+      provider: %{
+        "id" => provider.id,
+        "model" => provider.model,
+        "type" => to_string(provider.provider)
+      },
+      prompt_version: %{
+        "id" => version.id,
+        "version" => version.version
+      },
+      execution: %{
+        "input_tokens" => result.input_tokens,
+        "output_tokens" => result.output_tokens,
+        "cost_usd" => result.cost_usd,
+        "latency_ms" => result.latency_ms,
+        "metadata" => result.metadata
+      }
+    )
+  end
+
+  defp first_artifact_step(%{"steps" => [step | _remaining]}) when is_map(step) do
+    step
+  end
+
+  defp first_artifact_step(_artifacts) do
+    %{}
   end
 
   defp successful_test_case_result(

--- a/lib/aludel/evals/assertion_evaluator.ex
+++ b/lib/aludel/evals/assertion_evaluator.ex
@@ -3,12 +3,13 @@ defmodule Aludel.Evals.AssertionEvaluator do
   Backward-compatible facade for behaviour-driven evaluation metrics.
   """
 
+  alias Aludel.Evals.Metric.Context
   alias Aludel.Evals.Metric.Registry
   alias Aludel.Evals.Metric.Result
 
-  @spec evaluate(String.t(), map()) :: map()
-  def evaluate(output, assertion) do
-    case Registry.evaluate(output, assertion) do
+  @spec evaluate(Context.t() | String.t(), map()) :: map()
+  def evaluate(input, assertion) do
+    case Registry.evaluate(input, assertion) do
       {:ok, result} ->
         Result.to_map(result, legacy_fields(result, assertion))
 

--- a/lib/aludel/evals/metric.ex
+++ b/lib/aludel/evals/metric.ex
@@ -6,6 +6,7 @@ defmodule Aludel.Evals.Metric do
   result maps is handled by `Aludel.Evals.AssertionEvaluator`.
   """
 
+  alias Aludel.Evals.Metric.Context
   alias Aludel.Evals.Metric.Result
 
   @default_threshold 100.0
@@ -19,7 +20,21 @@ defmodule Aludel.Evals.Metric do
           | %{optional(String.t()) => json_value()}
 
   @callback type() :: String.t()
-  @callback evaluate(String.t(), map()) :: Result.t()
+  @type input :: Context.t() | String.t()
+
+  @callback evaluate(input(), map()) :: Result.t()
+
+  @doc """
+  Returns generated output from either a contextual or legacy metric input.
+  """
+  @spec output(input()) :: String.t()
+  def output(%Context{output: output}) do
+    output
+  end
+
+  def output(output) when is_binary(output) do
+    output
+  end
 
   @spec boolean_result(String.t(), boolean(), String.t(), String.t(), map()) :: Result.t()
   def boolean_result(type, passed, success_reason, failure_reason, metadata \\ %{}) do

--- a/lib/aludel/evals/metric/context.ex
+++ b/lib/aludel/evals/metric/context.ex
@@ -1,0 +1,63 @@
+defmodule Aludel.Evals.Metric.Context do
+  @moduledoc """
+  Evidence available to an evaluation metric.
+
+  The context keeps metric implementations independent from Ecto schemas while
+  providing enough information for deterministic checks, model-based judges,
+  and application-defined evaluators. Optional fields use JSON-compatible
+  values so results can be reproduced and reported consistently.
+
+  Existing metrics that only need generated text may continue to accept a
+  string. Use `new/2` when a metric needs prompt, provider, document, or
+  execution evidence.
+  """
+
+  @enforce_keys [:output]
+  defstruct output: nil,
+            expected: nil,
+            rendered_input: nil,
+            prompt_template: nil,
+            variables: %{},
+            messages: [],
+            documents: [],
+            metadata: %{},
+            provider: nil,
+            prompt_version: nil,
+            execution: %{}
+
+  @type json_value ::
+          nil
+          | boolean()
+          | number()
+          | String.t()
+          | [json_value()]
+          | %{optional(String.t()) => json_value()}
+
+  @type t :: %__MODULE__{
+          output: String.t(),
+          expected: json_value(),
+          rendered_input: String.t() | nil,
+          prompt_template: String.t() | nil,
+          variables: map(),
+          messages: [map()],
+          documents: [map()],
+          metadata: map(),
+          provider: map() | nil,
+          prompt_version: map() | nil,
+          execution: map()
+        }
+
+  @doc """
+  Creates a metric context for generated output and optional evidence.
+  """
+  @spec new(String.t(), keyword()) :: t()
+  def new(output, attrs \\ [])
+
+  def new(output, attrs) when is_binary(output) and is_list(attrs) do
+    struct!(__MODULE__, Keyword.put(attrs, :output, output))
+  end
+
+  def new(_output, _attrs) do
+    raise ArgumentError, "metric output must be a string"
+  end
+end

--- a/lib/aludel/evals/metric/registry.ex
+++ b/lib/aludel/evals/metric/registry.ex
@@ -6,6 +6,7 @@ defmodule Aludel.Evals.Metric.Registry do
   aggregation code.
   """
 
+  alias Aludel.Evals.Metric.Context
   alias Aludel.Evals.Metrics.Contains
   alias Aludel.Evals.Metrics.ExactMatch
   alias Aludel.Evals.Metrics.JSONDeepCompare
@@ -35,15 +36,16 @@ defmodule Aludel.Evals.Metric.Registry do
     end
   end
 
-  @spec evaluate(String.t(), map()) :: {:ok, Aludel.Evals.Metric.Result.t()} | :error
-  def evaluate(output, %{"type" => type} = assertion) do
+  @spec evaluate(Context.t() | String.t(), map()) ::
+          {:ok, Aludel.Evals.Metric.Result.t()} | :error
+  def evaluate(input, %{"type" => type} = assertion) do
     case fetch(type) do
-      {:ok, module} -> {:ok, module.evaluate(output, assertion)}
+      {:ok, module} -> {:ok, module.evaluate(input, assertion)}
       :error -> :error
     end
   end
 
-  def evaluate(_output, _assertion) do
+  def evaluate(_input, _assertion) do
     :error
   end
 end

--- a/lib/aludel/evals/metrics/contains.ex
+++ b/lib/aludel/evals/metrics/contains.ex
@@ -11,7 +11,9 @@ defmodule Aludel.Evals.Metrics.Contains do
   end
 
   @impl true
-  def evaluate(output, %{"value" => value}) do
+  def evaluate(input, %{"value" => value}) do
+    output = Metric.output(input)
+
     Metric.boolean_result(
       type(),
       String.contains?(output, value),

--- a/lib/aludel/evals/metrics/exact_match.ex
+++ b/lib/aludel/evals/metrics/exact_match.ex
@@ -11,7 +11,9 @@ defmodule Aludel.Evals.Metrics.ExactMatch do
   end
 
   @impl true
-  def evaluate(output, %{"value" => value}) do
+  def evaluate(input, %{"value" => value}) do
+    output = Metric.output(input)
+
     Metric.boolean_result(
       type(),
       output == value,

--- a/lib/aludel/evals/metrics/json_deep_compare.ex
+++ b/lib/aludel/evals/metrics/json_deep_compare.ex
@@ -20,7 +20,8 @@ defmodule Aludel.Evals.Metrics.JSONDeepCompare do
   end
 
   @impl true
-  def evaluate(output, %{"expected" => _expected} = assertion) do
+  def evaluate(input, %{"expected" => _expected} = assertion) do
+    output = Metric.output(input)
     threshold = Metric.normalize_threshold(assertion)
 
     case Metric.decode_json(output) do

--- a/lib/aludel/evals/metrics/json_field.ex
+++ b/lib/aludel/evals/metrics/json_field.ex
@@ -12,7 +12,9 @@ defmodule Aludel.Evals.Metrics.JSONField do
   end
 
   @impl true
-  def evaluate(output, %{"field" => field, "expected" => expected}) do
+  def evaluate(input, %{"field" => field, "expected" => expected}) do
+    output = Metric.output(input)
+
     case Metric.decode_json(output) do
       {:ok, json} ->
         actual_value = get_in(json, String.split(field, "."))

--- a/lib/aludel/evals/metrics/not_contains.ex
+++ b/lib/aludel/evals/metrics/not_contains.ex
@@ -11,7 +11,9 @@ defmodule Aludel.Evals.Metrics.NotContains do
   end
 
   @impl true
-  def evaluate(output, %{"value" => value}) do
+  def evaluate(input, %{"value" => value}) do
+    output = Metric.output(input)
+
     Metric.boolean_result(
       type(),
       not String.contains?(output, value),

--- a/lib/aludel/evals/metrics/regex.ex
+++ b/lib/aludel/evals/metrics/regex.ex
@@ -11,7 +11,9 @@ defmodule Aludel.Evals.Metrics.Regex do
   end
 
   @impl true
-  def evaluate(output, %{"value" => pattern}) do
+  def evaluate(input, %{"value" => pattern}) do
+    output = Metric.output(input)
+
     case Regex.compile(pattern) do
       {:ok, regex} ->
         Metric.boolean_result(

--- a/test/aludel/evals/metric_test.exs
+++ b/test/aludel/evals/metric_test.exs
@@ -2,6 +2,7 @@ defmodule Aludel.Evals.MetricTest do
   use ExUnit.Case, async: true
 
   alias Aludel.Evals.AssertionEvaluator
+  alias Aludel.Evals.Metric.Context
   alias Aludel.Evals.Metric.Registry
 
   describe "registry" do
@@ -24,6 +25,88 @@ defmodule Aludel.Evals.MetricTest do
         assert function_exported?(module, :evaluate, 2)
         assert module.type() == type
       end
+    end
+
+    test "evaluates built-in metrics with a contextual input" do
+      context =
+        Context.new("hello world",
+          rendered_input: "Greet Alice",
+          variables: %{"name" => "Alice"},
+          metadata: %{"language" => "en"}
+        )
+
+      assert {:ok, result} =
+               Registry.evaluate(context, %{"type" => "contains", "value" => "hello"})
+
+      assert result.passed
+      assert result.score == 100.0
+    end
+  end
+
+  describe "metric context" do
+    test "normalizes the output and evaluation evidence" do
+      context =
+        Context.new("answer",
+          expected: "expected answer",
+          rendered_input: "question",
+          prompt_template: "{{question}}",
+          variables: %{"question" => "question"},
+          messages: [%{"role" => "user", "content" => "question"}],
+          documents: [%{"name" => "guide.txt", "content_type" => "text/plain"}],
+          metadata: %{"category" => "support"},
+          provider: %{"id" => "provider-id", "model" => "model"},
+          prompt_version: %{"id" => "version-id", "version" => 2},
+          execution: %{"latency_ms" => 25}
+        )
+
+      assert context.output == "answer"
+      assert context.expected == "expected answer"
+      assert context.rendered_input == "question"
+      assert context.prompt_template == "{{question}}"
+      assert context.variables == %{"question" => "question"}
+      assert context.messages == [%{"role" => "user", "content" => "question"}]
+      assert context.documents == [%{"name" => "guide.txt", "content_type" => "text/plain"}]
+      assert context.metadata == %{"category" => "support"}
+      assert context.provider == %{"id" => "provider-id", "model" => "model"}
+      assert context.prompt_version == %{"id" => "version-id", "version" => 2}
+      assert context.execution == %{"latency_ms" => 25}
+    end
+
+    test "uses safe defaults for optional evidence" do
+      assert %Context{
+               output: "answer",
+               expected: nil,
+               rendered_input: nil,
+               prompt_template: nil,
+               variables: %{},
+               messages: [],
+               documents: [],
+               metadata: %{},
+               provider: nil,
+               prompt_version: nil,
+               execution: %{}
+             } = Context.new("answer")
+    end
+
+    test "rejects a non-string output" do
+      assert_raise ArgumentError, "metric output must be a string", fn ->
+        Context.new(nil)
+      end
+    end
+
+    test "keeps the legacy assertion evaluator API working" do
+      legacy =
+        AssertionEvaluator.evaluate("hello world", %{
+          "type" => "contains",
+          "value" => "hello"
+        })
+
+      contextual =
+        "hello world"
+        |> Context.new(metadata: %{"source" => "suite"})
+        |> AssertionEvaluator.evaluate(%{"type" => "contains", "value" => "hello"})
+
+      assert contextual == legacy
     end
   end
 


### PR DESCRIPTION
## Motivation

Metrics currently receive only generated text, which prevents evaluators from using prompt, provider, document, metadata, and execution evidence. This adds a stable contextual input while preserving every existing string-based metric call.

## Test Plan

- Added coverage for contextual construction, defaults, invalid output, registry dispatch, and legacy compatibility.
- Verified the complete test suite, static analysis, documentation generation, package build, and dependency audits.

## Next Steps

Later evaluation features can consume the contextual contract without changing existing deterministic metrics or historical result shapes.