### PR TITLE
feat(evals): add repeated sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Aludel gives teams a clean way to evaluate prompt and model behavior without inv
 - Compare the same prompt across OpenAI, Anthropic, Gemini, Ollama, xAI, Groq, and OpenRouter.
 - Inspect output, latency, token usage, and cost side by side.
 - Compare prompt versions and see pass-rate, cost, and latency changes over time.
-- Run evaluation suites with assertions, document attachments, and CSV or JSON test case imports.
+- Run evaluation suites with assertions, repeated sampling, document attachments, and CSV or JSON test case imports.
 - Execute suites headlessly with machine-readable JSON output for CI workflows.
 - Route runs and suites through your app's real LLM workflow with callback execution.
 - Reuse single-turn and multi-turn datasets across suites with provenance and metadata filtering.
@@ -40,7 +40,7 @@ Most teams evaluating LLM behavior end up with some combination of scripts, spre
 | Prompts | `{{variable}}` templates, immutable versions, tags, search, pagination, typed projects, version diffs, and provider-specific evolution history |
 | Providers | OpenAI, Anthropic, Google Gemini, Ollama, xAI, Groq, and OpenRouter; active and deprecated text-model discovery; custom model IDs; built-in or overridden pricing |
 | Runs | Multi-provider execution, concurrent or sequential dispatch, live status updates, partial-failure handling, normalized execution artifacts, result copy actions, and JSON exports |
-| Evaluation suites | Visual and JSON test-case editing, single-turn and multi-turn inputs, document attachments, suite history, per-result retries, and aggregate quality, cost, and latency |
+| Evaluation suites | Visual and JSON test-case editing, single-turn and multi-turn inputs, bounded repeated sampling with configurable pass reducers, document attachments, suite history, per-result retries, and aggregate quality, cost, and latency |
 | Assertions | `contains`, `not_contains`, `regex`, `exact_match`, typed `json_field`, and scored `json_deep_compare` with configurable thresholds |
 | Imports and datasets | CSV and JSON import previews with row-level errors; reusable ordered datasets with variables, messages, assertions, metadata filters, provenance, and idempotent suite population |
 | Prompt evolution | Version and provider trends, version-over-version deltas, suite-scoped Pareto frontiers, failure-grounded prompt suggestions, and explicit accept or dismiss decisions |
