### PR TITLE
feat(evals): add quality policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ Most teams evaluating LLM behavior end up with some combination of scripts, spre
 | Prompts | `{{variable}}` templates, immutable versions, tags, search, pagination, typed projects, version diffs, and provider-specific evolution history |
 | Providers | OpenAI, Anthropic, Google Gemini, Ollama, xAI, Groq, and OpenRouter; active and deprecated text-model discovery; custom model IDs; built-in or overridden pricing |
 | Runs | Multi-provider execution, concurrent or sequential dispatch, live status updates, partial-failure handling, normalized execution artifacts, result copy actions, and JSON exports |
-| Evaluation suites | Visual and JSON test-case editing, contextual prompt and execution evidence, normalized evaluator details, single-turn and multi-turn inputs, bounded repeated sampling with configurable pass reducers, document attachments, suite history, per-result retries, and aggregate quality, cost, and latency |
+| Evaluation suites | Visual and JSON test-case editing, contextual prompt and execution evidence, normalized evaluator details, immutable versioned quality policies, single-turn and multi-turn inputs, bounded repeated sampling with configurable pass reducers, document attachments, suite history, per-result retries, and aggregate quality, cost, and latency |
 | Assertions | `contains`, `not_contains`, `regex`, `exact_match`, typed `json_field`, scored `json_deep_compare`, custom rubric judges, and seven versioned judge templates |
 | Imports and datasets | CSV and JSON import previews with row-level errors; reusable ordered datasets with variables, messages, assertions, metadata filters, provenance, and idempotent suite population |
 | Prompt evolution | Version and provider trends, version-over-version deltas, suite-scoped Pareto frontiers, failure-grounded prompt suggestions, and explicit accept or dismiss decisions |
-| Automation and exports | JSON run and suite exports, CSV or JSON evolution exports, and `mix aludel.eval` with stable JSON output and CI-friendly exit status |
+| Automation and exports | JSON run and suite exports, CSV or JSON evolution exports, and policy-aware `mix aludel.eval` quality gates with stable JSON output and CI-friendly exit status |
 | Execution and extension | Native provider calls, host-app callback execution, pluggable LLM, storage, and document-conversion boundaries, optional callback metadata, and configurable run concurrency |
 | Deployment | Embedded Phoenix dashboard, standalone app, Docker Compose, local/AWS S3/GCS document storage, custom auth/access resolvers, CSP nonce support, theming, and read-only mode |
 | Demo data | Deterministic prompts, providers, datasets, suites, runs, failures, artifacts, and 60 days of comparison history through `mix aludel.seed` |
