### PR TITLE
feat(evals): record evaluator execution details

### DIFF
--- a/lib/aludel/evals/assertion_evaluator.ex
+++ b/lib/aludel/evals/assertion_evaluator.ex
@@ -4,6 +4,7 @@ defmodule Aludel.Evals.AssertionEvaluator do
   """
 
   alias Aludel.Evals.Metric.Context
+  alias Aludel.Evals.Metric.Evaluator
   alias Aludel.Evals.Metric.Registry
   alias Aludel.Evals.Metric.Result
 
@@ -78,7 +79,12 @@ defmodule Aludel.Evals.AssertionEvaluator do
       passed: false,
       score: 0.0,
       reason: "Unsupported metric type",
-      metadata: %{}
+      metadata: %{},
+      evaluator:
+        Evaluator.unavailable(%{
+          "type" => "unsupported_metric",
+          "message" => "Metric type is not registered"
+        })
     }
     |> Result.to_map(%{"value" => Map.get(assertion, "value")})
   end

--- a/lib/aludel/evals/metric/evaluator.ex
+++ b/lib/aludel/evals/metric/evaluator.ex
@@ -1,0 +1,102 @@
+defmodule Aludel.Evals.Metric.Evaluator do
+  @moduledoc """
+  Normalized execution details for the evaluator behind a metric result.
+
+  Deterministic metrics usually record only status and duration. Model-backed
+  evaluators can also attribute provider, model, token usage, and cost without
+  mixing that usage with the model output being evaluated.
+  """
+
+  @statuses [:completed, :error, :unavailable]
+
+  @enforce_keys [:status]
+  defstruct status: nil,
+            duration_ms: nil,
+            provider: nil,
+            model: nil,
+            input_tokens: nil,
+            output_tokens: nil,
+            cost_usd: nil,
+            error: nil
+
+  @type status :: :completed | :error | :unavailable
+
+  @type t :: %__MODULE__{
+          status: status(),
+          duration_ms: number() | nil,
+          provider: String.t() | nil,
+          model: String.t() | nil,
+          input_tokens: non_neg_integer() | nil,
+          output_tokens: non_neg_integer() | nil,
+          cost_usd: number() | nil,
+          error: map() | nil
+        }
+
+  @doc """
+  Creates evaluator details and validates the lifecycle status.
+  """
+  @spec new(status(), keyword()) :: t()
+  def new(status, attrs \\ []) when status in @statuses and is_list(attrs) do
+    struct!(__MODULE__, Keyword.put(attrs, :status, status))
+  end
+
+  @doc """
+  Records a successfully completed evaluator.
+  """
+  @spec completed(number(), keyword()) :: t()
+  def completed(duration_ms, attrs \\ []) when is_number(duration_ms) and duration_ms >= 0 do
+    new(:completed, Keyword.put(attrs, :duration_ms, duration_ms))
+  end
+
+  @doc """
+  Records an evaluator infrastructure failure.
+  """
+  @spec error(map(), keyword()) :: t()
+  def error(error, attrs \\ []) when is_map(error) and is_list(attrs) do
+    new(:error, Keyword.put(attrs, :error, error))
+  end
+
+  @doc """
+  Records an evaluator that could not be resolved or used.
+  """
+  @spec unavailable(map()) :: t()
+  def unavailable(error) when is_map(error) do
+    new(:unavailable, error: error)
+  end
+
+  @doc """
+  Adds measured duration when the evaluator did not provide its own timing.
+  """
+  @spec with_duration(t(), number()) :: t()
+  def with_duration(%__MODULE__{duration_ms: nil} = evaluator, duration_ms)
+      when is_number(duration_ms) and duration_ms >= 0 do
+    %{evaluator | duration_ms: duration_ms}
+  end
+
+  def with_duration(%__MODULE__{} = evaluator, _duration_ms) do
+    evaluator
+  end
+
+  @doc """
+  Converts evaluator details to a JSON-compatible map, omitting absent values.
+  """
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = evaluator) do
+    %{"status" => Atom.to_string(evaluator.status)}
+    |> put_if_present("duration_ms", evaluator.duration_ms)
+    |> put_if_present("provider", evaluator.provider)
+    |> put_if_present("model", evaluator.model)
+    |> put_if_present("input_tokens", evaluator.input_tokens)
+    |> put_if_present("output_tokens", evaluator.output_tokens)
+    |> put_if_present("cost_usd", evaluator.cost_usd)
+    |> put_if_present("error", evaluator.error)
+  end
+
+  defp put_if_present(map, _key, nil) do
+    map
+  end
+
+  defp put_if_present(map, key, value) do
+    Map.put(map, key, value)
+  end
+end

--- a/lib/aludel/evals/metric/registry.ex
+++ b/lib/aludel/evals/metric/registry.ex
@@ -7,6 +7,7 @@ defmodule Aludel.Evals.Metric.Registry do
   """
 
   alias Aludel.Evals.Metric.Context