@@ -74,6 +74,22 @@ For structured outputs, use `json_deep_compare` to score partial matches instead
 ```
 
 Aludel stores field-level comparison details, per-test match scores, and suite-run average scores so prompt evolution and exports can track structured output quality over time.
+
+## Repeated Evaluation Sampling
+
+Nondeterministic model output can make a single response misleading. Run each test case up to 20 times and reduce the ordered attempts into one result:
+
+```elixir
+{:ok, suite_run} =
+  Aludel.Evals.execute_suite(suite, prompt_version, provider,
+    samples: 5,
+    reducer: {:minimum_pass_rate, 0.8}
+  )
+```
+
+Reducers support `:all`, `:any`, strict `:majority`, and a minimum pass rate. Aludel retains every attempt, sums token usage, cost, and latency, and reruns the complete sampling configuration when a result is retried.
+
+See the [evaluation guide](https://hexdocs.pm/aludel/evaluations.html#repeat-nondeterministic-cases) and [repeated sampling wiki guide](https://github.com/ccarvalho-eng/aludel/wiki/Repeated-Sampling) for the full result shape and reducer examples.
 
 ## Test Case Imports
 

--- a/guides/evaluations.md
+++ b/guides/evaluations.md
@@ -142,6 +142,22 @@ For common checks, replace `rubric` with a versioned built-in `template`:
 
 Templates and custom rubrics are mutually exclusive. Aludel records the resolved rubric and template version with each result, so a historical run retains the criteria it used.
 
+### Repeat nondeterministic cases
+
+Run each test case more than once when a single model response is not reliable enough to make a decision:
+
+```elixir
+{:ok, suite_run} =
+  Aludel.Evals.execute_suite(suite, prompt_version, provider,
+    samples: 5,
+    reducer: :majority
+  )
+```
+
+`samples` accepts `1` through `20`. Reducers can require `:all`, `:any`, a strict `:majority`, or a minimum rate such as `{:minimum_pass_rate, 0.8}`. Invalid sampling configuration returns an error before any model request is made.
+
+Sampled results retain every ordered attempt and record passed and failed counts, pass rate, reducer configuration, and the representative attempt. Token usage, cost, and latency are summed across attempts; available scores are averaged. Retrying a sampled test case reruns the complete persisted sampling configuration and replaces the previous aggregate.
+
 ## 5. Populate a suite
 
 Create an evaluation suite for the prompt, open it, select a dataset, and choose **Add entries**. Aludel copies entries in dataset order and records each source entry.

--- a/lib/aludel/evals.ex
+++ b/lib/aludel/evals.ex
@@ -7,6 +7,7 @@ defmodule Aludel.Evals do
 
   alias Aludel.Evals.{
     AssertionEvaluator,
+    Sampling,
     Suite,
     SuiteRun,
     SuiteRunner,
@@ -348,19 +349,21 @@ defmodule Aludel.Evals do
   Retries a single test case result within an existing suite run.
 
   The existing embedded result is replaced in-place and the suite run
-  aggregates are recalculated from the updated result set.
+  aggregates are recalculated from the updated result set. Sampled results
+  repeat their complete persisted sampling configuration.
   """
   @spec retry_suite_run_test_case(SuiteRun.t(), binary()) ::
           {:ok, SuiteRun.t()} | {:error, term()}
   def retry_suite_run_test_case(%SuiteRun{} = suite_run, test_case_id)
       when is_binary(test_case_id) do
     with {:ok, existing_result} <- fetch_suite_run_result(suite_run, test_case_id),
+         {:ok, sampling} <- Sampling.from_result(existing_result),
          {:ok, test_case} <- fetch_suite_test_case(suite_run.suite_id, test_case_id),
          {:ok, version} <- fetch_prompt_version(suite_run.prompt_version_id),
          {:ok, provider} <- fetch_provider(suite_run.provider_id) do
       retried_result =
         test_case
-        |> execute_test_case(version, provider)
+        |> execute_test_case(version, provider, sampling)
         |> merge_retry_metadata(existing_result)
 
       updated_results = replace_suite_run_result(suite_run.results, test_case_id, retried_result)
@@ -389,37 +392,48 @@ defmodule Aludel.Evals do
     - suite: The test suite to execute
     - prompt_version: The prompt version to use
     - provider: The LLM provider to call
+    - opts: Sampling options accepted by `Aludel.Evals.Sampling.new/1`
 
   ## Returns
     - `{:ok, suite_run}` with execution results
     - `{:error, reason}` if execution fails
   """
-  @spec execute_suite(Suite.t(), PromptVersion.t(), Provider.t()) ::
+  @spec execute_suite(Suite.t(), PromptVersion.t(), Provider.t(), keyword()) ::
           {:ok, SuiteRun.t()} | {:error, term()}
-  def execute_suite(%Suite{} = suite, %PromptVersion{} = version, %Provider{} = provider) do
-    suite = repo().preload(suite, test_cases: :documents)
+  def execute_suite(
+        %Suite{} = suite,
+        %PromptVersion{} = version,
+        %Provider{} = provider,
+        opts \\ []
+      ) do
+    with {:ok, sampling} <- Sampling.new(opts) do
+      suite = repo().preload(suite, test_cases: :documents)
 
-    results = Enum.map(suite.test_cases, &execute_test_case(&1, version, provider))
-    summary = summarize_suite_results(results)
+      results =
+        Enum.map(suite.test_cases, &execute_test_case(&1, version, provider, sampling))
 
-    create_suite_run(
-      Map.merge(summary, %{
-        suite_id: suite.id,
-        prompt_version_id: version.id,
-        provider_id: provider.id,
-        results: results
-      })
-    )
+      summary = summarize_suite_results(results)
+
+      create_suite_run(
+        Map.merge(summary, %{
+          suite_id: suite.id,
+          prompt_version_id: version.id,
+          provider_id: provider.id,
+          results: results
+        })
+      )
+    end
   end
 
   @doc """
   Launches suite execution in a supervised task and reports completion
-  back to the given recipient process.
+  back to the given recipient process. Sampling options are forwarded to the
+  execution task.
   """
-  @spec launch_suite_execution(pid(), binary(), binary(), binary()) ::
+  @spec launch_suite_execution(pid(), binary(), binary(), binary(), keyword()) ::
           {:ok, reference()} | {:error, term()}
-  def launch_suite_execution(recipient, suite_id, version_id, provider_id) do
-    case SuiteRunner.launch(recipient, suite_id, version_id, provider_id) do
+  def launch_suite_execution(recipient, suite_id, version_id, provider_id, opts \\ []) do
+    case SuiteRunner.launch(recipient, suite_id, version_id, provider_id, opts) do
       {:ok, task_pid} -> {:ok, Process.monitor(task_pid)}
       {:error, reason} -> {:error, reason}
     end
@@ -486,7 +500,20 @@ defmodule Aludel.Evals do
 
   # Private functions
 
-  defp execute_test_case(test_case, version, provider) do
+  defp execute_test_case(test_case, version, provider, %Sampling{samples: 1}) do
+    execute_test_case_attempt(test_case, version, provider)
+  end
+
+  defp execute_test_case(test_case, version, provider, %Sampling{samples: samples} = sampling) do
+    attempts =
+      Enum.map(1..samples, fn _ ->
+        execute_test_case_attempt(test_case, version, provider)
+      end)
+
+    Sampling.aggregate(attempts, sampling)
+  end
+
+  defp execute_test_case_attempt(test_case, version, provider) do
     test_case = ensure_documents_loaded(test_case)
 
     request = %{
@@ -760,33 +787,56 @@ defmodule Aludel.Evals do
     }
   end
 
-  defp accumulate_cost_and_latency(acc, %{"cost_usd" => cost, "latency_ms" => latency}) do
+  defp accumulate_cost_and_latency(
+         acc,
+         %{"cost_usd" => cost, "latency_ms" => latency} = result
+       ) do
     acc
-    |> maybe_accumulate_cost(cost)
-    |> maybe_accumulate_latency(latency)
+    |> maybe_accumulate_cost(cost, sample_count(result, "cost_sample_count", cost))
+    |> maybe_accumulate_latency(
+      latency,
+      sample_count(result, "latency_sample_count", latency)
+    )
   end
 
   defp accumulate_cost_and_latency(acc, _result), do: acc
 
-  defp maybe_accumulate_cost(acc, cost) when is_number(cost) do
+  defp maybe_accumulate_cost(acc, cost, sample_count)
+       when is_number(cost) and is_integer(sample_count) and sample_count > 0 do
     %{
       acc
       | total_cost: Decimal.add(acc.total_cost, decimal_from_number(cost)),
-        cost_samples: acc.cost_samples + 1
+        cost_samples: acc.cost_samples + sample_count
     }
   end
 
-  defp maybe_accumulate_cost(acc, _cost), do: acc
+  defp maybe_accumulate_cost(acc, _cost, _sample_count) do
+    acc
+  end
 
-  defp maybe_accumulate_latency(acc, latency) when is_number(latency) do
+  defp maybe_accumulate_latency(acc, latency, sample_count)
+       when is_number(latency) and is_integer(sample_count) and sample_count > 0 do
     %{
       acc
       | total_latency: acc.total_latency + round(latency),
-        latency_samples: acc.latency_samples + 1
+        latency_samples: acc.latency_samples + sample_count
     }
   end
 
-  defp maybe_accumulate_latency(acc, _latency), do: acc
+  defp maybe_accumulate_latency(acc, _latency, _sample_count) do
+    acc
+  end
+
+  defp sample_count(result, field, value) when is_number(value) do
+    case Map.get(result, field) do
+      count when is_integer(count) and count > 0 -> count
+      _missing_or_invalid -> 1
+    end
+  end
+
+  defp sample_count(_result, _field, _value) do
+    0
+  end
 
   defp accumulate_score(acc, %{"score" => score}) when is_number(score) do
     %{

--- a/lib/aludel/evals/sampling.ex
+++ b/lib/aludel/evals/sampling.ex
@@ -1,0 +1,256 @@
+defmodule Aludel.Evals.Sampling do
+  @moduledoc """
+  Configuration and deterministic reduction for repeated test case execution.
+
+  Sampling is bounded to protect callers from accidental request amplification.
+  Attempts remain ordered and are retained in the aggregate result. The latest
+  attempt matching the reduced outcome supplies representative output and
+  artifacts, while scores and usage are aggregated across every attempt.
+  """
+
+  @max_samples 20
+  @reducers [:all, :any, :majority]
+  @schema_version 1
+
+  @enforce_keys [:samples, :reducer]
+  defstruct samples: 1, reducer: :all, minimum_pass_rate: nil
+
+  @type reducer :: :all | :any | :majority | :minimum_pass_rate
+  @type reducer_option :: :all | :any | :majority | {:minimum_pass_rate, number()}
+  @type option :: {:samples, pos_integer()} | {:reducer, reducer_option()}
+
+  @type t :: %__MODULE__{
+          samples: pos_integer(),
+          reducer: reducer(),
+          minimum_pass_rate: float() | nil
+        }
+
+  @doc """
+  Validates sampling options.
+
+  `:samples` defaults to `1` and accepts values up to #{@max_samples}. `:reducer`
+  accepts `:all`, `:any`, `:majority`, or `{:minimum_pass_rate, rate}` where the
+  rate is between `0.0` and `1.0`.
+  """
+  @spec new([option()]) :: {:ok, t()} | {:error, {:invalid_sampling, String.t()}}
+  def new(opts \\ [])
+
+  def new(opts) when is_list(opts) do
+    with :ok <- validate_options(opts),
+         {:ok, samples} <- validate_samples(Keyword.get(opts, :samples, 1)),
+         {:ok, reducer, minimum_pass_rate} <-
+           validate_reducer(Keyword.get(opts, :reducer, :all)) do
+      {:ok,
+       %__MODULE__{
+         samples: samples,
+         reducer: reducer,
+         minimum_pass_rate: minimum_pass_rate
+       }}
+    end
+  end
+
+  def new(_opts) do
+    invalid("options must be a keyword list")
+  end
+
+  @doc """
+  Restores the sampling configuration stored in a test case result.
+
+  Results created before sampling default to one attempt with the `:all`
+  reducer.
+  """
+  @spec from_result(map()) :: {:ok, t()} | {:error, {:invalid_sampling, String.t()}}
+  def from_result(%{"sampling" => %{"schema_version" => 1} = sampling}) do
+    with {:ok, reducer} <- persisted_reducer(sampling) do
+      new(samples: sampling["samples"], reducer: reducer)
+    end
+  end
+
+  def from_result(%{"sampling" => _sampling}) do
+    invalid("persisted sampling configuration has an unsupported schema")
+  end
+
+  def from_result(result) when is_map(result) do
+    new()
+  end
+
+  @doc """
+  Aggregates ordered attempt results according to a validated configuration.
+
+  The aggregate retains every attempt, reports pass-rate evidence, sums token,
+  cost, and latency usage, and averages available attempt scores.
+  """
+  @spec aggregate([map()], t()) :: map()
+  def aggregate(attempts, %__MODULE__{samples: samples} = sampling)
+      when is_list(attempts) and length(attempts) == samples and samples > 0 do
+    attempts =
+      attempts
+      |> Enum.with_index(1)
+      |> Enum.map(fn {attempt, attempt_number} ->
+        Map.put(attempt, "attempt", attempt_number)
+      end)
+
+    passed_attempts = Enum.count(attempts, &(&1["passed"] == true))
+    pass_rate = passed_attempts / samples
+    passed = reduced_pass?(sampling, passed_attempts, pass_rate)
+    representative = representative_attempt(attempts, passed)
+
+    sampling_metadata =
+      sampling_metadata(sampling, passed_attempts, pass_rate, representative["attempt"])
+
+    representative
+    |> Map.delete("attempt")
+    |> Map.merge(%{
+      "passed" => passed,
+      "score" => average(attempts, "score"),
+      "input_tokens" => total(attempts, "input_tokens"),
+      "output_tokens" => total(attempts, "output_tokens"),
+      "cost_usd" => total(attempts, "cost_usd"),
+      "latency_ms" => total(attempts, "latency_ms"),
+      "cost_sample_count" => count(attempts, "cost_usd"),
+      "latency_sample_count" => count(attempts, "latency_ms"),
+      "sampling" => sampling_metadata,
+      "attempts" => attempts
+    })
+  end
+
+  def aggregate(_attempts, _sampling) do
+    raise ArgumentError, "attempt results must match the configured sample count"
+  end
+
+  defp validate_options(opts) do
+    if Keyword.keyword?(opts) do
+      validate_option_names(Keyword.keys(opts) -- [:samples, :reducer])
+    else
+      invalid("options must be a keyword list")
+    end
+  end
+
+  defp validate_option_names([]) do
+    :ok
+  end
+
+  defp validate_option_names(unknown_options) do
+    invalid("unknown options: #{Enum.map_join(unknown_options, ", ", &inspect/1)}")
+  end
+
+  defp validate_samples(samples)
+       when is_integer(samples) and samples >= 1 and samples <= @max_samples do
+    {:ok, samples}
+  end
+
+  defp validate_samples(_samples) do
+    invalid("samples must be an integer between 1 and #{@max_samples}")
+  end
+
+  defp validate_reducer(reducer) when reducer in @reducers do
+    {:ok, reducer, nil}
+  end
+
+  defp validate_reducer({:minimum_pass_rate, rate})
+       when is_number(rate) and rate >= 0 and rate <= 1 do
+    {:ok, :minimum_pass_rate, rate / 1}
+  end
+
+  defp validate_reducer(_reducer) do
+    invalid("reducer must be :all, :any, :majority, or {:minimum_pass_rate, rate}")
+  end
+
+  defp persisted_reducer(%{
+         "reducer" => "minimum_pass_rate",
+         "minimum_pass_rate" => rate
+       }) do
+    {:ok, {:minimum_pass_rate, rate}}
+  end
+
+  defp persisted_reducer(%{"reducer" => reducer}) do
+    case reducer do
+      "all" -> {:ok, :all}
+      "any" -> {:ok, :any}
+      "majority" -> {:ok, :majority}
+      _unknown -> invalid("persisted reducer is invalid")
+    end
+  end
+
+  defp persisted_reducer(_sampling) do
+    invalid("persisted sampling configuration is incomplete")
+  end
+
+  defp reduced_pass?(%__MODULE__{reducer: :all, samples: samples}, passed, _rate) do
+    passed == samples
+  end
+
+  defp reduced_pass?(%__MODULE__{reducer: :any}, passed, _rate) do
+    passed > 0
+  end
+
+  defp reduced_pass?(%__MODULE__{reducer: :majority, samples: samples}, passed, _rate) do
+    passed * 2 > samples
+  end
+
+  defp reduced_pass?(%__MODULE__{reducer: :minimum_pass_rate} = sampling, _passed, rate) do
+    rate >= sampling.minimum_pass_rate
+  end
+
+  defp representative_attempt(attempts, passed) do
+    reversed_attempts = Enum.reverse(attempts)
+
+    Enum.find(reversed_attempts, &(&1["passed"] == passed)) || hd(reversed_attempts)
+  end
+
+  defp sampling_metadata(sampling, passed_attempts, pass_rate, representative_attempt) do
+    %{
+      "schema_version" => @schema_version,
+      "samples" => sampling.samples,
+      "reducer" => Atom.to_string(sampling.reducer),
+      "passed_attempts" => passed_attempts,
+      "failed_attempts" => sampling.samples - passed_attempts,
+      "pass_rate" => Float.round(pass_rate, 4),
+      "representative_attempt" => representative_attempt
+    }
+    |> maybe_put_minimum_pass_rate(sampling.minimum_pass_rate)
+  end
+
+  defp maybe_put_minimum_pass_rate(metadata, nil) do
+    metadata
+  end
+
+  defp maybe_put_minimum_pass_rate(metadata, minimum_pass_rate) do
+    Map.put(metadata, "minimum_pass_rate", minimum_pass_rate)
+  end
+
+  defp total(attempts, field) do
+    case numeric_values(attempts, field) do
+      [] -> nil
+      values -> Enum.sum(values)
+    end
+  end
+
+  defp count(attempts, field) do
+    attempts
+    |> numeric_values(field)
+    |> length()
+  end
+
+  defp average(attempts, field) do
+    case numeric_values(attempts, field) do
+      [] ->
+        nil
+
+      values ->
+        values
+        |> then(&(Enum.sum(&1) / length(&1)))
+        |> Float.round(1)
+    end
+  end
+
+  defp numeric_values(attempts, field) do
+    attempts
+    |> Enum.map(&Map.get(&1, field))
+    |> Enum.filter(&is_number/1)
+  end
+
+  defp invalid(message) do
+    {:error, {:invalid_sampling, message}}
+  end
+end

--- a/lib/aludel/evals/suite_runner.ex
+++ b/lib/aludel/evals/suite_runner.ex
@@ -12,27 +12,28 @@ defmodule Aludel.Evals.SuiteRunner do
 
   @type execution_result :: {:ok, SuiteRun.t()} | {:error, term()}
 
-  @spec launch(pid(), binary(), binary(), binary()) :: {:ok, pid()} | {:error, term()}
-  def launch(recipient, suite_id, version_id, provider_id)
+  @spec launch(pid(), binary(), binary(), binary(), keyword()) ::
+          {:ok, pid()} | {:error, term()}
+  def launch(recipient, suite_id, version_id, provider_id, opts \\ [])
       when is_pid(recipient) and is_binary(suite_id) and is_binary(version_id) and
-             is_binary(provider_id) do
+             is_binary(provider_id) and is_list(opts) do
     Task.Supervisor.start_child(TaskSupervisor, fn ->
-      send(recipient, {:suite_completed, execute(suite_id, version_id, provider_id)})
+      send(recipient, {:suite_completed, execute(suite_id, version_id, provider_id, opts)})
     end)
   end
 
-  @spec execute(binary(), binary(), binary()) :: execution_result()
-  def execute(suite_id, version_id, provider_id)
+  @spec execute(binary(), binary(), binary(), keyword()) :: execution_result()
+  def execute(suite_id, version_id, provider_id, opts \\ [])
       when is_binary(suite_id) and is_binary(version_id) and is_binary(provider_id) do
     with {:ok, suite} <- fetch_suite(suite_id),
          {:ok, version} <- fetch_prompt_version(version_id),
          {:ok, provider} <- fetch_provider(provider_id) do
-      run_execution(suite, version, provider)
+      run_execution(suite, version, provider, opts)
     end
   end
 
-  defp run_execution(suite, version, provider) do
-    Evals.execute_suite(suite, version, provider)
+  defp run_execution(suite, version, provider, opts) do
+    Evals.execute_suite(suite, version, provider, opts)
   rescue
     error ->
       {:error, {:execution_failed, Exception.message(error)}}

--- a/test/aludel/evals/sampling_test.exs
+++ b/test/aludel/evals/sampling_test.exs
@@ -1,0 +1,85 @@
+defmodule Aludel.Evals.SamplingTest do
+  use ExUnit.Case, async: true
+
+  alias Aludel.Evals.Sampling
+
+  test "applies all, any, and majority reducers" do
+    attempts = [attempt(true), attempt(true), attempt(false)]
+
+    assert {:ok, all} = Sampling.new(samples: 3, reducer: :all)
+    refute Sampling.aggregate(attempts, all)["passed"]
+
+    assert {:ok, any} = Sampling.new(samples: 3, reducer: :any)
+    assert Sampling.aggregate(attempts, any)["passed"]
+
+    assert {:ok, majority} = Sampling.new(samples: 3, reducer: :majority)
+    aggregate = Sampling.aggregate(attempts, majority)
+    assert aggregate["passed"]
+    assert aggregate["score"] == 66.7
+    assert aggregate["sampling"]["pass_rate"] == 0.6667
+  end
+
+  test "applies a minimum pass-rate reducer without rounding its decision" do
+    attempts = [attempt(true), attempt(true), attempt(false)]
+
+    assert {:ok, passing} =
+             Sampling.new(samples: 3, reducer: {:minimum_pass_rate, 0.66})
+
+    assert Sampling.aggregate(attempts, passing)["passed"]
+
+    assert {:ok, failing} =
+             Sampling.new(samples: 3, reducer: {:minimum_pass_rate, 0.67})
+
+    refute Sampling.aggregate(attempts, failing)["passed"]
+  end
+
+  test "rejects unsafe or ambiguous configurations" do
+    assert {:error, {:invalid_sampling, _message}} = Sampling.new(samples: 0)
+    assert {:error, {:invalid_sampling, _message}} = Sampling.new(samples: 21)
+    assert {:error, {:invalid_sampling, _message}} = Sampling.new(reducer: :unknown)
+
+    assert {:error, {:invalid_sampling, _message}} =
+             Sampling.new(reducer: {:minimum_pass_rate, 1.1})
+
+    assert {:error, {:invalid_sampling, _message}} = Sampling.new(extra: true)
+  end
+
+  test "restores configuration from a persisted aggregate" do
+    result = %{
+      "sampling" => %{
+        "schema_version" => 1,
+        "samples" => 4,
+        "reducer" => "minimum_pass_rate",
+        "minimum_pass_rate" => 0.75
+      }
+    }
+
+    assert {:ok, sampling} = Sampling.from_result(result)
+    assert sampling.samples == 4
+    assert sampling.reducer == :minimum_pass_rate
+    assert sampling.minimum_pass_rate == 0.75
+
+    assert {:ok, default} = Sampling.from_result(%{})
+    assert default.samples == 1
+    assert default.reducer == :all
+
+    assert {:error, {:invalid_sampling, _message}} =
+             Sampling.from_result(%{"sampling" => %{"schema_version" => 2}})
+  end
+
+  defp attempt(passed) do
+    %{
+      "test_case_id" => "test-case",
+      "passed" => passed,
+      "score" => if(passed, do: 100.0, else: 0.0),
+      "input_tokens" => 5,
+      "output_tokens" => 2,
+      "cost_usd" => 0.01,
+      "latency_ms" => 10,
+      "output" => if(passed, do: "pass", else: "fail"),
+      "assertion_results" => [],
+      "metadata" => %{},
+      "artifacts" => %{}
+    }
+  end
+end

--- a/test/aludel/evals/suite_runner_test.exs
+++ b/test/aludel/evals/suite_runner_test.exs
@@ -8,7 +8,7 @@ defmodule Aludel.Evals.SuiteRunnerTest do
   setup :set_mox_global
   setup :verify_on_exit!
 
-  describe "execute/3" do
+  describe "execute/3 and execute/4" do
     test "returns a persisted suite run" do
       prompt = prompt_fixture_with_version(%{template: "Hello {{name}}"})
       suite = suite_fixture(%{prompt_id: prompt.id})
@@ -35,6 +35,16 @@ defmodule Aludel.Evals.SuiteRunnerTest do
 
       assert {:error, :provider_not_found} =
                SuiteRunner.execute(suite.id, version.id, Ecto.UUID.generate())
+    end
+
+    test "forwards sampling validation errors" do
+      prompt = prompt_fixture_with_version(%{template: "Hello {{name}}"})
+      suite = suite_fixture(%{prompt_id: prompt.id})
+      provider = provider_fixture()
+      version = List.first(prompt.versions)
+
+      assert {:error, {:invalid_sampling, _message}} =
+               SuiteRunner.execute(suite.id, version.id, provider.id, samples: 21)
     end
 
     test "executes suites through the configured callback executor" do

--- a/test/aludel/evals_test.exs
+++ b/test/aludel/evals_test.exs
@@ -481,7 +481,93 @@ defmodule Aludel.EvalsTest do
     end
   end
 
-  describe "execute_suite/3" do
+  describe "execute_suite/3 and execute_suite/4" do
+    test "retains repeated attempts, reduces them, and repeats the same sampling on retry" do
+      Process.put(:sampling_outputs, ["miss", "pass", "pass", "miss", "miss", "miss"])
+
+      expect(HttpClientMock, :request, 6, fn _model, _prompt, _opts ->
+        [output | remaining] = Process.get(:sampling_outputs)
+        Process.put(:sampling_outputs, remaining)
+        {:ok, build_mock_response(output, 5, 2)}
+      end)
+
+      suite = suite_fixture()
+      prompt = prompt_fixture()
+      {:ok, version} = Aludel.Prompts.create_prompt_version(prompt, "Answer {{input}}")
+
+      provider =
+        provider_fixture(%{
+          pricing: %{"input" => 1000.0, "output" => 2000.0}
+        })
+
+      test_case =
+        test_case_fixture(%{
+          suite_id: suite.id,
+          variable_values: %{"input" => "now"},
+          assertions: [%{"type" => "exact_match", "value" => "pass"}]
+        })
+
+      assert {:ok, suite_run} =
+               Evals.execute_suite(suite, version, provider,
+                 samples: 3,
+                 reducer: :majority
+               )
+
+      assert suite_run.passed == 1
+      assert suite_run.failed == 0
+      assert suite_run.cost_sample_count == 3
+      assert suite_run.latency_sample_count == 3
+      assert [result] = suite_run.results
+      assert result["passed"]
+      assert result["output"] == "pass"
+      assert result["score"] == 66.7
+      assert result["input_tokens"] == 15
+      assert result["output_tokens"] == 6
+      assert_in_delta result["cost_usd"], 0.027, 0.000_001
+      assert_in_delta Decimal.to_float(suite_run.total_cost_usd), 0.027, 0.000_001
+      assert_in_delta Decimal.to_float(suite_run.avg_cost_usd), 0.009, 0.000_001
+
+      assert result["sampling"] == %{
+               "failed_attempts" => 1,
+               "pass_rate" => 0.6667,
+               "passed_attempts" => 2,
+               "reducer" => "majority",
+               "representative_attempt" => 3,
+               "schema_version" => 1,
+               "samples" => 3
+             }
+
+      assert Enum.map(result["attempts"], & &1["attempt"]) == [1, 2, 3]
+      assert Enum.map(result["attempts"], & &1["passed"]) == [false, true, true]
+
+      assert {:ok, retried_run} = Evals.retry_suite_run_test_case(suite_run, test_case.id)
+      assert retried_run.passed == 0
+      assert retried_run.failed == 1
+      assert retried_run.cost_sample_count == 3
+      assert [retried_result] = retried_run.results
+      assert retried_result["retry_count"] == 1
+      assert retried_result["sampling"]["reducer"] == "majority"
+      assert Enum.map(retried_result["attempts"], & &1["passed"]) == [false, false, false]
+    end
+
+    test "rejects invalid sampling before executing or persisting a run" do
+      suite = suite_fixture()
+      prompt = prompt_fixture()
+      {:ok, version} = Aludel.Prompts.create_prompt_version(prompt, "Answer")
+      provider = provider_fixture()
+
+      _test_case =
+        test_case_fixture(%{
+          suite_id: suite.id,
+          assertions: [%{"type" => "contains", "value" => "answer"}]
+        })
+
+      assert {:error, {:invalid_sampling, _message}} =
+               Evals.execute_suite(suite, version, provider, samples: 0)
+
+      assert Evals.list_suite_runs() == []
+    end
+
     test "executes multi-turn cases with the rendered prompt as system context" do
       expect(HttpClientMock, :request, fn _model, messages, _opts ->
         assert messages == [


### PR DESCRIPTION
## Motivation

Single model responses can be too variable to support reliable evaluation decisions. This adds bounded repeated execution for each suite test case with `:all`, `:any`, strict `:majority`, and configurable minimum pass-rate reducers.

Sampled results retain every ordered attempt and a versioned aggregate. Token usage, cost, and latency are summed without losing per-attempt evidence, available scores are averaged, and an attempt matching the aggregate outcome supplies representative output and artifacts. Existing one-attempt result shapes remain unchanged.

Retries restore the persisted sample count and reducer, execute a complete replacement attempt set, and recalculate suite aggregates. Invalid or unsupported sampling configurations fail before model execution or run persistence.

The README and evaluation guide introduce the feature at the point of use. The [repeated sampling wiki guide](https://github.com/ccarvalho-eng/aludel/wiki/Repeated-Sampling) covers every reducer, both execution APIs, result evidence, retry behavior, and cost guidance.

```mermaid
flowchart LR
  A[Validate bounded options] --> B[Execute ordered attempts]
  B --> C[Retain attempt evidence]
  C --> D[Apply reducer]
  D --> E[Persist aggregate]
  E -->|Retry case| F[Restore versioned config]
  F --> B
```

## Test Plan

Added pure reducer coverage for all supported strategies, exact minimum-rate decisions, configuration bounds, persisted configuration restoration, and schema compatibility.

Added end-to-end suite coverage for ordered attempts, aggregate decisions, representative output, scores, token and cost accounting, full sampled retries, and rejection before external execution or persistence. Added supervised runner coverage for option forwarding.

The full project test and static-analysis suite, documentation build, package build, Dialyzer, and dependency security audits pass locally.

## Next Steps

A separate follow-up will add versioned suite quality policies and budget gates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added repeated evaluation sampling, allowing each test case to run up to 20 times.
  * Added configurable result reducers: all, any, majority, and minimum pass rate.
  * Evaluation results now retain all attempts and aggregate scores, token usage, cost, and latency.
  * Retries preserve the original sampling configuration.

* **Documentation**
  * Added usage guidance and examples for repeated sampling, validation, aggregation, and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->