### PR TITLE
docs(evals): document evaluation foundations

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Aludel gives teams a clean way to evaluate prompt and model behavior without inv
 - Compare the same prompt across OpenAI, Anthropic, Gemini, Ollama, xAI, Groq, and OpenRouter.
 - Inspect output, latency, token usage, and cost side by side.
 - Compare prompt versions and see pass-rate, cost, and latency changes over time.
-- Run evaluation suites with assertions, repeated sampling, document attachments, and CSV or JSON test case imports.
+- Run evaluation suites with deterministic assertions, model-based judges, repeated sampling, document attachments, and CSV or JSON test case imports.
 - Execute suites headlessly with machine-readable JSON output for CI workflows.
 - Route runs and suites through your app's real LLM workflow with callback execution.
 - Reuse single-turn and multi-turn datasets across suites with provenance and metadata filtering.
@@ -40,8 +40,8 @@ Most teams evaluating LLM behavior end up with some combination of scripts, spre
 | Prompts | `{{variable}}` templates, immutable versions, tags, search, pagination, typed projects, version diffs, and provider-specific evolution history |
 | Providers | OpenAI, Anthropic, Google Gemini, Ollama, xAI, Groq, and OpenRouter; active and deprecated text-model discovery; custom model IDs; built-in or overridden pricing |
 | Runs | Multi-provider execution, concurrent or sequential dispatch, live status updates, partial-failure handling, normalized execution artifacts, result copy actions, and JSON exports |
-| Evaluation suites | Visual and JSON test-case editing, single-turn and multi-turn inputs, bounded repeated sampling with configurable pass reducers, document attachments, suite history, per-result retries, and aggregate quality, cost, and latency |
-| Assertions | `contains`, `not_contains`, `regex`, `exact_match`, typed `json_field`, and scored `json_deep_compare` with configurable thresholds |
+| Evaluation suites | Visual and JSON test-case editing, contextual prompt and execution evidence, normalized evaluator details, single-turn and multi-turn inputs, bounded repeated sampling with configurable pass reducers, document attachments, suite history, per-result retries, and aggregate quality, cost, and latency |
+| Assertions | `contains`, `not_contains`, `regex`, `exact_match`, typed `json_field`, scored `json_deep_compare`, custom rubric judges, and seven versioned judge templates |
 | Imports and datasets | CSV and JSON import previews with row-level errors; reusable ordered datasets with variables, messages, assertions, metadata filters, provenance, and idempotent suite population |
 | Prompt evolution | Version and provider trends, version-over-version deltas, suite-scoped Pareto frontiers, failure-grounded prompt suggestions, and explicit accept or dismiss decisions |
 | Automation and exports | JSON run and suite exports, CSV or JSON evolution exports, and `mix aludel.eval` with stable JSON output and CI-friendly exit status |
@@ -50,6 +50,30 @@ Most teams evaluating LLM behavior end up with some combination of scripts, spre
 | Demo data | Deterministic prompts, providers, datasets, suites, runs, failures, artifacts, and 60 days of comparison history through `mix aludel.seed` |
 
 See the [complete feature guide](https://hexdocs.pm/aludel/features.html) for behavior, constraints, and examples.
+
+## Model-Based Evaluation
+
+Use a rubric judge when correctness depends on meaning instead of an exact string or JSON shape. Choose a separate configured provider for the judge and use either a custom rubric or a versioned built-in template:
+
+```json
+[
+  {
+    "type": "rubric_judge",
+    "template": "faithfulness",
+    "provider_id": "00000000-0000-0000-0000-000000000000",
+    "threshold": 85,
+    "context": "Claims must be supported by this grounding evidence."
+  }
+]
+```
+
+Replace the placeholder with the ID of a configured provider.
+
+The catalog includes correctness, relevance, faithfulness, safety, refusal quality, PII protection, and hallucination checks. Aludel records the resolved rubric and template version alongside score, reasoning, duration, provider, model, token usage, cost, and structured evaluator status.
+
+See the [evaluation guide](https://hexdocs.pm/aludel/evaluations.html#custom-rubric-judge), [rubric judge guide](https://github.com/ccarvalho-eng/aludel/wiki/Rubric-Judges), and [judge catalog](https://github.com/ccarvalho-eng/aludel/wiki/Judge-Catalog).
+
+Suite execution supplies metrics with normalized output, rendered input, prompt template, variables, messages, documents, metadata, provider, prompt version, and execution evidence. Expected references remain available in assertion configuration, and direct callers can also set `expected` on `Aludel.Evals.Metric.Context`. See [metric context](https://github.com/ccarvalho-eng/aludel/wiki/Metric-Context) and [evaluator execution details](https://github.com/ccarvalho-eng/aludel/wiki/Evaluator-Execution-Details).
 
 ## Structured Output Scoring
 

--- a/guides/evaluations.md
+++ b/guides/evaluations.md
@@ -142,6 +142,37 @@ For common checks, replace `rubric` with a versioned built-in `template`:
 
 Templates and custom rubrics are mutually exclusive. Aludel records the resolved rubric and template version with each result, so a historical run retains the criteria it used.
 
+### Inspect metric context and evaluator details
+
+Suite execution gives every metric a normalized `Aludel.Evals.Metric.Context` containing the generated output, rendered input, prompt template, variables, messages, documents, metadata, provider, prompt version, and execution details. Expected references remain in assertion configuration. Direct callers can also set `expected` on the context.
+
+Direct callers can use the same contract:
+
+```elixir
+alias Aludel.Evals.AssertionEvaluator
+alias Aludel.Evals.Metric.Context
+
+context =
+  Context.new("Paris",
+    expected: "Paris",
+    rendered_input: "What is the capital of France?",
+    variables: %{"country" => "France"},
+    metadata: %{"category" => "geography"}
+  )
+
+result =
+  AssertionEvaluator.evaluate(context, %{
+    "type" => "contains",
+    "value" => "Paris"
+  })
+```
+
+Passing a string as the first argument remains supported for metrics that only need generated text.
+
+Every assertion result has an `evaluator` map. Deterministic metrics record `status: "completed"` and measured `duration_ms`. Model-backed judges also record their provider, model, input and output tokens, and cost independently from the model being evaluated.
+
+Evaluator status is one of `completed`, `error`, or `unavailable`. Failures use stable structured error types without retaining exception messages, provider response bodies, credentials, or other sensitive details. This keeps a failed evaluator distinct from an assertion that ran successfully and scored the output as failing.
+
 ### Repeat nondeterministic cases
 
 Run each test case more than once when a single model response is not reliable enough to make a decision:


### PR DESCRIPTION
## Summary

Make the current evaluation foundations discoverable from the README and HexDocs evaluation guide.

- Add model-based rubric judges and all seven versioned judge templates to the README feature catalog.
- Document normalized metric context, including the evidence supplied by suite execution and direct callers.
- Explain evaluator lifecycle status, timing, provider/model identity, token usage, cost attribution, and safe structured failures.
- Link focused wiki guides for metric context, evaluator execution details, rubric judges, and the judge catalog.

The wiki update includes runnable examples, field and result contracts, security boundaries, failure behavior, and a usage example for every built-in judge template.

## Test Plan

The HexDocs build, Hex package build, full test suite, Credo, and Sobelow checks pass. Local wiki links resolve to existing pages, and both publication diffs pass whitespace and prohibited-reference checks.