@@ -114,6 +114,33 @@ Nondeterministic model output can make a single response misleading. Run each te
 Reducers support `:all`, `:any`, strict `:majority`, and a minimum pass rate. Aludel retains every attempt, sums token usage, cost, and latency, and reruns the complete sampling configuration when a result is retried.
 
 See the [evaluation guide](https://hexdocs.pm/aludel/evaluations.html#repeat-nondeterministic-cases) and [repeated sampling wiki guide](https://github.com/ccarvalho-eng/aludel/wiki/Repeated-Sampling) for the full result shape and reducer examples.
+
+## Versioned Quality Policies
+
+Define what a suite must satisfy instead of treating every run as an all-or-nothing test count:
+
+```elixir
+{:ok, policy} =
+  Aludel.Evals.create_suite_policy(suite, %{
+    "schema_version" => 1,
+    "rules" => [
+      %{"id" => "overall", "type" => "overall_pass_rate", "minimum" => 0.95},
+      %{
+        "id" => "priority",
+        "type" => "metadata_pass_rate",
+        "metadata" => %{"priority" => "high"},
+        "minimum" => 1.0
+      },
+      %{"id" => "budget", "type" => "total_cost_usd", "maximum" => 0.50}
+    ]
+  })
+```
+
+Policies can gate overall pass rate, metadata groups, evaluator scores, total cost, and average latency. Each update creates an immutable suite-local version. A run snapshots the latest version before execution, and retries continue to use that same version.
+
+Policy results report `passed`, `failed`, `invalid`, or `unavailable`; missing evidence never silently passes. `mix aludel.eval` uses the policy outcome as its exit gate and preserves the legacy all-cases-must-pass behavior for suites without a policy.
+
+See the [evaluation guide](https://hexdocs.pm/aludel/evaluations.html#enforce-a-versioned-quality-policy) and [quality policies wiki guide](https://github.com/ccarvalho-eng/aludel/wiki/Quality-Policies) for every rule and result example.
 
 ## Test Case Imports
 

--- a/guides/evaluations.md
+++ b/guides/evaluations.md
@@ -189,6 +189,50 @@ Run each test case more than once when a single model response is not reliable e
 
 Sampled results retain every ordered attempt and record passed and failed counts, pass rate, reducer configuration, and the representative attempt. Token usage, cost, and latency are summed across attempts; available scores are averaged. Retrying a sampled test case reruns the complete persisted sampling configuration and replaces the previous aggregate.
 
+### Enforce a versioned quality policy
+
+Create an immutable policy version for a suite:
+
+```elixir
+{:ok, policy} =
+  Aludel.Evals.create_suite_policy(suite, %{
+    "schema_version" => 1,
+    "rules" => [
+      %{"id" => "overall", "type" => "overall_pass_rate", "minimum" => 0.95},
+      %{
+        "id" => "priority",
+        "type" => "metadata_pass_rate",
+        "metadata" => %{"priority" => "high"},
+        "minimum" => 1.0
+      },
+      %{
+        "id" => "faithfulness",
+        "type" => "evaluator_score",
+        "metric" => "rubric_judge",
+        "minimum" => 85
+      },
+      %{"id" => "cost", "type" => "total_cost_usd", "maximum" => 0.50},
+      %{"id" => "latency", "type" => "average_latency_ms", "maximum" => 1_500}
+    ]
+  })
+```
+
+Pass-rate minimums use values from `0.0` through `1.0`; evaluator-score minimums use `0` through `100`. Metadata groups match test cases whose metadata contains every configured key and value. Evaluator-score rules average every completed matching assertion, including every retained sampling attempt. Cost uses the full suite-run total, while latency uses the average across available request samples.
+
+Creating another policy produces the next suite-local version. Suite execution snapshots the latest version before making model requests. A later single-case retry restores the policy associated with the original run instead of switching to a newer contract.
+
+Each rule and the aggregate policy record a status. `passed` and `failed` are measured quality decisions. `unavailable` means required evidence such as a matching metadata group, completed evaluator score, cost, or latency was missing. `invalid` means a direct policy evaluation received a malformed or unsupported definition. Stored policy versions are field-strict, JSON-only, limited to 50 rules and 100,000 encoded bytes, and validated before persistence.
+
+```elixir
+case suite_run.quality_policy_result do
+  %{"status" => "passed"} -> :ok
+  %{"status" => status, "rules" => rules} -> {:error, status, rules}
+  nil -> :no_policy
+end
+```
+
+`mix aludel.eval` uses a stored policy outcome as its process exit gate. Suites without a policy keep the legacy behavior: every test case must pass and an empty suite fails.
+
 ## 5. Populate a suite
 
 Create an evaluation suite for the prompt, open it, select a dataset, and choose **Add entries**. Aludel copies entries in dataset order and records each source entry.

--- a/guides/features.md
+++ b/guides/features.md
@@ -70,11 +70,14 @@ The suite UI supports:
 - population from reusable datasets
 - selection of a prompt version and provider for each suite run
 - persisted suite-run history with aggregate pass/fail, quality score, cost, and latency
-- detailed assertion and field-comparison results
+- detailed assertion, field-comparison, metric-context, and evaluator execution results
+- custom rubric judges and versioned correctness, relevance, faithfulness, safety, refusal, PII, and hallucination templates
+- bounded repeated sampling with all, any, majority, and minimum pass-rate reducers
+- immutable versioned quality policies for overall and metadata-group pass rates, evaluator scores, total cost, and average latency
 - retrying one test result without rerunning the entire suite
 - copy actions and raw JSON exports
 
-Built-in metrics are `contains`, `not_contains`, `regex`, `exact_match`, `json_field`, and `json_deep_compare`. See the [Evaluation Guide](evaluations.md) for examples.
+Built-in metrics are `contains`, `not_contains`, `regex`, `exact_match`, `json_field`, `json_deep_compare`, and `rubric_judge`. See the [Evaluation Guide](evaluations.md) for examples and programmatic policy configuration.
 
 ## Reusable datasets
 

--- a/lib/aludel/evals.ex
+++ b/lib/aludel/evals.ex
@@ -1,14 +1,16 @@
 defmodule Aludel.Evals do
   @moduledoc """
-  Context for managing evaluation suites, test cases, and runs.
+  Context for managing evaluation suites, test cases, quality policies, and runs.
   """
 
   import Ecto.Query
 
   alias Aludel.Evals.{
     AssertionEvaluator,
+    QualityPolicy,
     Sampling,
     Suite,
+    SuitePolicy,
     SuiteRun,
     SuiteRunner,
     TestCase,
@@ -97,6 +99,60 @@ defmodule Aludel.Evals do
       test_cases: {test_cases_query, [:documents, source_dataset_entry: :dataset]},
       prompt: []
     )
+  end
+
+  @doc """
+  Lists immutable quality policy versions for a suite, newest first.
+  """
+  @spec list_suite_policies(Suite.t()) :: [SuitePolicy.t()]
+  def list_suite_policies(%Suite{id: suite_id}) do
+    SuitePolicy
+    |> where([policy], policy.suite_id == ^suite_id)
+    |> order_by([policy], desc: policy.version)
+    |> repo().all()
+  end
+
+  @doc """
+  Returns the latest quality policy for a suite, or `nil` when none exists.
+  """
+  @spec latest_suite_policy(Suite.t()) :: SuitePolicy.t() | nil
+  def latest_suite_policy(%Suite{id: suite_id}) do
+    SuitePolicy
+    |> where([policy], policy.suite_id == ^suite_id)
+    |> order_by([policy], desc: policy.version)
+    |> limit(1)
+    |> repo().one()
+  end
+
+  @doc """
+  Creates the next immutable quality policy version for a suite.
+
+  Version assignment locks the parent suite row so concurrent writers cannot
+  create the same suite-local version.
+  """
+  @spec create_suite_policy(Suite.t(), map()) ::
+          {:ok, SuitePolicy.t()} | {:error, Changeset.t()}
+  def create_suite_policy(%Suite{id: suite_id}, definition) when is_map(definition) do
+    repo().transaction(fn ->
+      lock_suite!(suite_id)
+      version = next_suite_policy_version(suite_id)
+
+      %SuitePolicy{}
+      |> SuitePolicy.changeset(%{
+        suite_id: suite_id,
+        version: version,
+        definition: definition
+      })
+      |> repo().insert()
+      |> case do
+        {:ok, policy} -> policy
+        {:error, changeset} -> repo().rollback(changeset)
+      end
+    end)
+    |> case do
+      {:ok, policy} -> {:ok, policy}
+      {:error, %Changeset{} = changeset} -> {:error, changeset}
+    end
   end
 
   @doc """
@@ -314,7 +370,7 @@ defmodule Aludel.Evals do
   def get_suite_run_for_export!(id) do
     SuiteRun
     |> repo().get!(id)
-    |> repo().preload([:suite, :prompt_version, :provider])
+    |> repo().preload([:suite, :suite_policy, :prompt_version, :provider])
   end
 
   @doc """
@@ -322,7 +378,7 @@ defmodule Aludel.Evals do
   """
   @spec reload_suite_run_with_associations(SuiteRun.t()) :: SuiteRun.t()
   def reload_suite_run_with_associations(%SuiteRun{} = suite_run) do
-    repo().preload(suite_run, [:prompt_version, :provider], force: true)
+    repo().preload(suite_run, [:suite_policy, :prompt_version, :provider], force: true)
   end
 
   @doc """
@@ -367,10 +423,14 @@ defmodule Aludel.Evals do
         |> merge_retry_metadata(existing_result)
 
       updated_results = replace_suite_run_result(suite_run.results, test_case_id, retried_result)
+      summary = summarize_suite_results(updated_results)
+      policy = suite_policy_for_run(suite_run)
 
       suite_run
       |> SuiteRun.changeset(
-        Map.put(summarize_suite_results(updated_results), :results, updated_results)
+        summary
+        |> Map.put(:results, updated_results)
+        |> Map.merge(quality_policy_attrs(policy, updated_results, summary))
       )
       |> repo().update()
     end
@@ -386,7 +446,9 @@ defmodule Aludel.Evals do
   Executes a test suite against a prompt version and provider.
 
   Runs all test cases for the suite, evaluating their assertions
-  against the LLM output and creating a suite_run with results.
+  against the LLM output and creating a suite run with results. When the suite
+  has a quality policy, execution snapshots the latest immutable version before
+  any model requests and persists its evaluation with the run.
 
   ## Parameters
     - suite: The test suite to execute
@@ -408,6 +470,7 @@ defmodule Aludel.Evals do
       ) do
     with {:ok, sampling} <- Sampling.new(opts) do
       suite = repo().preload(suite, test_cases: :documents)
+      policy = latest_suite_policy(suite)
 
       results =
         Enum.map(suite.test_cases, &execute_test_case(&1, version, provider, sampling))
@@ -415,12 +478,14 @@ defmodule Aludel.Evals do
       summary = summarize_suite_results(results)
 
       create_suite_run(
-        Map.merge(summary, %{
+        summary
+        |> Map.merge(%{
           suite_id: suite.id,
           prompt_version_id: version.id,
           provider_id: provider.id,
           results: results
         })
+        |> Map.merge(quality_policy_attrs(policy, results, summary))
       )
     end
   end
@@ -539,7 +604,7 @@ defmodule Aludel.Evals do
         artifacts = Artifact.put_metrics(result.artifacts, assertion_results, score)
 
         successful_test_case_result(
-          test_case.id,
+          test_case,
           result,
           passed,
           score,
@@ -548,7 +613,7 @@ defmodule Aludel.Evals do
         )
 
       {:error, reason, artifacts} ->
-        failed_test_case_result(test_case.id, reason, artifacts)
+        failed_test_case_result(test_case, reason, artifacts)
     end
   end
 
@@ -594,7 +659,7 @@ defmodule Aludel.Evals do
   end
 
   defp successful_test_case_result(
-         test_case_id,
+         test_case,
          result,
          passed,
          score,
@@ -602,7 +667,8 @@ defmodule Aludel.Evals do
          artifacts
        ) do
     %{
-      "test_case_id" => test_case_id,
+      "test_case_id" => test_case.id,
+      "test_case_metadata" => test_case.metadata,
       "passed" => passed,
       "score" => score,
       "output" => result.output,
@@ -616,9 +682,10 @@ defmodule Aludel.Evals do
     }
   end
 
-  defp failed_test_case_result(test_case_id, reason, artifacts) do
+  defp failed_test_case_result(test_case, reason, artifacts) do
     %{
-      "test_case_id" => test_case_id,
+      "test_case_id" => test_case.id,
+      "test_case_metadata" => test_case.metadata,
       "passed" => false,
       "score" => nil,
       "output" => error_message(reason),
@@ -711,6 +778,44 @@ defmodule Aludel.Evals do
     Enum.map(results, fn result ->
       if result["test_case_id"] == test_case_id, do: replacement, else: result
     end)
+  end
+
+  defp quality_policy_attrs(nil, _results, _summary) do
+    %{suite_policy_id: nil, quality_policy_result: nil}
+  end
+
+  defp quality_policy_attrs(%SuitePolicy{} = policy, results, summary) do
+    policy_result =
+      policy.definition
+      |> QualityPolicy.evaluate(results, summary)
+      |> Map.put("policy_id", policy.id)
+      |> Map.put("policy_version", policy.version)
+
+    %{suite_policy_id: policy.id, quality_policy_result: policy_result}
+  end
+
+  defp suite_policy_for_run(%SuiteRun{suite_policy_id: nil}) do
+    nil
+  end
+
+  defp suite_policy_for_run(%SuiteRun{suite_policy_id: policy_id}) do
+    repo().get(SuitePolicy, policy_id)
+  end
+
+  defp lock_suite!(suite_id) do
+    Suite
+    |> where([suite], suite.id == ^suite_id)
+    |> lock("FOR UPDATE")
+    |> repo().one!()
+  end
+
+  defp next_suite_policy_version(suite_id) do
+    SuitePolicy
+    |> where([policy], policy.suite_id == ^suite_id)
+    |> select([policy], max(policy.version))
+    |> repo().one()
+    |> Kernel.||(0)
+    |> Kernel.+(1)
   end
 
   defp summarize_suite_results(results) do

--- a/lib/aludel/evals/quality_policy.ex
+++ b/lib/aludel/evals/quality_policy.ex
@@ -1,0 +1,456 @@
+defmodule Aludel.Evals.QualityPolicy do
+  @moduledoc """
+  Validates and evaluates versioned suite quality policies.
+
+  Policies combine pass-rate, metadata-group, evaluator-score, cost, and
+  latency rules. Evaluation returns explicit `passed`, `failed`, `invalid`, or
+  `unavailable` status without conflating missing evidence with a quality
+  failure.
+  """
+
+  @schema_version 1
+  @max_rules 50
+  @max_definition_bytes 100_000
+  @rule_types [
+    "overall_pass_rate",
+    "metadata_pass_rate",
+    "evaluator_score",
+    "total_cost_usd",
+    "average_latency_ms"
+  ]
+
+  @type definition :: %{required(String.t()) => term()}
+  @type evaluation :: %{required(String.t()) => term()}
+
+  @doc """
+  Validates a version-one policy definition.
+
+  A policy must be JSON-compatible, cannot exceed #{@max_definition_bytes}
+  encoded bytes, and must contain between one and #{@max_rules} field-strict
+  rules with unique IDs. Pass rates use values from `0.0` through `1.0`,
+  evaluator scores use values from `0` through `100`, and budget maximums must
+  be non-negative.
+  """
+  @spec validate(term()) :: :ok | {:error, [String.t()]}
+  def validate(definition) do
+    errors = definition_errors(definition)
+
+    if errors == [] do
+      :ok
+    else
+      {:error, errors}
+    end
+  end
+
+  @doc """
+  Evaluates a policy against persisted test case results and suite aggregates.
+
+  Missing test cases, matching metadata groups, evaluator scores, cost, or
+  latency produce an `unavailable` rule instead of silently passing or failing.
+  Malformed definitions produce an `invalid` policy result.
+  """
+  @spec evaluate(term(), [map()], map()) :: evaluation()
+  def evaluate(definition, results, summary) when is_list(results) and is_map(summary) do
+    with :ok <- validate(definition),
+         true <- Enum.all?(results, &is_map/1) do
+      evaluate_rules(definition["rules"], results, summary)
+    else
+      {:error, errors} -> invalid_evaluation(errors)
+      false -> invalid_evaluation(["results must contain only maps"])
+    end
+  end
+
+  def evaluate(definition, _results, _summary) do
+    errors =
+      case validate(definition) do
+        :ok -> ["results must be a list and summary must be a map"]
+        {:error, definition_errors} -> definition_errors
+      end
+
+    invalid_evaluation(errors)
+  end
+
+  defp definition_errors(definition) when is_map(definition) do
+    encoding_errors = encoding_errors(definition)
+
+    field_errors =
+      if Map.keys(definition) -- ["schema_version", "rules"] == [] do
+        []
+      else
+        ["policy contains unsupported fields"]
+      end
+
+    schema_errors =
+      if definition["schema_version"] == @schema_version do
+        []
+      else
+        ["schema_version must be #{@schema_version}"]
+      end
+
+    rules = definition["rules"]
+
+    rules_errors =
+      if is_list(rules) and length(rules) in 1..@max_rules do
+        rules
+        |> Enum.with_index()
+        |> Enum.flat_map(fn {rule, index} -> rule_errors(rule, index) end)
+        |> Kernel.++(duplicate_id_errors(rules))
+      else
+        ["rules must contain between 1 and #{@max_rules} entries"]
+      end
+
+    encoding_errors ++ field_errors ++ schema_errors ++ rules_errors
+  end
+
+  defp definition_errors(_definition) do
+    ["policy must be a map"]
+  end
+
+  defp rule_errors(rule, index) when is_map(rule) do
+    rule_id_errors(rule, index) ++
+      rule_type_errors(rule, index) ++
+      rule_field_errors(rule, index) ++ rule_configuration_errors(rule, index)
+  end
+
+  defp rule_errors(_rule, index) do
+    ["rules[#{index}] must be a map"]
+  end
+
+  defp rule_id_errors(%{"id" => id}, index) when is_binary(id) and byte_size(id) <= 100 do
+    if String.trim(id) == "" do
+      ["rules[#{index}].id must be a non-empty string up to 100 bytes"]
+    else
+      []
+    end
+  end
+
+  defp rule_id_errors(_rule, index) do
+    ["rules[#{index}].id must be a non-empty string up to 100 bytes"]
+  end
+
+  defp rule_type_errors(%{"type" => type}, _index) when type in @rule_types do
+    []
+  end
+
+  defp rule_type_errors(_rule, index) do
+    ["rules[#{index}].type is not supported"]
+  end
+
+  defp rule_field_errors(%{"type" => type} = rule, index) when type in @rule_types do
+    allowed_fields =
+      case type do
+        "overall_pass_rate" -> ["id", "type", "minimum"]
+        "metadata_pass_rate" -> ["id", "type", "metadata", "minimum"]
+        "evaluator_score" -> ["id", "type", "metric", "minimum"]
+        _budget -> ["id", "type", "maximum"]
+      end
+
+    if Map.keys(rule) -- allowed_fields == [] do
+      []
+    else
+      ["rules[#{index}] contains unsupported fields"]
+    end
+  end
+
+  defp rule_field_errors(_rule, _index) do
+    []
+  end
+
+  defp rule_configuration_errors(%{"type" => "overall_pass_rate"} = rule, index) do
+    minimum_rate_errors(rule, index)
+  end
+
+  defp rule_configuration_errors(%{"type" => "metadata_pass_rate"} = rule, index) do
+    metadata_errors(rule, index) ++ minimum_rate_errors(rule, index)
+  end
+
+  defp rule_configuration_errors(%{"type" => "evaluator_score"} = rule, index) do
+    metric_errors(rule, index) ++ score_errors(rule, index)
+  end
+
+  defp rule_configuration_errors(%{"type" => type} = rule, index)
+       when type in ["total_cost_usd", "average_latency_ms"] do
+    maximum_errors(rule, index)
+  end
+
+  defp rule_configuration_errors(_rule, _index) do
+    []
+  end
+
+  defp minimum_rate_errors(%{"minimum" => minimum}, _index)
+       when is_number(minimum) and minimum >= 0 and minimum <= 1 do
+    []
+  end
+
+  defp minimum_rate_errors(_rule, index) do
+    ["rules[#{index}].minimum must be a number between 0 and 1"]
+  end
+
+  defp score_errors(%{"minimum" => minimum}, _index)
+       when is_number(minimum) and minimum >= 0 and minimum <= 100 do
+    []
+  end
+
+  defp score_errors(_rule, index) do
+    ["rules[#{index}].minimum must be a number between 0 and 100"]
+  end
+
+  defp maximum_errors(%{"maximum" => maximum}, _index)
+       when is_number(maximum) and maximum >= 0 do
+    []
+  end
+
+  defp maximum_errors(_rule, index) do
+    ["rules[#{index}].maximum must be a non-negative number"]
+  end
+
+  defp metadata_errors(%{"metadata" => metadata}, _index)
+       when is_map(metadata) and map_size(metadata) > 0 do
+    []
+  end
+
+  defp metadata_errors(_rule, index) do
+    ["rules[#{index}].metadata must be a non-empty map"]
+  end
+
+  defp metric_errors(%{"metric" => metric}, index)
+       when is_binary(metric) and byte_size(metric) <= 100 do
+    if String.trim(metric) == "" do
+      ["rules[#{index}].metric must be a non-empty string up to 100 bytes"]
+    else
+      []
+    end
+  end
+
+  defp metric_errors(_rule, index) do
+    ["rules[#{index}].metric must be a non-empty string up to 100 bytes"]
+  end
+
+  defp duplicate_id_errors(rules) do
+    duplicate? =
+      rules
+      |> Enum.map(fn
+        %{"id" => id} when is_binary(id) -> id
+        _rule -> nil
+      end)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.frequencies()
+      |> Enum.any?(fn {_id, count} -> count > 1 end)
+
+    if duplicate?, do: ["rule ids must be unique"], else: []
+  end
+
+  defp encoding_errors(definition) do
+    case Jason.encode(definition) do
+      {:ok, encoded} when byte_size(encoded) <= @max_definition_bytes ->
+        []
+
+      {:ok, _encoded} ->
+        ["policy cannot exceed #{@max_definition_bytes} encoded bytes"]
+
+      {:error, _reason} ->
+        ["policy must contain only JSON-compatible values"]
+    end
+  end
+
+  defp evaluate_rules(rules, results, summary) do
+    rule_results = Enum.map(rules, &evaluate_rule(&1, results, summary))
+    status = overall_status(rule_results)
+
+    %{
+      "schema_version" => @schema_version,
+      "status" => status,
+      "passed" => status == "passed",
+      "rules" => rule_results
+    }
+  end
+
+  defp evaluate_rule(%{"type" => "overall_pass_rate"} = rule, results, _summary) do
+    rate_rule(rule, results, "No test case results were available")
+  end
+
+  defp evaluate_rule(%{"type" => "metadata_pass_rate"} = rule, results, _summary) do
+    matching_results =
+      Enum.filter(results, fn result ->
+        metadata_matches?(result["test_case_metadata"], rule["metadata"])
+      end)
+
+    rate_rule(rule, matching_results, "No test cases matched the metadata group")
+  end
+
+  defp evaluate_rule(%{"type" => "evaluator_score"} = rule, results, _summary) do
+    scores = evaluator_scores(results, rule["metric"])
+
+    case average(scores) do
+      nil -> unavailable_rule(rule, "No completed evaluator scores were available")
+      actual -> minimum_rule(rule, actual, length(scores))
+    end
+  end
+
+  defp evaluate_rule(%{"type" => "total_cost_usd"} = rule, _results, summary) do
+    case normalize_number(summary_value(summary, :total_cost_usd)) do
+      nil -> unavailable_rule(rule, "Total cost was unavailable")
+      actual -> maximum_rule(rule, actual)
+    end
+  end
+
+  defp evaluate_rule(%{"type" => "average_latency_ms"} = rule, _results, summary) do
+    case normalize_number(summary_value(summary, :avg_latency_ms)) do
+      nil -> unavailable_rule(rule, "Average latency was unavailable")
+      actual -> maximum_rule(rule, actual)
+    end
+  end
+
+  defp rate_rule(rule, [], reason) do
+    unavailable_rule(rule, reason)
+  end
+
+  defp rate_rule(rule, results, _reason) do
+    passed = Enum.count(results, &(&1["passed"] == true))
+    actual = passed / length(results)
+    minimum_rule(rule, actual, length(results))
+  end
+
+  defp minimum_rule(rule, actual, sample_count) do
+    passed = actual >= rule["minimum"]
+
+    rule
+    |> Map.take(["id", "type", "minimum", "metadata", "metric"])
+    |> Map.merge(%{
+      "status" => status(passed),
+      "passed" => passed,
+      "actual" => displayed_actual(rule["type"], actual),
+      "sample_count" => sample_count
+    })
+  end
+
+  defp maximum_rule(rule, actual) do
+    passed = actual <= rule["maximum"]
+
+    rule
+    |> Map.take(["id", "type", "maximum"])
+    |> Map.merge(%{"status" => status(passed), "passed" => passed, "actual" => actual})
+  end
+
+  defp unavailable_rule(rule, reason) do
+    rule
+    |> Map.take(["id", "type", "minimum", "maximum", "metadata", "metric"])
+    |> Map.merge(%{
+      "status" => "unavailable",
+      "passed" => false,
+      "actual" => nil,
+      "sample_count" => 0,
+      "reason" => reason
+    })
+  end
+
+  defp evaluator_scores(results, metric) do
+    results
+    |> Enum.flat_map(&attempt_results/1)
+    |> Enum.flat_map(&assertion_results/1)
+    |> Enum.filter(&completed_metric?(&1, metric))
+    |> Enum.map(& &1["score"])
+    |> Enum.filter(&is_number/1)
+  end
+
+  defp attempt_results(%{"attempts" => attempts}) when is_list(attempts) and attempts != [] do
+    attempts
+  end
+
+  defp attempt_results(result) do
+    [result]
+  end
+
+  defp assertion_results(%{"assertion_results" => results}) when is_list(results) do
+    results
+  end
+
+  defp assertion_results(_result) do
+    []
+  end
+
+  defp completed_metric?(%{"type" => metric, "evaluator" => %{"status" => status}}, metric) do
+    status == "completed"
+  end
+
+  defp completed_metric?(%{"type" => metric, "evaluator" => nil}, metric) do
+    true
+  end
+
+  defp completed_metric?(%{"type" => metric} = result, metric) do
+    not Map.has_key?(result, "evaluator")
+  end
+
+  defp completed_metric?(_result, _metric) do
+    false
+  end
+
+  defp metadata_matches?(metadata, matcher) when is_map(metadata) and is_map(matcher) do
+    Enum.all?(matcher, fn {key, value} -> Map.get(metadata, key) == value end)
+  end
+
+  defp metadata_matches?(_metadata, _matcher) do
+    false
+  end
+
+  defp summary_value(summary, key) do
+    Map.get(summary, key, Map.get(summary, Atom.to_string(key)))
+  end
+
+  defp normalize_number(%Decimal{} = value) do
+    Decimal.to_float(value)
+  end
+
+  defp normalize_number(value) when is_number(value) do
+    value
+  end
+
+  defp normalize_number(_value) do
+    nil
+  end
+
+  defp average([]) do
+    nil
+  end
+
+  defp average(values) do
+    Enum.sum(values) / length(values)
+  end
+
+  defp displayed_actual(type, actual)
+       when type in ["overall_pass_rate", "metadata_pass_rate"] do
+    Float.round(actual, 4)
+  end
+
+  defp displayed_actual("evaluator_score", actual) do
+    Float.round(actual, 1)
+  end
+
+  defp overall_status(rule_results) do
+    statuses = Enum.map(rule_results, & &1["status"])
+
+    cond do
+      "unavailable" in statuses -> "unavailable"
+      "failed" in statuses -> "failed"
+      true -> "passed"
+    end
+  end
+
+  defp status(true) do
+    "passed"
+  end
+
+  defp status(false) do
+    "failed"
+  end
+
+  defp invalid_evaluation(errors) do
+    %{
+      "schema_version" => @schema_version,
+      "status" => "invalid",
+      "passed" => false,
+      "rules" => [],
+      "errors" => errors
+    }
+  end
+end

--- a/lib/aludel/evals/suite.ex
+++ b/lib/aludel/evals/suite.ex
@@ -9,7 +9,7 @@ defmodule Aludel.Evals.Suite do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Aludel.Evals.{SuiteRun, TestCase}
+  alias Aludel.Evals.{SuitePolicy, SuiteRun, TestCase}
   alias Aludel.Projects.Project
   alias Aludel.Prompts.Prompt
   alias Ecto.Changeset
@@ -28,6 +28,7 @@ defmodule Aludel.Evals.Suite do
     belongs_to(:project, Project)
     belongs_to(:prompt, Prompt)
     has_many(:test_cases, TestCase)
+    has_many(:quality_policies, SuitePolicy)
     has_many(:suite_runs, SuiteRun)
 
     timestamps(type: :utc_datetime)

--- a/lib/aludel/evals/suite_policy.ex
+++ b/lib/aludel/evals/suite_policy.ex
@@ -1,0 +1,57 @@
+defmodule Aludel.Evals.SuitePolicy do
+  @moduledoc """
+  Immutable version of a quality policy attached to an evaluation suite.
+
+  Creating a new policy produces the next suite-local version. Existing suite
+  runs keep their policy association so retries and exports use the same
+  evaluation contract that was active when the run started.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Aludel.Evals.QualityPolicy
+  alias Aludel.Evals.Suite
+  alias Aludel.Evals.SuiteRun
+  alias Ecto.Changeset
+
+  @type t :: %__MODULE__{}
+
+  @required_fields ~w(suite_id version definition)a
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  schema "suite_quality_policies" do
+    field :version, :integer
+    field :definition, :map
+
+    belongs_to :suite, Suite
+    has_many :suite_runs, SuiteRun
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc """
+  Builds a changeset for a versioned suite policy.
+  """
+  @spec changeset(t(), map()) :: Changeset.t()
+  def changeset(policy, attrs) do
+    policy
+    |> cast(attrs, @required_fields)
+    |> validate_required(@required_fields)
+    |> validate_number(:version, greater_than: 0)
+    |> validate_definition()
+    |> foreign_key_constraint(:suite_id)
+    |> unique_constraint([:suite_id, :version])
+  end
+
+  defp validate_definition(changeset) do
+    validate_change(changeset, :definition, fn :definition, definition ->
+      case QualityPolicy.validate(definition) do
+        :ok -> []
+        {:error, _errors} -> [definition: "is invalid"]
+      end
+    end)
+  end
+end

--- a/lib/aludel/evals/suite_run.ex
+++ b/lib/aludel/evals/suite_run.ex
@@ -4,13 +4,14 @@ defmodule Aludel.Evals.SuiteRun do
 
   Records the outcome of running a test suite against a specific
   prompt version and provider, storing individual test results and
-  summary counts.
+  summary counts. Runs with a quality policy retain the immutable policy
+  association and its evaluated rule evidence.
   """
 
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Aludel.Evals.Suite
+  alias Aludel.Evals.{Suite, SuitePolicy}
   alias Aludel.Prompts.PromptVersion
   alias Aludel.Providers.Provider
   alias Ecto.Changeset
@@ -29,6 +30,8 @@ defmodule Aludel.Evals.SuiteRun do
     cost_sample_count
     total_latency_ms
     latency_sample_count
+    suite_policy_id
+    quality_policy_result
   )a
 
   @primary_key {:id, :binary_id, autogenerate: true}
@@ -45,8 +48,10 @@ defmodule Aludel.Evals.SuiteRun do
     field :cost_sample_count, :integer, default: 0
     field :total_latency_ms, :integer
     field :latency_sample_count, :integer, default: 0
+    field :quality_policy_result, :map
 
     belongs_to(:suite, Suite)
+    belongs_to(:suite_policy, SuitePolicy)
     belongs_to(:prompt_version, PromptVersion)
     belongs_to(:provider, Provider)
 
@@ -64,5 +69,27 @@ defmodule Aludel.Evals.SuiteRun do
     suite_run
     |> cast(attrs, @required_fields ++ @optional_fields)
     |> validate_required(@required_fields)
+    |> validate_quality_policy_pair()
+    |> foreign_key_constraint(:suite_policy_id)
+  end
+
+  defp validate_quality_policy_pair(changeset) do
+    case {get_field(changeset, :suite_policy_id), get_field(changeset, :quality_policy_result)} do
+      {nil, nil} ->
+        changeset
+
+      {nil, _result} ->
+        add_error(
+          changeset,
+          :quality_policy_result,
+          "must be stored with its policy association"
+        )
+
+      {_policy_id, nil} ->
+        add_error(changeset, :suite_policy_id, "must be stored with its policy result")
+
+      {_policy_id, _result} ->
+        changeset
+    end
   end
 end

--- a/lib/aludel/web/export_controller.ex
+++ b/lib/aludel/web/export_controller.ex
@@ -6,6 +6,7 @@ defmodule Aludel.Web.ExportController do
   import Plug.Conn
 
   alias Aludel.Evals
+  alias Aludel.Evals.SuitePolicy
   alias Aludel.Prompts
   alias Aludel.Prompts.Evolution.Export, as: EvolutionExport
   alias Aludel.Runs
@@ -132,6 +133,7 @@ defmodule Aludel.Web.ExportController do
           prompt_id: suite_run.prompt_version.prompt_id
         },
         provider: serialize_provider(suite_run.provider),
+        quality_policy: serialize_quality_policy(suite_run),
         summary: %{
           passed: suite_run.passed,
           failed: suite_run.failed,
@@ -147,9 +149,23 @@ defmodule Aludel.Web.ExportController do
     }
   end
 
+  defp serialize_quality_policy(%{suite_policy: %SuitePolicy{} = suite_policy} = suite_run) do
+    %{
+      id: suite_policy.id,
+      version: suite_policy.version,
+      definition: suite_policy.definition,
+      result: suite_run.quality_policy_result
+    }
+  end
+
+  defp serialize_quality_policy(_suite_run) do
+    nil
+  end
+
   defp serialize_suite_result(result) do
     %{
       test_case_id: result["test_case_id"],
+      test_case_metadata: result["test_case_metadata"],
       status: if(result["passed"], do: "passed", else: "failed"),
       passed: result["passed"],
       score: result["score"],

--- a/lib/mix/tasks/aludel.eval.ex
+++ b/lib/mix/tasks/aludel.eval.ex
@@ -8,7 +8,8 @@ defmodule Mix.Tasks.Aludel.Eval do
         --provider-id PROVIDER_ID
 
   The task exits unsuccessfully when arguments or targets are invalid, execution
-  cannot complete, the suite has no test cases, or any test case fails.
+  cannot complete, or the active suite quality policy does not pass. Suites
+  without a quality policy retain the all-test-cases-must-pass behavior.
   """
 
   @shortdoc "Runs an Aludel suite and emits JSON"
@@ -114,7 +115,7 @@ defmodule Mix.Tasks.Aludel.Eval do
 
   defp suite_run_payload(suite_run) do
     total = suite_run.passed + suite_run.failed
-    status = if suite_run.failed == 0 and total > 0, do: "passed", else: "failed"
+    status = evaluation_status(suite_run, total)
 
     %{
       type: "aludel_eval",
@@ -124,6 +125,7 @@ defmodule Mix.Tasks.Aludel.Eval do
       suite_id: suite_run.suite_id,
       prompt_version_id: suite_run.prompt_version_id,
       provider_id: suite_run.provider_id,
+      quality_policy: suite_run.quality_policy_result,
       summary: %{
         passed: suite_run.passed,
         failed: suite_run.failed,
@@ -137,9 +139,19 @@ defmodule Mix.Tasks.Aludel.Eval do
     }
   end
 
+  defp evaluation_status(%{quality_policy_result: %{"status" => status}}, _total)
+       when status in ["passed", "failed", "invalid", "unavailable"] do
+    status
+  end
+
+  defp evaluation_status(suite_run, total) do
+    if suite_run.failed == 0 and total > 0, do: "passed", else: "failed"
+  end
+
   defp result_payload(result) do
     %{
       test_case_id: result["test_case_id"],
+      test_case_metadata: result["test_case_metadata"],
       status: if(result["passed"], do: "passed", else: "failed"),
       passed: result["passed"],
       score: result["score"],

--- a/priv/repo/migrations/20260904190000_create_suite_quality_policies.exs
+++ b/priv/repo/migrations/20260904190000_create_suite_quality_policies.exs
@@ -1,0 +1,23 @@
+defmodule Aludel.Repo.Migrations.CreateSuiteQualityPolicies do
+  use Ecto.Migration
+
+  def change do
+    create table(:suite_quality_policies, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :suite_id, references(:suites, type: :binary_id, on_delete: :delete_all), null: false
+      add :version, :integer, null: false
+      add :definition, :jsonb, null: false
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create unique_index(:suite_quality_policies, [:suite_id, :version])
+
+    alter table(:suite_runs) do
+      add :suite_policy_id,
+          references(:suite_quality_policies, type: :binary_id, on_delete: :nilify_all)
+
+      add :quality_policy_result, :jsonb
+    end
+  end
+end

--- a/priv/repo/migrations/20260904190100_index_suite_quality_policy_runs.exs
+++ b/priv/repo/migrations/20260904190100_index_suite_quality_policy_runs.exs
@@ -1,0 +1,10 @@
+defmodule Aludel.Repo.Migrations.IndexSuiteQualityPolicyRuns do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change do
+    create_if_not_exists index(:suite_runs, [:suite_policy_id], concurrently: true)
+  end
+end

--- a/test/aludel/evals/quality_policy_test.exs
+++ b/test/aludel/evals/quality_policy_test.exs
@@ -1,0 +1,281 @@
+defmodule Aludel.Evals.QualityPolicyTest do
+  use ExUnit.Case, async: true
+
+  alias Aludel.Evals.QualityPolicy
+
+  describe "evaluate/3" do
+    test "evaluates pass rate, metadata groups, metric scores, cost, and latency" do
+      policy = %{
+        "schema_version" => 1,
+        "rules" => [
+          %{"id" => "overall", "type" => "overall_pass_rate", "minimum" => 0.5},
+          %{
+            "id" => "priority",
+            "type" => "metadata_pass_rate",
+            "metadata" => %{"priority" => "high"},
+            "minimum" => 1.0
+          },
+          %{
+            "id" => "judge",
+            "type" => "evaluator_score",
+            "metric" => "rubric_judge",
+            "minimum" => 80
+          },
+          %{"id" => "cost", "type" => "total_cost_usd", "maximum" => 0.3},
+          %{"id" => "latency", "type" => "average_latency_ms", "maximum" => 150}
+        ]
+      }
+
+      results = [
+        result(true, %{"priority" => "high"}, 90.0),
+        result(false, %{"priority" => "low"}, 70.0)
+      ]
+
+      summary = %{total_cost_usd: Decimal.new("0.30"), avg_latency_ms: 150}
+
+      assert %{
+               "schema_version" => 1,
+               "status" => "passed",
+               "passed" => true,
+               "rules" => rules
+             } = QualityPolicy.evaluate(policy, results, summary)
+
+      assert Enum.map(rules, & &1["status"]) == List.duplicate("passed", 5)
+      assert rule(rules, "overall")["actual"] == 0.5
+      assert rule(rules, "overall")["sample_count"] == 2
+      assert rule(rules, "priority")["actual"] == 1.0
+      assert rule(rules, "priority")["sample_count"] == 1
+      assert rule(rules, "judge")["actual"] == 80.0
+      assert rule(rules, "judge")["sample_count"] == 2
+      assert rule(rules, "cost")["actual"] == 0.3
+      assert rule(rules, "latency")["actual"] == 150
+    end
+
+    test "reports failed rules without treating them as evaluator failures" do
+      policy = %{
+        "schema_version" => 1,
+        "rules" => [
+          %{"id" => "overall", "type" => "overall_pass_rate", "minimum" => 0.75}
+        ]
+      }
+
+      result = QualityPolicy.evaluate(policy, [result(true), result(false)], %{})
+
+      assert result["status"] == "failed"
+      refute result["passed"]
+      assert [rule] = result["rules"]
+      assert rule["status"] == "failed"
+      assert rule["actual"] == 0.5
+    end
+
+    test "uses unrounded values for threshold decisions" do
+      pass_rate_policy = %{
+        "schema_version" => 1,
+        "rules" => [
+          %{"id" => "rate", "type" => "overall_pass_rate", "minimum" => 0.6667}
+        ]
+      }
+
+      rate_result =
+        QualityPolicy.evaluate(
+          pass_rate_policy,
+          [result(true), result(true), result(false)],
+          %{}
+        )
+
+      assert rate_result["status"] == "failed"
+      assert hd(rate_result["rules"])["actual"] == 0.6667
+
+      score_policy = %{
+        "schema_version" => 1,
+        "rules" => [
+          %{
+            "id" => "score",
+            "type" => "evaluator_score",
+            "metric" => "rubric_judge",
+            "minimum" => 83.33
+          }
+        ]
+      }
+
+      score_result =
+        QualityPolicy.evaluate(
+          score_policy,
+          [result(true, %{}, 80.0), result(true, %{}, 86.68)],
+          %{}
+        )
+
+      assert score_result["status"] == "passed"
+      assert hd(score_result["rules"])["actual"] == 83.3
+    end
+
+    test "reports unavailable evidence explicitly" do
+      policy = %{
+        "schema_version" => 1,
+        "rules" => [
+          %{
+            "id" => "missing_group",
+            "type" => "metadata_pass_rate",
+            "metadata" => %{"priority" => "missing"},
+            "minimum" => 1.0
+          },
+          %{
+            "id" => "missing_metric",
+            "type" => "evaluator_score",
+            "metric" => "rubric_judge",
+            "minimum" => 80
+          },
+          %{"id" => "missing_cost", "type" => "total_cost_usd", "maximum" => 1.0},
+          %{
+            "id" => "missing_latency",
+            "type" => "average_latency_ms",
+            "maximum" => 1_000
+          }
+        ]
+      }
+
+      result = QualityPolicy.evaluate(policy, [result(true)], %{})
+
+      assert result["status"] == "unavailable"
+      refute result["passed"]
+      assert Enum.all?(result["rules"], &(&1["status"] == "unavailable"))
+      assert Enum.all?(result["rules"], &is_binary(&1["reason"]))
+    end
+
+    test "averages evaluator scores across every repeated attempt" do
+      policy = %{
+        "schema_version" => 1,
+        "rules" => [
+          %{
+            "id" => "judge",
+            "type" => "evaluator_score",
+            "metric" => "rubric_judge",
+            "minimum" => 80
+          }
+        ]
+      }
+
+      sampled_result = %{
+        "passed" => true,
+        "test_case_metadata" => %{},
+        "attempts" => [result(true, %{}, 70.0), result(true, %{}, 90.0)]
+      }
+
+      result = QualityPolicy.evaluate(policy, [sampled_result], %{})
+
+      assert result["status"] == "passed"
+      assert [rule] = result["rules"]
+      assert rule["actual"] == 80.0
+      assert rule["sample_count"] == 2
+    end
+
+    test "returns an invalid outcome for malformed definitions" do
+      policy = %{
+        "schema_version" => 1,
+        "rules" => [
+          %{"id" => "duplicate", "type" => "overall_pass_rate", "minimum" => 1.1},
+          %{"id" => "duplicate", "type" => "unknown"}
+        ]
+      }
+
+      assert %{
+               "schema_version" => 1,
+               "status" => "invalid",
+               "passed" => false,
+               "rules" => [],
+               "errors" => errors
+             } = QualityPolicy.evaluate(policy, [], %{})
+
+      assert length(errors) >= 3
+      assert Enum.all?(errors, &is_binary/1)
+    end
+
+    test "reports overall pass rate as unavailable for an empty result set" do
+      policy = %{
+        "schema_version" => 1,
+        "rules" => [
+          %{"id" => "overall", "type" => "overall_pass_rate", "minimum" => 1.0}
+        ]
+      }
+
+      result = QualityPolicy.evaluate(policy, [], %{})
+
+      assert result["status"] == "unavailable"
+      assert [rule] = result["rules"]
+      assert rule["reason"] == "No test case results were available"
+    end
+  end
+
+  describe "validate/1" do
+    test "accepts a bounded version-one policy" do
+      assert :ok =
+               QualityPolicy.validate(%{
+                 "schema_version" => 1,
+                 "rules" => [
+                   %{"id" => "overall", "type" => "overall_pass_rate", "minimum" => 0.9}
+                 ]
+               })
+    end
+
+    test "rejects unsupported schemas and empty rule sets" do
+      assert {:error, errors} =
+               QualityPolicy.validate(%{"schema_version" => 2, "rules" => []})
+
+      assert "schema_version must be 1" in errors
+      assert "rules must contain between 1 and 50 entries" in errors
+    end
+
+    test "rejects unknown fields and non-JSON policy data" do
+      assert {:error, unknown_errors} =
+               QualityPolicy.validate(%{
+                 "label" => "typo",
+                 "schema_version" => 1,
+                 "rules" => [
+                   %{
+                     "id" => "overall",
+                     "type" => "overall_pass_rate",
+                     "minimum" => 0.9,
+                     "mininum" => 0.8
+                   }
+                 ]
+               })
+
+      assert "rules[0] contains unsupported fields" in unknown_errors
+      assert "policy contains unsupported fields" in unknown_errors
+
+      assert {:error, json_errors} =
+               QualityPolicy.validate(%{
+                 "schema_version" => 1,
+                 "rules" => [
+                   %{
+                     "id" => "group",
+                     "type" => "metadata_pass_rate",
+                     "minimum" => 1.0,
+                     "metadata" => %{"owner" => self()}
+                   }
+                 ]
+               })
+
+      assert "policy must contain only JSON-compatible values" in json_errors
+    end
+  end
+
+  defp result(passed, metadata \\ %{}, score \\ nil) do
+    assertion_results =
+      if is_number(score) do
+        [%{"type" => "rubric_judge", "score" => score, "passed" => passed}]
+      else
+        []
+      end
+
+    %{
+      "passed" => passed,
+      "test_case_metadata" => metadata,
+      "assertion_results" => assertion_results
+    }
+  end
+
+  defp rule(rules, id) do
+    Enum.find(rules, &(&1["id"] == id))
+  end
+end

--- a/test/aludel/evals/suite_policy_test.exs
+++ b/test/aludel/evals/suite_policy_test.exs
@@ -1,0 +1,165 @@
+defmodule Aludel.Evals.SuitePolicyTest do
+  use Aludel.DataCase, async: true
+
+  import Mox
+
+  alias Aludel.Evals
+  alias Aludel.Interfaces.HttpClientMock
+  alias Aludel.Prompts
+
+  setup :verify_on_exit!
+
+  describe "create_suite_policy/2" do
+    test "creates immutable policy versions in suite order" do
+      suite = suite_fixture()
+
+      assert {:ok, first} = Evals.create_suite_policy(suite, pass_rate_policy(0.5))
+      assert first.suite_id == suite.id
+      assert first.version == 1
+
+      assert {:ok, second} = Evals.create_suite_policy(suite, pass_rate_policy(0.9))
+      assert second.version == 2
+
+      assert Enum.map(Evals.list_suite_policies(suite), & &1.version) == [2, 1]
+      assert Evals.latest_suite_policy(suite).id == second.id
+    end
+
+    test "rejects invalid policy definitions before persistence" do
+      suite = suite_fixture()
+
+      assert {:error, changeset} =
+               Evals.create_suite_policy(suite, %{"schema_version" => 2, "rules" => []})
+
+      assert "is invalid" in errors_on(changeset).definition
+      assert Evals.list_suite_policies(suite) == []
+    end
+  end
+
+  describe "suite execution" do
+    test "snapshots the latest policy and persists its evaluation" do
+      prompt = prompt_fixture()
+      {:ok, version} = Prompts.create_prompt_version(prompt, "Answer for {{name}}")
+      suite = suite_fixture(%{prompt_id: prompt.id})
+      provider = provider_fixture(%{model: "policy-model"})
+
+      passing_case =
+        test_case_fixture(%{
+          suite_id: suite.id,
+          variable_values: %{"name" => "pass"},
+          metadata: %{"priority" => "high"},
+          assertions: [%{"type" => "contains", "value" => "accepted"}]
+        })
+
+      failing_case =
+        test_case_fixture(%{
+          suite_id: suite.id,
+          variable_values: %{"name" => "fail"},
+          metadata: %{"priority" => "low"},
+          assertions: [%{"type" => "contains", "value" => "accepted"}]
+        })
+
+      expect(HttpClientMock, :request, 2, fn _model, rendered_prompt, _opts ->
+        output =
+          if rendered_prompt =~ "pass" do
+            "accepted"
+          else
+            "rejected"
+          end
+
+        {:ok, %{content: output, input_tokens: 10, output_tokens: 2}}
+      end)
+
+      definition = %{
+        "schema_version" => 1,
+        "rules" => [
+          %{"id" => "overall", "type" => "overall_pass_rate", "minimum" => 0.5},
+          %{
+            "id" => "priority",
+            "type" => "metadata_pass_rate",
+            "metadata" => %{"priority" => "high"},
+            "minimum" => 1.0
+          }
+        ]
+      }
+
+      assert {:ok, policy} = Evals.create_suite_policy(suite, definition)
+      assert {:ok, suite_run} = Evals.execute_suite(suite, version, provider)
+
+      assert suite_run.suite_policy_id == policy.id
+      assert suite_run.quality_policy_result["status"] == "passed"
+      assert suite_run.quality_policy_result["policy_version"] == 1
+      assert suite_run.quality_policy_result["policy_id"] == policy.id
+
+      results_by_id = Map.new(suite_run.results, &{&1["test_case_id"], &1})
+
+      assert results_by_id[passing_case.id]["test_case_metadata"] == %{"priority" => "high"}
+      assert results_by_id[failing_case.id]["test_case_metadata"] == %{"priority" => "low"}
+    end
+
+    test "retry evaluates the immutable policy snapshot instead of the latest policy" do
+      prompt = prompt_fixture()
+      {:ok, version} = Prompts.create_prompt_version(prompt, "Answer for {{name}}")
+      suite = suite_fixture(%{prompt_id: prompt.id})
+      provider = provider_fixture(%{model: "policy-retry-model"})
+
+      passing_case =
+        test_case_fixture(%{
+          suite_id: suite.id,
+          variable_values: %{"name" => "pass"},
+          assertions: [%{"type" => "contains", "value" => "accepted"}]
+        })
+
+      failing_case =
+        test_case_fixture(%{
+          suite_id: suite.id,
+          variable_values: %{"name" => "fail"},
+          assertions: [%{"type" => "contains", "value" => "accepted"}]
+        })
+
+      expect(HttpClientMock, :request, 2, fn _model, rendered_prompt, _opts ->
+        output = if rendered_prompt =~ "pass", do: "accepted", else: "rejected"
+        {:ok, %{content: output, input_tokens: 10, output_tokens: 2}}
+      end)
+
+      assert {:ok, first_policy} = Evals.create_suite_policy(suite, pass_rate_policy(0.5))
+      assert {:ok, suite_run} = Evals.execute_suite(suite, version, provider)
+      assert suite_run.quality_policy_result["status"] == "passed"
+
+      assert {:ok, latest_policy} = Evals.create_suite_policy(suite, pass_rate_policy(1.0))
+      assert latest_policy.version == 2
+
+      expect(HttpClientMock, :request, fn _model, _messages, _opts ->
+        {:ok, %{content: "rejected", input_tokens: 10, output_tokens: 2}}
+      end)
+
+      assert {:ok, retried_run} =
+               Evals.retry_suite_run_test_case(suite_run, failing_case.id)
+
+      assert retried_run.suite_policy_id == first_policy.id
+      assert retried_run.quality_policy_result["policy_version"] == 1
+      assert retried_run.quality_policy_result["status"] == "passed"
+      assert retried_run.quality_policy_result["rules"] |> hd() |> Map.fetch!("actual") == 0.5
+      assert Enum.any?(retried_run.results, &(&1["test_case_id"] == passing_case.id))
+    end
+
+    test "leaves legacy runs without a policy result" do
+      prompt = prompt_fixture()
+      {:ok, version} = Prompts.create_prompt_version(prompt, "Answer")
+      suite = suite_fixture(%{prompt_id: prompt.id})
+      provider = provider_fixture(%{model: "no-policy-model"})
+
+      assert {:ok, suite_run} = Evals.execute_suite(suite, version, provider)
+      assert is_nil(suite_run.suite_policy_id)
+      assert is_nil(suite_run.quality_policy_result)
+    end
+  end
+
+  defp pass_rate_policy(minimum) do
+    %{
+      "schema_version" => 1,
+      "rules" => [
+        %{"id" => "overall", "type" => "overall_pass_rate", "minimum" => minimum}
+      ]
+    }
+  end
+end

--- a/test/aludel/evals/suite_run_test.exs
+++ b/test/aludel/evals/suite_run_test.exs
@@ -124,5 +124,34 @@ defmodule Aludel.Evals.SuiteRunTest do
       assert changeset.valid?
       assert Ecto.Changeset.get_field(changeset, :failed) == 0
     end
+
+    test "requires a policy association and result to be stored together" do
+      suite = suite_fixture()
+      prompt = prompt_fixture()
+      {:ok, version} = Aludel.Prompts.create_prompt_version(prompt, "Template {{var}}")
+      provider = provider_fixture()
+
+      attrs = %{
+        suite_id: suite.id,
+        prompt_version_id: version.id,
+        provider_id: provider.id
+      }
+
+      missing_result =
+        SuiteRun.changeset(%SuiteRun{}, Map.put(attrs, :suite_policy_id, Ecto.UUID.generate()))
+
+      refute missing_result.valid?
+      assert "must be stored with its policy result" in errors_on(missing_result).suite_policy_id
+
+      missing_policy =
+        SuiteRun.changeset(
+          %SuiteRun{},
+          Map.put(attrs, :quality_policy_result, %{"passed" => true})
+        )
+
+      refute missing_policy.valid?
+
+      assert "must be stored with its policy association" in errors_on(missing_policy).quality_policy_result
+    end
   end
 end

--- a/test/aludel_web/export_controller_test.exs
+++ b/test/aludel_web/export_controller_test.exs
@@ -64,6 +64,23 @@ defmodule Aludel.Web.ExportControllerTest do
       provider = provider_fixture(%{name: "Suite Provider"})
       test_case = test_case_fixture(%{suite_id: suite.id})
 
+      {:ok, suite_policy} =
+        Aludel.Evals.create_suite_policy(suite, %{
+          "schema_version" => 1,
+          "rules" => [
+            %{"id" => "overall", "type" => "overall_pass_rate", "minimum" => 0.9}
+          ]
+        })
+
+      policy_result = %{
+        "schema_version" => 1,
+        "policy_id" => suite_policy.id,
+        "policy_version" => 1,
+        "status" => "passed",
+        "passed" => true,
+        "rules" => []
+      }
+
       suite_run =
         suite_run_fixture(%{
           suite_id: suite.id,
@@ -74,9 +91,12 @@ defmodule Aludel.Web.ExportControllerTest do
           avg_cost_usd: Decimal.new("0.0010"),
           avg_latency_ms: 250,
           avg_score: Decimal.new("75.0"),
+          suite_policy_id: suite_policy.id,
+          quality_policy_result: policy_result,
           results: [
             %{
               "test_case_id" => test_case.id,
+              "test_case_metadata" => %{"priority" => "high"},
               "passed" => true,
               "score" => 75.0,
               "output" => "Structured output",
@@ -150,6 +170,13 @@ defmodule Aludel.Web.ExportControllerTest do
       assert payload["suite_run"]["summary"]["avg_cost_usd"] == 0.001
       assert payload["suite_run"]["summary"]["avg_score"] == 75.0
 
+      assert payload["suite_run"]["quality_policy"] == %{
+               "id" => suite_policy.id,
+               "version" => 1,
+               "definition" => suite_policy.definition,
+               "result" => policy_result
+             }
+
       assert payload["suite_run"]["results"] == [
                %{
                  "assertion_results" => [
@@ -200,7 +227,8 @@ defmodule Aludel.Web.ExportControllerTest do
                  "retry_count" => 1,
                  "retried_at" => "2026-04-26T13:00:00Z",
                  "status" => "passed",
-                 "test_case_id" => test_case.id
+                 "test_case_id" => test_case.id,
+                 "test_case_metadata" => %{"priority" => "high"}
                }
              ]
     end

--- a/test/mix/tasks/aludel.eval_test.exs
+++ b/test/mix/tasks/aludel.eval_test.exs
@@ -7,6 +7,7 @@ defmodule Mix.Tasks.Aludel.EvalTest do
   import ExUnit.CaptureIO
   import Mox
 
+  alias Aludel.Evals
   alias Aludel.Interfaces.HttpClientMock
   alias Aludel.Prompts
   alias Mix.Tasks.Aludel.Eval, as: EvalTask
@@ -90,6 +91,75 @@ defmodule Mix.Tasks.Aludel.EvalTest do
     assert payload["summary"]["total"] == 0
     assert payload["summary"]["pass_rate"] == 0.0
     assert payload["results"] == []
+  end
+
+  test "uses a suite quality policy as the CI gate" do
+    %{suite: suite, prompt_version: prompt_version, provider: provider} = evaluation_targets()
+
+    assert {:ok, policy} =
+             Evals.create_suite_policy(suite, %{
+               "schema_version" => 1,
+               "rules" => [
+                 %{
+                   "id" => "overall",
+                   "type" => "overall_pass_rate",
+                   "minimum" => 0.0
+                 }
+               ]
+             })
+
+    expect(HttpClientMock, :request, fn _model, _prompt, _options ->
+      {:ok, %{content: "Goodbye", input_tokens: 4, output_tokens: 2}}
+    end)
+
+    output =
+      capture_io(fn ->
+        EvalTask.run(task_args(suite, prompt_version, provider))
+      end)
+
+    payload = Jason.decode!(output)
+
+    assert payload["status"] == "passed"
+    assert payload["summary"]["failed"] == 1
+    assert payload["quality_policy"]["policy_id"] == policy.id
+    assert payload["quality_policy"]["policy_version"] == 1
+    assert payload["quality_policy"]["status"] == "passed"
+  end
+
+  test "fails with an explicit unavailable policy status" do
+    %{suite: suite, prompt_version: prompt_version, provider: provider} = evaluation_targets()
+
+    assert {:ok, _policy} =
+             Evals.create_suite_policy(suite, %{
+               "schema_version" => 1,
+               "rules" => [
+                 %{
+                   "id" => "priority",
+                   "type" => "metadata_pass_rate",
+                   "metadata" => %{"priority" => "missing"},
+                   "minimum" => 1.0
+                 }
+               ]
+             })
+
+    expect(HttpClientMock, :request, fn _model, _prompt, _options ->
+      {:ok, %{content: "Hello Alice", input_tokens: 5, output_tokens: 3}}
+    end)
+
+    output =
+      capture_io(fn ->
+        assert_raise Mix.Error, "Evaluation did not pass", fn ->
+          EvalTask.run(task_args(suite, prompt_version, provider))
+        end
+      end)
+
+    payload = Jason.decode!(output)
+
+    assert payload["status"] == "unavailable"
+    assert payload["quality_policy"]["status"] == "unavailable"
+
+    assert payload["quality_policy"]["rules"] |> hd() |> Map.fetch!("reason") =~
+             "metadata"
   end
 
   test "emits a JSON error for missing required options" do

--- a/test/support/migrations/20260904190000_create_suite_quality_policies.exs
+++ b/test/support/migrations/20260904190000_create_suite_quality_policies.exs
@@ -1,0 +1,23 @@
+defmodule Aludel.Test.Repo.Migrations.CreateSuiteQualityPolicies do
+  use Ecto.Migration
+
+  def change do
+    create table(:suite_quality_policies, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :suite_id, references(:suites, type: :binary_id, on_delete: :delete_all), null: false
+      add :version, :integer, null: false
+      add :definition, :jsonb, null: false
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create unique_index(:suite_quality_policies, [:suite_id, :version])
+
+    alter table(:suite_runs) do
+      add :suite_policy_id,
+          references(:suite_quality_policies, type: :binary_id, on_delete: :nilify_all)
+
+      add :quality_policy_result, :jsonb
+    end
+  end
+end

--- a/test/support/migrations/20260904190100_index_suite_quality_policy_runs.exs
+++ b/test/support/migrations/20260904190100_index_suite_quality_policy_runs.exs
@@ -1,0 +1,10 @@
+defmodule Aludel.Test.Repo.Migrations.IndexSuiteQualityPolicyRuns do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change do
+    create_if_not_exists index(:suite_runs, [:suite_policy_id], concurrently: true)
+  end
+end


### PR DESCRIPTION
## Motivation

Evaluation suites currently either require every case to pass or need downstream tooling to reinterpret results. This adds immutable, versioned quality policies so teams can define explicit release criteria and obtain a stable decision from each run.

## Behavior

- Supports overall pass rate, metadata-scoped pass rate, evaluator score, total cost, and average latency rules.
- Produces `passed`, `failed`, `unavailable`, or `invalid` policy outcomes with per-rule details.
- Snapshots the latest policy before execution and reuses that exact revision when retrying a run.
- Exposes the policy revision and result through CLI JSON and suite-run exports.
- Preserves the existing all-cases-pass CLI behavior for suites without a policy.
- Validates strict JSON-compatible definitions with bounded rule counts and payload size.

```mermaid
flowchart LR
  A[Create policy revision] --> B[Snapshot revision before run]
  B --> C[Execute suite]
  C --> D[Evaluate policy rules]
  D --> E[Persist run and policy result]
  E -->|Retry| C
```

## Migration and compatibility

The migration adds a policy-revision table and nullable policy fields to suite runs. The index on the existing run table is created concurrently. Existing suites and historical runs remain valid without a policy.

## Test Plan

- Covers every rule type and each aggregate policy status.
- Covers strict validation, payload limits, unavailable metrics, repeated samples, and raw-value threshold precision.
- Covers policy version ordering, execution snapshots, retrying with the original revision, and legacy runs.
- Covers CLI exit behavior, JSON output, exports, schema invariants, compilation, static analysis, dependency audits, and documentation generation.

## Documentation

README and HexDocs guides now introduce versioned quality policies and link to a focused wiki guide with runnable examples for every rule type.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added immutable, versioned quality policies for evaluation suites.
  - Policies can assess pass rates, metadata groups, evaluator scores, cost, and latency.
  - Suite runs now record policy versions, results, rule details, and test-case metadata.
  - Evaluation exports and CI results include quality-policy outcomes.

- **Behavior**
  - CI gates use policy results when configured, while suites without policies retain existing behavior.
  - Retries continue using the policy snapshot captured by the original run.

- **Documentation**
  - Added guidance covering policy creation, supported rules, validation, versioning, statuses, and CI integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->