+  alias Aludel.Evals.Metric.Runner
   alias Aludel.Evals.Metrics.Contains
   alias Aludel.Evals.Metrics.ExactMatch
   alias Aludel.Evals.Metrics.JSONDeepCompare
@@ -40,7 +41,7 @@ defmodule Aludel.Evals.Metric.Registry do
           {:ok, Aludel.Evals.Metric.Result.t()} | :error
   def evaluate(input, %{"type" => type} = assertion) do
     case fetch(type) do
-      {:ok, module} -> {:ok, module.evaluate(input, assertion)}
+      {:ok, module} -> {:ok, Runner.run(module, input, assertion)}
       :error -> :error
     end
   end

--- a/lib/aludel/evals/metric/result.ex
+++ b/lib/aludel/evals/metric/result.ex
@@ -3,26 +3,40 @@ defmodule Aludel.Evals.Metric.Result do
   Normalized result returned by every evaluation metric.
   """
 
+  alias Aludel.Evals.Metric.Evaluator
+
   @enforce_keys [:type, :score, :passed, :reason, :metadata]
-  defstruct [:type, :score, :passed, :reason, :metadata]
+  defstruct [:type, :score, :passed, :reason, :metadata, :evaluator]
 
   @type t :: %__MODULE__{
           type: String.t(),
           score: float(),
           passed: boolean(),
           reason: String.t(),
-          metadata: map()
+          metadata: map(),
+          evaluator: Evaluator.t() | nil
         }
 
   @spec to_map(t(), map()) :: map()
   def to_map(%__MODULE__{} = result, legacy_fields \\ %{}) do
-    %{
+    result_map = %{
       "type" => result.type,
       "score" => result.score,
       "passed" => result.passed,
       "reason" => result.reason,
       "metadata" => result.metadata
     }
+
+    result_map
+    |> maybe_put_evaluator(result.evaluator)
     |> Map.merge(legacy_fields)
+  end
+
+  defp maybe_put_evaluator(result, nil) do
+    result
+  end
+
+  defp maybe_put_evaluator(result, %Evaluator{} = evaluator) do
+    Map.put(result, "evaluator", Evaluator.to_map(evaluator))
   end
 end

--- a/lib/aludel/evals/metric/runner.ex
+++ b/lib/aludel/evals/metric/runner.ex
@@ -1,0 +1,94 @@
+defmodule Aludel.Evals.Metric.Runner do
+  @moduledoc false
+
+  alias Aludel.Evals.Metric.Evaluator
+  alias Aludel.Evals.Metric.Result
+
+  @spec run(module(), Aludel.Evals.Metric.input(), map()) :: Result.t()
+  def run(module, input, assertion) when is_atom(module) and is_map(assertion) do
+    started_at = System.monotonic_time(:microsecond)
+
+    try do
+      case module.evaluate(input, assertion) do
+        %Result{} = result -> complete(result, elapsed_ms(started_at))
+        _other -> invalid_result(metric_type(module, assertion), elapsed_ms(started_at))
+      end
+    rescue
+      _error -> exception_result(metric_type(module, assertion), elapsed_ms(started_at))
+    catch
+      _kind, _reason -> exit_result(metric_type(module, assertion), elapsed_ms(started_at))
+    end
+  end
+
+  defp complete(%Result{evaluator: nil} = result, duration_ms) do
+    %{result | evaluator: Evaluator.completed(duration_ms)}
+  end
+
+  defp complete(%Result{evaluator: evaluator} = result, duration_ms) do
+    %{result | evaluator: Evaluator.with_duration(evaluator, duration_ms)}
+  end
+
+  defp invalid_result(type, duration_ms) do
+    failed_result(
+      type,
+      "Metric returned an invalid result",
+      %{
+        "type" => "invalid_result",
+        "message" => "Evaluator must return a metric result"
+      },
+      duration_ms
+    )
+  end
+
+  defp exception_result(type, duration_ms) do
+    failed_result(
+      type,
+      "Metric evaluation failed",
+      %{
+        "type" => "evaluator_exception",
+        "message" => "Evaluator raised an exception"
+      },
+      duration_ms
+    )
+  end
+
+  defp exit_result(type, duration_ms) do
+    failed_result(
+      type,
+      "Metric evaluation failed",
+      %{
+        "type" => "evaluator_exit",
+        "message" => "Evaluator stopped before returning a result"
+      },
+      duration_ms
+    )
+  end
+
+  defp failed_result(type, reason, error, duration_ms) do
+    %Result{
+      type: type,
+      passed: false,
+      score: 0.0,
+      reason: reason,
+      metadata: %{},
+      evaluator: Evaluator.error(error, duration_ms: duration_ms)
+    }
+  end
+
+  defp metric_type(module, assertion) do
+    Map.get(assertion, "type") || safe_metric_type(module)
+  end
+
+  defp safe_metric_type(module) do
+    module.type()
+  rescue
+    _error -> "unknown"
+  catch
+    _kind, _reason -> "unknown"
+  end
+
+  defp elapsed_ms(started_at) do
+    elapsed_microseconds = System.monotonic_time(:microsecond) - started_at
+    Float.round(elapsed_microseconds / 1_000, 3)
+  end
+end

--- a/test/aludel/evals/metric_test.exs
+++ b/test/aludel/evals/metric_test.exs
@@ -4,6 +4,27 @@ defmodule Aludel.Evals.MetricTest do
   alias Aludel.Evals.AssertionEvaluator
   alias Aludel.Evals.Metric.Context
   alias Aludel.Evals.Metric.Registry
+  alias Aludel.Evals.Metric.Runner
+
+  defmodule RaisingMetric do
+    def type do
+      "raising"
+    end
+
+    def evaluate(_input, _assertion) do
+      raise "sensitive evaluator detail"
+    end
+  end
+
+  defmodule InvalidResultMetric do
+    def type do
+      "invalid_result"
+    end
+
+    def evaluate(_input, _assertion) do
+      :invalid
+    end
+  end
 
   describe "registry" do
     test "lists the supported metric types in form order" do
@@ -40,6 +61,66 @@ defmodule Aludel.Evals.MetricTest do
 
       assert result.passed
       assert result.score == 100.0
+      assert result.evaluator.status == :completed
+      assert is_number(result.evaluator.duration_ms)
+      assert result.evaluator.duration_ms >= 0
+    end
+  end
+
+  describe "evaluator execution details" do
+    test "serializes successful evaluator timing" do
+      result =
+        AssertionEvaluator.evaluate("hello world", %{
+          "type" => "contains",
+          "value" => "hello"
+        })
+
+      assert %{
+               "status" => "completed",
+               "duration_ms" => duration_ms
+             } = result["evaluator"]
+
+      assert is_number(duration_ms)
+      assert duration_ms >= 0
+      refute Map.has_key?(result["evaluator"], "error")
+    end
+
+    test "marks unsupported evaluators as unavailable" do
+      result = AssertionEvaluator.evaluate("output", %{"type" => "missing"})
+
+      assert result["evaluator"] == %{
+               "status" => "unavailable",
+               "error" => %{
+                 "type" => "unsupported_metric",
+                 "message" => "Metric type is not registered"
+               }
+             }
+    end
+
+    test "isolates evaluator exceptions without persisting their messages" do
+      result = Runner.run(RaisingMetric, "output", %{})
+
+      assert result.passed == false
+      assert result.score == 0.0
+      assert result.reason == "Metric evaluation failed"
+      assert result.evaluator.status == :error
+
+      assert result.evaluator.error == %{
+               "type" => "evaluator_exception",
+               "message" => "Evaluator raised an exception"
+             }
+
+      refute inspect(result) =~ "sensitive evaluator detail"
+    end
+
+    test "normalizes invalid evaluator return values" do
+      result = Runner.run(InvalidResultMetric, "output", %{})
+
+      assert result.passed == false
+      assert result.score == 0.0
+      assert result.reason == "Metric returned an invalid result"
+      assert result.evaluator.status == :error
+      assert result.evaluator.error["type"] == "invalid_result"
     end
   end
 
@@ -106,7 +187,7 @@ defmodule Aludel.Evals.MetricTest do
         |> Context.new(metadata: %{"source" => "suite"})
         |> AssertionEvaluator.evaluate(%{"type" => "contains", "value" => "hello"})
 
-      assert contextual == legacy
+      assert Map.delete(contextual, "evaluator") == Map.delete(legacy, "evaluator")
     end
   end
 


### PR DESCRIPTION
## Motivation

Evaluation results need to distinguish a quality failure from evaluator infrastructure failure or an unavailable metric. This adds normalized evaluator status, timing, usage, cost, provider/model, and structured error fields while keeping existing assertion scoring compatible.

## Test Plan

- Added coverage for successful timing, unavailable metric types, evaluator exceptions, invalid return values, redacted failures, and legacy compatibility.
- Verified the complete test suite, static analysis, documentation generation, package build, and dependency audits.

## Next Steps

Model-backed evaluators can attach their own provider, model, token, cost, and latency evidence to this result contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added evaluator execution details to metric results, including status, duration, provider, model, token usage, cost, and error information.
  * Added structured reporting for unavailable metrics and invalid or failed evaluations.
  * Metric results now consistently include timing information for successful evaluations.

* **Bug Fixes**
  * Prevented metric exceptions and invalid return values from disrupting evaluation, converting them into structured error results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->