### PR TITLE
feat(ci): add evaluation reporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Aludel gives teams a clean way to evaluate prompt and model behavior without inv
 - Inspect output, latency, token usage, and cost side by side.
 - Compare prompt versions and see pass-rate, cost, and latency changes over time.
 - Run evaluation suites with deterministic assertions, model-based judges, repeated sampling, document attachments, and CSV or JSON test case imports.
-- Execute suites headlessly with machine-readable JSON output for CI workflows.
+- Execute suites headlessly with console, versioned JSON, JUnit XML, or GitHub annotation reports for CI workflows.
 - Route runs and suites through your app's real LLM workflow with callback execution.
 - Reuse single-turn and multi-turn datasets across suites with provenance and metadata filtering.
 - Find quality, cost, latency, stability, and regression trade-offs with rolling analytics and Pareto analysis.
@@ -44,7 +44,7 @@ Most teams evaluating LLM behavior end up with some combination of scripts, spre
 | Assertions | `contains`, `not_contains`, `regex`, `exact_match`, typed `json_field`, scored `json_deep_compare`, custom rubric judges, and seven versioned judge templates |
 | Imports and datasets | CSV and JSON import previews with row-level errors; reusable ordered datasets with variables, messages, assertions, metadata filters, provenance, and idempotent suite population |
 | Prompt evolution | Version and provider trends, version-over-version deltas, suite-scoped Pareto frontiers, failure-grounded prompt suggestions, and explicit accept or dismiss decisions |
-| Automation and exports | JSON run and suite exports, CSV or JSON evolution exports, and policy-aware `mix aludel.eval` quality gates with stable JSON output and CI-friendly exit status |
+| Automation and exports | JSON run and suite exports, CSV or JSON evolution exports, a custom reporter behavior, console reports, versioned JSON, JUnit XML, GitHub annotations, and policy-aware `mix aludel.eval` quality gates |
 | Execution and extension | Native provider calls, host-app callback execution, pluggable LLM, storage, and document-conversion boundaries, optional callback metadata, and configurable run concurrency |
 | Deployment | Embedded Phoenix dashboard, standalone app, Docker Compose, local/AWS S3/GCS document storage, custom auth/access resolvers, CSP nonce support, theming, and read-only mode |
 | Demo data | Deterministic prompts, providers, datasets, suites, runs, failures, artifacts, and 60 days of comparison history through `mix aludel.seed` |
@@ -141,6 +141,25 @@ Policies can gate overall pass rate, metadata groups, evaluator scores, total co
 Policy results report `passed`, `failed`, `invalid`, or `unavailable`; missing evidence never silently passes. `mix aludel.eval` uses the policy outcome as its exit gate and preserves the legacy all-cases-must-pass behavior for suites without a policy.
 
 See the [evaluation guide](https://hexdocs.pm/aludel/evaluations.html#enforce-a-versioned-quality-policy) and [quality policies wiki guide](https://github.com/ccarvalho-eng/aludel/wiki/Quality-Policies) for every rule and result example.
+
+## Evaluation Reporters
+
+Render the same persisted suite result for local review, API consumers, and CI systems without coupling those formats to persistence:
+
+```elixir
+alias Aludel.Evals.Reporter
+
+console = Reporter.render!(suite_run, :console)
+json = Reporter.render!(suite_run, :json, pretty: true)
+junit_xml = Reporter.render!(suite_run, :junit)
+github_annotations = Reporter.render!(suite_run, :github)
+```
+
+`Aludel.Evals.Report` defines the stable schema-version-2 model. Built-in reporters cover concise console text, JSON interchange, JUnit test reports, and GitHub Actions annotations. Custom modules can implement the `Aludel.Evals.Reporter` behavior.
+
+The GitHub reporter escapes and bounds untrusted evaluator text before emitting workflow commands. JUnit output escapes identifiers and reasons, omits model output by default, and represents a policy-only rejection as a failed test case. Pass `include_output: true` or `--include-output` only when the target artifact is appropriate for generated responses.
+
+See the [reporter guide](https://hexdocs.pm/aludel/reporters.html) and [evaluation reporters wiki guide](https://github.com/ccarvalho-eng/aludel/wiki/Evaluation-Reporters) for CLI, library, CI, and custom reporter examples.
 
 ## Test Case Imports
 
@@ -285,7 +304,7 @@ Set `run_execution_mode: :sequential` when provider calls must not overlap.
 
 ### Headless suite execution
 
-Run a suite from scripts or CI with stable JSON output:
+Run a suite from scripts or CI. JSON schema version 2 is the default:
 
 ```bash
 mix aludel.eval \
@@ -294,9 +313,20 @@ mix aludel.eval \
   --provider-id PROVIDER_ID
 ```
 
-The task exits unsuccessfully when its arguments or targets are invalid, execution cannot complete, the suite has no test cases, or any test case fails.
+Select another reporter and optionally write it directly to a file:
 
-Successful and failed executions emit a stable `aludel_eval` JSON envelope with a schema version, suite and provider identifiers, aggregate pass/fail, score, cost and latency data, plus individual assertion results.
+```bash
+mix aludel.eval \
+  --suite-id SUITE_ID \
+  --prompt-version-id PROMPT_VERSION_ID \
+  --provider-id PROVIDER_ID \
+  --format junit \
+  --output aludel-junit.xml
+```
+
+Supported formats are `console`, `json`, `junit`, and `github`; `--pretty` formats JSON for human review, while `--include-output` opts JUnit into generated responses. The task exits unsuccessfully when its arguments or targets are invalid, execution cannot complete, the suite is empty, or the active quality gate does not pass.
+
+The versioned `aludel_eval` JSON envelope includes suite and provider identifiers, aggregate and total score/cost/latency data, quality-policy evidence, and individual assertion results.
 
 ### Standalone mode
 
@@ -434,6 +464,7 @@ The README is intentionally optimized for first contact. For deeper setup, usage
 
 - [Feature Guide](https://hexdocs.pm/aludel/features.html)
 - [Evaluation Guide](https://hexdocs.pm/aludel/evaluations.html)
+- [Reporter Guide](https://hexdocs.pm/aludel/reporters.html)
 - [Embedding Guide](https://hexdocs.pm/aludel/embedding.html)
 - [Wiki](https://github.com/ccarvalho-eng/aludel/wiki)
 - [HexDocs](https://hexdocs.pm/aludel)

--- a/guides/evaluations.md
+++ b/guides/evaluations.md
@@ -291,12 +291,12 @@ mix aludel.eval \
   --provider-id PROVIDER_ID
 ```
 
-The command emits one JSON object:
+The command emits one schema-version-2 JSON object by default:
 
 ```json
 {
   "type": "aludel_eval",
-  "schema_version": 1,
+  "schema_version": 2,
   "status": "passed",
   "suite_id": "SUITE_ID",
   "prompt_version_id": "PROMPT_VERSION_ID",
@@ -311,4 +311,6 @@ The command emits one JSON object:
 }
 ```
 
-The task exits unsuccessfully when arguments or targets are invalid, the prompt version belongs to another prompt, execution cannot be persisted, the suite is empty, or any test case fails.
+The task exits unsuccessfully when arguments or targets are invalid, the prompt version belongs to another prompt, execution cannot be persisted, the suite is empty, or the active quality gate does not pass.
+
+Choose `--format console`, `--format junit`, or `--format github` for a human-readable log, CI test report, or GitHub Actions annotations. Add `--output PATH` to write the report to a file, `--pretty` to pretty-print JSON, or JUnit-only `--include-output` when the artifact is appropriate for generated responses. See the [reporter guide](reporters.html) for complete examples and the custom reporter behavior.

--- a/guides/features.md
+++ b/guides/features.md
@@ -124,9 +124,12 @@ Aludel provides:
 - JSON exports for individual run results
 - JSON exports for suite runs, including assertions, retries, callback metadata, and artifacts
 - JSON and CSV exports for prompt evolution metrics and provider breakdowns
-- `mix aludel.eval` for headless suite execution
+- `Aludel.Evals.Reporter` with console, schema-version-2 JSON, JUnit XML, GitHub annotation, and custom reporter support
+- `mix aludel.eval` for headless suite execution and optional report file output
 
-The Mix task emits a versioned `aludel_eval` JSON envelope and exits unsuccessfully for invalid targets, execution errors, empty suites, or failed test cases. This makes the task suitable for CI quality gates.
+The Mix task emits JSON by default and accepts `--format console|json|junit|github`, `--output PATH`, JSON-only `--pretty`, and JUnit-only `--include-output`. It exits unsuccessfully for invalid targets, execution errors, empty suites, or a non-passing active quality gate. The normalized report model keeps each output format independent from suite-run persistence.
+
+See the [reporter guide](reporters.html) for output examples, CI configuration, and custom reporter modules.
 
 ## Execution modes
 

--- a/guides/reporters.md
+++ b/guides/reporters.md
@@ -1,0 +1,145 @@
+# Evaluation Reporters
+
+Aludel turns every persisted suite run into one normalized report before formatting it. This gives local tools and CI systems the same status, identifiers, summaries, quality-policy evidence, and case results without tying an output format to the database schema.
+
+## Render reports in Elixir
+
+Pass a persisted `Aludel.Evals.SuiteRun` or an existing `Aludel.Evals.Report` to `Aludel.Evals.Reporter`:
+
+```elixir
+alias Aludel.Evals.Reporter
+
+{:ok, console} = Reporter.render(suite_run, :console)
+{:ok, json} = Reporter.render(suite_run, :json, pretty: true)
+{:ok, junit_xml} = Reporter.render(suite_run, :junit)
+{:ok, annotations} = Reporter.render(suite_run, :github)
+```
+
+Use `render!/3` when an unsupported reporter or invalid custom result should raise `ArgumentError`.
+
+## Console
+
+The console reporter prints a compact, ANSI-free summary with one line per test case and policy-rule evidence when present:
+
+```text
+Aludel evaluation FAILED
+Suite run: 017f...
+Summary: 2 passed, 1 failed, 66.67% pass rate
+Averages: score=86.7, cost=0.0041 USD, latency=428 ms
+[PASS] test case 018a...
+[FAIL] test case 018b...
+Policy: failed
+  [FAILED] priority: Pass rate was below the configured minimum
+```
+
+Generated model output is omitted from console text so routine logs remain concise.
+
+## JSON schema version 2
+
+The JSON reporter serializes `Aludel.Evals.Report.to_map/1`. Its top-level contract is:
+
+```json
+{
+  "type": "aludel_eval",
+  "schema_version": 2,
+  "status": "passed",
+  "suite_run_id": "RUN_ID",
+  "suite_id": "SUITE_ID",
+  "prompt_version_id": "PROMPT_VERSION_ID",
+  "provider_id": "PROVIDER_ID",
+  "quality_policy": null,
+  "summary": {
+    "passed": 2,
+    "failed": 0,
+    "total": 2,
+    "pass_rate": 100.0,
+    "avg_score": "100.0",
+    "avg_cost_usd": "0.0025",
+    "avg_latency_ms": 320,
+    "total_cost_usd": "0.005",
+    "cost_sample_count": 2,
+    "total_latency_ms": 640,
+    "latency_sample_count": 2
+  },
+  "results": []
+}
+```
+
+Decimal values remain decimal strings, preventing an interchange consumer from silently losing precision. JSON object key order is not part of the contract.
+
+## JUnit XML
+
+The JUnit reporter maps each evaluation case to `<testcase>` and failed assertions to `<failure>`. Generated output is omitted by default. A quality policy that rejects otherwise passing cases becomes an additional failed `quality-policy` case. An empty run becomes a failed `evaluation` case. These synthetic cases keep CI test viewers from reporting a false success.
+
+```elixir
+xml = Reporter.render!(suite_run, :junit)
+File.write!("aludel-junit.xml", xml)
+```
+
+Identifiers and failure reasons are escaped as XML text. XML 1.0 control characters are removed. Add `include_output: true` to `Reporter.render!/3`, or `--include-output` to the Mix task, only when the destination artifact is appropriate for generated responses; enabled output is escaped inside `<system-out>`.
+
+## GitHub Actions annotations
+
+The GitHub reporter emits an error annotation for each failed case and non-passing policy rule. A passing report emits one notice:
+
+```yaml
+- name: Run LLM evaluation gate
+  run: >-
+    mix aludel.eval
+    --suite-id "$SUITE_ID"
+    --prompt-version-id "$PROMPT_VERSION_ID"
+    --provider-id "$PROVIDER_ID"
+    --format github
+```
+
+Annotation titles and messages escape workflow-command control characters. Messages are bounded before rendering so evaluator output cannot inject a second command or create an unbounded annotation.
+
+## Mix task output
+
+JSON is the default format:
+
+```bash
+mix aludel.eval \
+  --suite-id SUITE_ID \
+  --prompt-version-id PROMPT_VERSION_ID \
+  --provider-id PROVIDER_ID \
+  --pretty
+```
+
+Write JUnit XML to a CI artifact path:
+
+```bash
+mix aludel.eval \
+  --suite-id SUITE_ID \
+  --prompt-version-id PROMPT_VERSION_ID \
+  --provider-id PROVIDER_ID \
+  --format junit \
+  --output aludel-junit.xml
+```
+
+The task writes the report before returning a nonzero exit for a failed, unavailable, or invalid quality decision. Argument and execution errors remain machine-readable JSON error envelopes.
+
+## Custom reporters
+
+A custom reporter receives the normalized report and keyword options, then returns `{:ok, iodata}` or `{:error, reason}`:
+
+```elixir
+defmodule MyApp.MarkdownReporter do
+  @behaviour Aludel.Evals.Reporter
+
+  alias Aludel.Evals.Report
+
+  @impl true
+  def render(%Report{} = report, _options) do
+    {:ok, ["# Evaluation ", String.upcase(report.status), "\n"]}
+  end
+end
+
+markdown =
+  Aludel.Evals.Reporter.render!(
+    suite_run,
+    MyApp.MarkdownReporter
+  )
+```
+
+Custom reporters should treat case output, assertion reasons, metadata, and identifiers as untrusted data and escape them for their target format.

--- a/lib/aludel/evals/report.ex
+++ b/lib/aludel/evals/report.ex
@@ -1,0 +1,147 @@
+defmodule Aludel.Evals.Report do
+  @moduledoc """
+  A normalized, versioned representation of an evaluation suite run.
+
+  Reporters consume this struct instead of reading persistence schemas directly.
+  This keeps output formats stable while the database representation evolves.
+  Use `from_suite_run/1` to create a report and `to_map/1` when a plain map is
+  needed for serialization.
+  """
+
+  alias Aludel.Evals.SuiteRun
+  alias Decimal
+
+  @schema_version 2
+  @statuses ~w(passed failed invalid unavailable)
+
+  @typedoc "The final quality decision: passed, failed, invalid, or unavailable."
+  @type status :: String.t()
+  @type t :: %__MODULE__{
+          type: String.t(),
+          schema_version: pos_integer(),
+          status: status(),
+          suite_run_id: binary(),
+          suite_id: binary(),
+          prompt_version_id: binary(),
+          provider_id: binary(),
+          quality_policy: map() | nil,
+          summary: map(),
+          results: [map()]
+        }
+
+  @enforce_keys [
+    :status,
+    :suite_run_id,
+    :suite_id,
+    :prompt_version_id,
+    :provider_id,
+    :summary,
+    :results
+  ]
+  defstruct type: "aludel_eval",
+            schema_version: @schema_version,
+            status: nil,
+            suite_run_id: nil,
+            suite_id: nil,
+            prompt_version_id: nil,
+            provider_id: nil,
+            quality_policy: nil,
+            summary: nil,
+            results: nil
+
+  @doc """
+  Builds a schema-version-2 report from a persisted suite run.
+
+  A quality-policy result determines the report status when present. Runs
+  without a policy pass only when they contain at least one result and every
+  result passed.
+  """
+  @spec from_suite_run(SuiteRun.t()) :: t()
+  def from_suite_run(%SuiteRun{} = suite_run) do
+    total = suite_run.passed + suite_run.failed
+
+    %__MODULE__{
+      status: evaluation_status(suite_run, total),
+      suite_run_id: suite_run.id,
+      suite_id: suite_run.suite_id,
+      prompt_version_id: suite_run.prompt_version_id,
+      provider_id: suite_run.provider_id,
+      quality_policy: suite_run.quality_policy_result,
+      summary: %{
+        "passed" => suite_run.passed,
+        "failed" => suite_run.failed,
+        "total" => total,
+        "pass_rate" => pass_rate(suite_run.passed, total),
+        "avg_score" => decimal_to_string(suite_run.avg_score),
+        "avg_cost_usd" => decimal_to_string(suite_run.avg_cost_usd),
+        "avg_latency_ms" => suite_run.avg_latency_ms,
+        "total_cost_usd" => decimal_to_string(suite_run.total_cost_usd),
+        "cost_sample_count" => suite_run.cost_sample_count,
+        "total_latency_ms" => suite_run.total_latency_ms,
+        "latency_sample_count" => suite_run.latency_sample_count
+      },
+      results: Enum.map(suite_run.results, &normalize_result/1)
+    }
+  end
+
+  @doc "Returns the report as a JSON-compatible map with string keys."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = report) do
+    %{
+      "type" => report.type,
+      "schema_version" => report.schema_version,
+      "status" => report.status,
+      "suite_run_id" => report.suite_run_id,
+      "suite_id" => report.suite_id,
+      "prompt_version_id" => report.prompt_version_id,
+      "provider_id" => report.provider_id,
+      "quality_policy" => report.quality_policy,
+      "summary" => report.summary,
+      "results" => report.results
+    }
+  end
+
+  defp evaluation_status(
+         %{quality_policy_result: %{"status" => status}},
+         _total
+       )
+       when status in @statuses do
+    status
+  end
+
+  defp evaluation_status(suite_run, total) do
+    if suite_run.failed == 0 and total > 0, do: "passed", else: "failed"
+  end
+
+  defp normalize_result(result) do
+    %{
+      "test_case_id" => result["test_case_id"],
+      "test_case_metadata" => result["test_case_metadata"],
+      "status" => if(result["passed"], do: "passed", else: "failed"),
+      "passed" => result["passed"],
+      "score" => result["score"],
+      "output" => result["output"],
+      "assertion_results" => Map.get(result, "assertion_results", []),
+      "input_tokens" => result["input_tokens"],
+      "output_tokens" => result["output_tokens"],
+      "cost_usd" => result["cost_usd"],
+      "latency_ms" => result["latency_ms"]
+    }
+  end
+
+  defp pass_rate(_passed, 0) do
+    0.0
+  end
+
+  defp pass_rate(passed, total) do
+    Float.round(passed / total * 100, 2)
+  end
+
+  defp decimal_to_string(nil) do
+    nil
+  end
+
+  defp decimal_to_string(%Decimal{} = decimal) do
+    Decimal.to_string(decimal, :normal)
+  end
+end

--- a/lib/aludel/evals/reporter.ex
+++ b/lib/aludel/evals/reporter.ex
@@ -1,0 +1,95 @@
+defmodule Aludel.Evals.Reporter do
+  @moduledoc """
+  Renders evaluation reports for people and CI systems.
+
+  The built-in reporter names are `:console`, `:json`, `:junit`, and
+  `:github`. A custom module can also be passed directly when it implements
+  this module's callback.
+
+      {:ok, output} = Aludel.Evals.Reporter.render(suite_run, :junit)
+
+  Reporter options are passed to the selected implementation. The JSON
+  reporter, for example, accepts `pretty: true`.
+  """
+
+  alias Aludel.Evals.Report
+  alias Aludel.Evals.Reporters.{Console, GitHub, JSON, JUnit}
+  alias Aludel.Evals.SuiteRun
+
+  @typedoc "A built-in reporter name or a custom reporter module."
+  @type reporter :: :console | :json | :junit | :github | module()
+
+  @typedoc "A stable error returned before or while rendering a report."
+  @type error :: :unknown_reporter | :invalid_reporter_output
+
+  @callback render(Report.t(), keyword()) :: {:ok, iodata()} | {:error, term()}
+
+  @reporters %{
+    console: Console,
+    github: GitHub,
+    json: JSON,
+    junit: JUnit
+  }
+
+  @doc "Renders a suite run with a built-in or custom reporter."
+  @spec render(SuiteRun.t() | Report.t(), reporter(), keyword()) ::
+          {:ok, String.t()} | {:error, error() | term()}
+  def render(suite_run_or_report, reporter, options \\ [])
+
+  def render(%SuiteRun{} = suite_run, reporter, options) do
+    suite_run
+    |> Report.from_suite_run()
+    |> render(reporter, options)
+  end
+
+  def render(%Report{} = report, reporter, options) do
+    with {:ok, reporter_module} <- resolve_reporter(reporter) do
+      render_with(reporter_module, report, options)
+    end
+  end
+
+  @doc "Renders a report and raises `ArgumentError` when rendering fails."
+  @spec render!(SuiteRun.t() | Report.t(), reporter(), keyword()) :: String.t()
+  def render!(suite_run_or_report, reporter, options \\ []) do
+    case render(suite_run_or_report, reporter, options) do
+      {:ok, output} ->
+        output
+
+      {:error, reason} ->
+        raise ArgumentError, "could not render evaluation report: #{inspect(reason)}"
+    end
+  end
+
+  defp resolve_reporter(reporter) when is_atom(reporter) do
+    case Map.fetch(@reporters, reporter) do
+      {:ok, reporter_module} -> {:ok, reporter_module}
+      :error -> resolve_custom_reporter(reporter)
+    end
+  end
+
+  defp resolve_reporter(_reporter) do
+    {:error, :unknown_reporter}
+  end
+
+  defp resolve_custom_reporter(reporter) do
+    if Code.ensure_loaded?(reporter) and function_exported?(reporter, :render, 2) do
+      {:ok, reporter}
+    else
+      {:error, :unknown_reporter}
+    end
+  end
+
+  defp render_with(reporter_module, report, options) do
+    case reporter_module.render(report, options) do
+      {:ok, rendered} -> to_binary(rendered)
+      {:error, reason} -> {:error, reason}
+      _invalid -> {:error, :invalid_reporter_output}
+    end
+  end
+
+  defp to_binary(rendered) do
+    {:ok, IO.iodata_to_binary(rendered)}
+  rescue
+    ArgumentError -> {:error, :invalid_reporter_output}
+  end
+end

--- a/lib/aludel/evals/reporters/console.ex
+++ b/lib/aludel/evals/reporters/console.ex
@@ -1,0 +1,92 @@
+defmodule Aludel.Evals.Reporters.Console do
+  @moduledoc """
+  Renders a concise, plain-text evaluation summary.
+
+  The output contains no ANSI sequences, which keeps it readable in local
+  terminals and portable across CI log collectors.
+  """
+
+  @behaviour Aludel.Evals.Reporter
+
+  alias Aludel.Evals.Report
+
+  @impl true
+  def render(%Report{} = report, _options) do
+    lines = [
+      "Aludel evaluation #{String.upcase(report.status)}",
+      "Suite run: #{report.suite_run_id}",
+      summary_line(report.summary),
+      metric_line(report.summary),
+      result_lines(report.results),
+      policy_lines(report.quality_policy)
+    ]
+
+    {:ok, lines |> List.flatten() |> Enum.reject(&is_nil/1) |> Enum.join("\n")}
+  end
+
+  defp summary_line(summary) do
+    "Summary: #{summary["passed"]} passed, #{summary["failed"]} failed, " <>
+      "#{summary["pass_rate"]}% pass rate"
+  end
+
+  defp metric_line(summary) do
+    metrics =
+      [
+        optional_metric("score", summary["avg_score"]),
+        optional_metric("cost", summary["avg_cost_usd"], " USD"),
+        optional_metric("latency", summary["avg_latency_ms"], " ms")
+      ]
+      |> Enum.reject(&is_nil/1)
+
+    if metrics == [], do: nil, else: "Averages: #{Enum.join(metrics, ", ")}"
+  end
+
+  defp optional_metric(name, value, suffix \\ "")
+
+  defp optional_metric(_name, nil, _suffix) do
+    nil
+  end
+
+  defp optional_metric(name, value, suffix) do
+    "#{name}=#{value}#{suffix}"
+  end
+
+  defp result_lines(results) do
+    Enum.map(results, fn result ->
+      marker = if result["passed"], do: "PASS", else: "FAIL"
+      "[#{marker}] test case #{display_id(result["test_case_id"])}"
+    end)
+  end
+
+  defp policy_lines(nil) do
+    []
+  end
+
+  defp policy_lines(policy) do
+    ["Policy: #{policy["status"]}" | Enum.map(policy["rules"] || [], &policy_rule_line/1)]
+  end
+
+  defp policy_rule_line(rule) do
+    "  [#{String.upcase(to_string(rule["status"]))}] #{display_id(rule["id"])}: " <>
+      display_text(rule["reason"])
+  end
+
+  defp display_id(nil) do
+    "unknown"
+  end
+
+  defp display_id(value) do
+    display_text(value)
+  end
+
+  defp display_text(nil) do
+    ""
+  end
+
+  defp display_text(value) do
+    value
+    |> to_string()
+    |> String.replace(~r/[\x00-\x1F\x7F]/u, " ")
+    |> String.trim()
+  end
+end

--- a/lib/aludel/evals/reporters/github.ex
+++ b/lib/aludel/evals/reporters/github.ex
@@ -1,0 +1,103 @@
+defmodule Aludel.Evals.Reporters.GitHub do
+  @moduledoc """
+  Renders GitHub Actions workflow-command annotations.
+
+  Failed test cases and non-passing policy rules become error annotations. A
+  passing run emits one notice. Untrusted result text is escaped and bounded so
+  it cannot create additional workflow commands or unbounded log records.
+  """
+
+  @behaviour Aludel.Evals.Reporter
+
+  alias Aludel.Evals.Report
+
+  @max_message_characters 4_096
+
+  @impl true
+  def render(%Report{status: "passed"} = report, _options) do
+    {:ok,
+     annotation(
+       "notice",
+       "Aludel evaluation",
+       "Suite run #{report.suite_run_id} passed"
+     )}
+  end
+
+  def render(%Report{} = report, _options) do
+    annotations =
+      report.results
+      |> Enum.reject(& &1["passed"])
+      |> Enum.map(&failed_test_annotation/1)
+      |> Kernel.++(policy_annotations(report.quality_policy))
+      |> ensure_failure_annotation(report)
+
+    {:ok, Enum.intersperse(annotations, "\n")}
+  end
+
+  defp failed_test_annotation(result) do
+    reasons =
+      result
+      |> Map.get("assertion_results", [])
+      |> Enum.reject(& &1["passed"])
+      |> Enum.map_join("; ", &(&1["reason"] || "Assertion failed"))
+
+    message = if reasons == "", do: "Evaluation failed", else: reasons
+    annotation("error", "Test case #{result["test_case_id"] || "unknown"}", message)
+  end
+
+  defp policy_annotations(nil) do
+    []
+  end
+
+  defp policy_annotations(policy) do
+    policy
+    |> Map.get("rules", [])
+    |> Enum.reject(&(&1["status"] == "passed"))
+    |> Enum.map(fn rule ->
+      annotation(
+        "error",
+        "Quality policy #{rule["id"] || "rule"}",
+        rule["reason"] || "Quality policy rule did not pass"
+      )
+    end)
+  end
+
+  defp ensure_failure_annotation([], report) do
+    [annotation("error", "Aludel evaluation", "Suite run #{report.suite_run_id} did not pass")]
+  end
+
+  defp ensure_failure_annotation(annotations, _report) do
+    annotations
+  end
+
+  defp annotation(level, title, message) do
+    "::#{level} title=#{escape_property(title)}::#{escape_message(message)}"
+  end
+
+  defp escape_property(value) do
+    value
+    |> bounded_string()
+    |> escape_common()
+    |> String.replace(":", "%3A")
+    |> String.replace(",", "%2C")
+  end
+
+  defp escape_message(value) do
+    value
+    |> bounded_string()
+    |> escape_common()
+  end
+
+  defp escape_common(value) do
+    value
+    |> String.replace("%", "%25")
+    |> String.replace("\r", "%0D")
+    |> String.replace("\n", "%0A")
+  end
+
+  defp bounded_string(value) do
+    value
+    |> to_string()
+    |> String.slice(0, @max_message_characters)
+  end
+end

--- a/lib/aludel/evals/reporters/json.ex
+++ b/lib/aludel/evals/reporters/json.ex
@@ -1,0 +1,18 @@
+defmodule Aludel.Evals.Reporters.JSON do
+  @moduledoc """
+  Renders the versioned evaluation report as JSON.
+
+  Pass `pretty: true` to make the output easier to read. The compact encoding
+  is deterministic at the schema level, but consumers must not depend on JSON
+  object key order.
+  """
+
+  @behaviour Aludel.Evals.Reporter
+
+  alias Aludel.Evals.Report
+
+  @impl true
+  def render(%Report{} = report, options) do
+    {:ok, Jason.encode!(Report.to_map(report), pretty: Keyword.get(options, :pretty, false))}
+  end
+end

--- a/lib/aludel/evals/reporters/junit.ex
+++ b/lib/aludel/evals/reporters/junit.ex
@@ -1,0 +1,176 @@
+defmodule Aludel.Evals.Reporters.JUnit do
+  @moduledoc """
+  Renders evaluation results as JUnit XML for CI test-report viewers.
+
+  Each evaluation case becomes a `<testcase>`. Failed cases contain a
+  `<failure>` element with their failed assertion reasons. Generated model
+  output is omitted by default and can be included as escaped `<system-out>`
+  text with `include_output: true`.
+  """
+
+  @behaviour Aludel.Evals.Reporter
+
+  alias Aludel.Evals.Report
+
+  @impl true
+  def render(%Report{} = report, options) do
+    suite_name = "Aludel suite #{report.suite_id}"
+
+    total_seconds = total_seconds(report.summary, length(report.results))
+
+    synthetic_failure_count = synthetic_failure_count(report)
+    test_count = length(report.results) + synthetic_failure_count
+    failure_count = Enum.count(report.results, &(not &1["passed"])) + synthetic_failure_count
+
+    document = [
+      ~s(<?xml version="1.0" encoding="UTF-8"?>\n),
+      ~s(<testsuites tests="#{test_count}" failures="#{failure_count}" errors="0" time="#{total_seconds}">\n),
+      ~s(  <testsuite name="#{xml(suite_name)}" tests="#{test_count}" failures="#{failure_count}" errors="0" time="#{total_seconds}">\n),
+      properties(report),
+      Enum.map(report.results, &test_case(report, &1, options)),
+      synthetic_test_case(report),
+      "  </testsuite>\n",
+      "</testsuites>\n"
+    ]
+
+    {:ok, document}
+  end
+
+  defp properties(report) do
+    [
+      "    <properties>\n",
+      property("schema_version", report.schema_version),
+      property("suite_run_id", report.suite_run_id),
+      property("status", report.status),
+      "    </properties>\n"
+    ]
+  end
+
+  defp property(name, value) do
+    ~s(      <property name="#{xml(name)}" value="#{xml(value)}"/>\n)
+  end
+
+  defp test_case(report, result, options) do
+    latency = milliseconds_to_seconds(result["latency_ms"], 1)
+    test_case_id = result["test_case_id"] || "unknown"
+
+    [
+      ~s(    <testcase name="#{xml(test_case_id)}" classname="aludel.suite.#{xml(report.suite_id)}" time="#{latency}">\n),
+      failure(result),
+      system_out(result["output"], Keyword.get(options, :include_output, false)),
+      "    </testcase>\n"
+    ]
+  end
+
+  defp failure(%{"passed" => true}) do
+    []
+  end
+
+  defp failure(result) do
+    message = failure_message(result)
+
+    ~s(      <failure message="Evaluation assertions failed" type="evaluation_failure">#{xml(message)}</failure>\n)
+  end
+
+  defp failure_message(result) do
+    result
+    |> Map.get("assertion_results", [])
+    |> Enum.reject(& &1["passed"])
+    |> Enum.map_join("; ", &(&1["reason"] || "Assertion failed"))
+    |> case do
+      "" -> "Evaluation failed"
+      message -> message
+    end
+  end
+
+  defp system_out(_output, false) do
+    []
+  end
+
+  defp system_out(nil, true) do
+    []
+  end
+
+  defp system_out(output, true) do
+    ~s(      <system-out>#{xml(output)}</system-out>\n)
+  end
+
+  defp synthetic_failure_count(%Report{status: "passed"}) do
+    0
+  end
+
+  defp synthetic_failure_count(%Report{quality_policy: quality_policy})
+       when not is_nil(quality_policy) do
+    1
+  end
+
+  defp synthetic_failure_count(%Report{results: results}) do
+    if Enum.any?(results, &(not &1["passed"])), do: 0, else: 1
+  end
+
+  defp synthetic_test_case(%Report{status: "passed"}) do
+    []
+  end
+
+  defp synthetic_test_case(%Report{quality_policy: quality_policy} = report)
+       when not is_nil(quality_policy) do
+    message =
+      report.quality_policy
+      |> Map.get("rules", [])
+      |> Enum.reject(&(&1["status"] == "passed"))
+      |> Enum.map_join("; ", &(&1["reason"] || "Quality policy rule did not pass"))
+      |> case do
+        "" -> "Quality policy did not pass"
+        reasons -> reasons
+      end
+
+    [
+      ~s(    <testcase name="quality-policy" classname="aludel.suite.#{xml(report.suite_id)}" time="0">\n),
+      ~s(      <failure message="Quality policy did not pass" type="quality_policy_failure">#{xml(message)}</failure>\n),
+      "    </testcase>\n"
+    ]
+  end
+
+  defp synthetic_test_case(%Report{} = report) do
+    if Enum.any?(report.results, &(not &1["passed"])) do
+      []
+    else
+      [
+        ~s(    <testcase name="evaluation" classname="aludel.suite.#{xml(report.suite_id)}" time="0">\n),
+        ~s(      <failure message="Evaluation did not pass" type="evaluation_failure">No evaluation cases were available</failure>\n),
+        "    </testcase>\n"
+      ]
+    end
+  end
+
+  defp milliseconds_to_seconds(nil, _multiplier) do
+    "0"
+  end
+
+  defp milliseconds_to_seconds(milliseconds, multiplier) do
+    milliseconds
+    |> Kernel.*(multiplier)
+    |> Kernel./(1000)
+    |> :erlang.float_to_binary(decimals: 3)
+  end
+
+  defp total_seconds(%{"total_latency_ms" => total_latency_ms}, _result_count)
+       when is_integer(total_latency_ms) do
+    milliseconds_to_seconds(total_latency_ms, 1)
+  end
+
+  defp total_seconds(summary, result_count) do
+    milliseconds_to_seconds(summary["avg_latency_ms"], result_count)
+  end
+
+  defp xml(value) do
+    value
+    |> to_string()
+    |> String.replace(~r/[^\x09\x0A\x0D\x20-\x{D7FF}\x{E000}-\x{FFFD}\x{10000}-\x{10FFFF}]/u, "")
+    |> String.replace("&", "&amp;")
+    |> String.replace("<", "&lt;")
+    |> String.replace(">", "&gt;")
+    |> String.replace("\"", "&quot;")
+    |> String.replace("'", "&apos;")
+  end
+end

--- a/lib/mix/tasks/aludel.eval.ex
+++ b/lib/mix/tasks/aludel.eval.ex
@@ -1,39 +1,59 @@
 defmodule Mix.Tasks.Aludel.Eval do
   @moduledoc """
-  Runs one Aludel evaluation suite and emits machine-readable JSON.
+  Runs one Aludel evaluation suite and emits a report.
 
       mix aludel.eval \
         --suite-id SUITE_ID \
         --prompt-version-id PROMPT_VERSION_ID \
-        --provider-id PROVIDER_ID
+        --provider-id PROVIDER_ID \
+        --format json
+
+  Supported formats are `json` (the default), `console`, `junit`, and
+  `github`. Use `--output PATH` to write the report to a file instead of
+  standard output. JSON output uses the versioned Aludel report schema. JUnit
+  omits generated responses unless `--include-output` is set.
 
   The task exits unsuccessfully when arguments or targets are invalid, execution
   cannot complete, or the active suite quality policy does not pass. Suites
   without a quality policy retain the all-test-cases-must-pass behavior.
   """
 
-  @shortdoc "Runs an Aludel suite and emits JSON"
+  @shortdoc "Runs an Aludel suite and emits a CI report"
   @requirements ["app.start"]
 
   use Mix.Task
 
   alias Aludel.Evals
+  alias Aludel.Evals.{Report, Reporter}
   alias Aludel.Prompts
   alias Aludel.Providers
-  alias Decimal
 
-  @schema_version 1
-  @switches [suite_id: :string, prompt_version_id: :string, provider_id: :string]
+  @schema_version 2
+  @switches [
+    suite_id: :string,
+    prompt_version_id: :string,
+    provider_id: :string,
+    format: :string,
+    output: :string,
+    pretty: :boolean,
+    include_output: :boolean
+  ]
   @required_options [:suite_id, :prompt_version_id, :provider_id]
+  @reporters %{
+    "console" => :console,
+    "github" => :github,
+    "json" => :json,
+    "junit" => :junit
+  }
 
   @impl Mix.Task
   def run(args) do
     case args |> parse_options() |> execute() do
-      {:ok, %{status: "passed"} = payload} ->
-        emit(payload)
+      {:ok, %Report{status: "passed"} = report, options} ->
+        emit_report(report, options)
 
-      {:ok, payload} ->
-        emit(payload)
+      {:ok, %Report{} = report, options} ->
+        emit_report(report, options)
         Mix.raise("Evaluation did not pass")
 
       {:error, error} ->
@@ -53,7 +73,9 @@ defmodule Mix.Tasks.Aludel.Eval do
     missing_options = Enum.reject(@required_options, &Keyword.has_key?(options, &1))
 
     if missing_options == [] do
-      {:ok, Map.new(options)}
+      options
+      |> Map.new()
+      |> validate_reporter()
     else
       missing_flags = Enum.map_join(missing_options, ", ", &option_flag/1)
       {:error, cli_error("invalid_arguments", "Missing required options: #{missing_flags}")}
@@ -74,7 +96,43 @@ defmodule Mix.Tasks.Aludel.Eval do
            fetch_target("provider", fn -> Providers.get_provider!(options.provider_id) end),
          :ok <- validate_prompt_version(suite, prompt_version),
          {:ok, suite_run} <- execute_suite(suite, prompt_version, provider) do
-      {:ok, suite_run_payload(suite_run)}
+      {:ok, Report.from_suite_run(suite_run), options}
+    end
+  end
+
+  defp validate_reporter(options) do
+    format = Map.get(options, :format, "json")
+
+    with {:ok, reporter} <- fetch_reporter(format),
+         :ok <- validate_reporter_options(format, options) do
+      {:ok, Map.put(options, :reporter, reporter)}
+    end
+  end
+
+  defp fetch_reporter(format) do
+    case Map.fetch(@reporters, format) do
+      {:ok, reporter} ->
+        {:ok, reporter}
+
+      :error ->
+        {:error,
+         cli_error(
+           "invalid_format",
+           "format must be one of: console, github, json, junit"
+         )}
+    end
+  end
+
+  defp validate_reporter_options(format, options) do
+    cond do
+      Map.get(options, :pretty, false) and format != "json" ->
+        {:error, cli_error("invalid_options", "--pretty requires --format json")}
+
+      Map.get(options, :include_output, false) and format != "junit" ->
+        {:error, cli_error("invalid_options", "--include-output requires --format junit")}
+
+      true ->
+        :ok
     end
   end
 
@@ -113,57 +171,6 @@ defmodule Mix.Tasks.Aludel.Eval do
       {:error, cli_error("execution_failed", "Suite execution failed")}
   end
 
-  defp suite_run_payload(suite_run) do
-    total = suite_run.passed + suite_run.failed
-    status = evaluation_status(suite_run, total)
-
-    %{
-      type: "aludel_eval",
-      schema_version: @schema_version,
-      status: status,
-      suite_run_id: suite_run.id,
-      suite_id: suite_run.suite_id,
-      prompt_version_id: suite_run.prompt_version_id,
-      provider_id: suite_run.provider_id,
-      quality_policy: suite_run.quality_policy_result,
-      summary: %{
-        passed: suite_run.passed,
-        failed: suite_run.failed,
-        total: total,
-        pass_rate: pass_rate(suite_run.passed, total),
-        avg_score: decimal_to_string(suite_run.avg_score),
-        avg_cost_usd: decimal_to_string(suite_run.avg_cost_usd),
-        avg_latency_ms: suite_run.avg_latency_ms
-      },
-      results: Enum.map(suite_run.results, &result_payload/1)
-    }
-  end
-
-  defp evaluation_status(%{quality_policy_result: %{"status" => status}}, _total)
-       when status in ["passed", "failed", "invalid", "unavailable"] do
-    status
-  end
-
-  defp evaluation_status(suite_run, total) do
-    if suite_run.failed == 0 and total > 0, do: "passed", else: "failed"
-  end
-
-  defp result_payload(result) do
-    %{
-      test_case_id: result["test_case_id"],
-      test_case_metadata: result["test_case_metadata"],
-      status: if(result["passed"], do: "passed", else: "failed"),
-      passed: result["passed"],
-      score: result["score"],
-      output: result["output"],
-      assertion_results: Map.get(result, "assertion_results", []),
-      input_tokens: result["input_tokens"],
-      output_tokens: result["output_tokens"],
-      cost_usd: result["cost_usd"],
-      latency_ms: result["latency_ms"]
-    }
-  end
-
   defp error_payload(error) do
     %{
       type: "aludel_eval",
@@ -177,26 +184,40 @@ defmodule Mix.Tasks.Aludel.Eval do
     %{code: code, message: message}
   end
 
-  defp pass_rate(_passed, 0) do
-    0.0
-  end
-
-  defp pass_rate(passed, total) do
-    Float.round(passed / total * 100, 2)
-  end
-
-  defp decimal_to_string(nil) do
-    nil
-  end
-
-  defp decimal_to_string(%Decimal{} = decimal) do
-    Decimal.to_string(decimal, :normal)
-  end
-
   defp emit(payload) do
     payload
     |> Jason.encode!()
     |> Mix.shell().info()
+  end
+
+  defp emit_report(report, options) do
+    reporter_options = [
+      pretty: Map.get(options, :pretty, false),
+      include_output: Map.get(options, :include_output, false)
+    ]
+
+    case Reporter.render(report, options.reporter, reporter_options) do
+      {:ok, output} -> write_report(output, Map.get(options, :output))
+      {:error, _reason} -> Mix.raise("Evaluation report could not be rendered")
+    end
+  end
+
+  defp write_report(output, nil) do
+    Mix.shell().info(output)
+  end
+
+  defp write_report(output, path) do
+    case File.write(path, output <> trailing_newline(output)) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Mix.raise("Evaluation report could not be written: #{:file.format_error(reason)}")
+    end
+  end
+
+  defp trailing_newline(output) do
+    if String.ends_with?(output, "\n"), do: "", else: "\n"
   end
 
   defp option_flag(option) do
@@ -204,6 +225,7 @@ defmodule Mix.Tasks.Aludel.Eval do
   end
 
   defp usage do
-    "Usage: mix aludel.eval --suite-id ID --prompt-version-id ID --provider-id ID"
+    "Usage: mix aludel.eval --suite-id ID --prompt-version-id ID --provider-id ID " <>
+      "[--format console|github|json|junit] [--output PATH] [--pretty] [--include-output]"
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -33,6 +33,7 @@ defmodule Aludel.MixProject do
           "README.md",
           "guides/features.md",
           "guides/evaluations.md",
+          "guides/reporters.md",
           "guides/embedding.md",
           "CHANGELOG.md",
           "CONTRIBUTING.md",
@@ -42,6 +43,7 @@ defmodule Aludel.MixProject do
           Guides: [
             "guides/features.md",
             "guides/evaluations.md",
+            "guides/reporters.md",
             "guides/embedding.md"
           ],
           Project: ["CHANGELOG.md", "CONTRIBUTING.md", "LICENSE"]

--- a/test/aludel/evals/reporter_test.exs
+++ b/test/aludel/evals/reporter_test.exs
@@ -1,0 +1,309 @@
+defmodule Aludel.Evals.ReporterTest do
+  use ExUnit.Case, async: true
+
+  alias Aludel.Evals.{Report, Reporter, SuiteRun}
+
+  defmodule CustomReporter do
+    @behaviour Reporter
+
+    @impl true
+    def render(%Report{} = report, options) do
+      {:ok, [Keyword.fetch!(options, :prefix), report.status]}
+    end
+  end
+
+  defmodule InvalidReporter do
+    @behaviour Reporter
+
+    @impl true
+    def render(%Report{}, _options) do
+      :invalid
+    end
+  end
+
+  describe "normalized reports" do
+    test "builds the versioned JSON-compatible report schema" do
+      report = Report.from_suite_run(suite_run())
+
+      assert report.schema_version == 2
+      assert report.status == "failed"
+
+      assert %{
+               "type" => "aludel_eval",
+               "schema_version" => 2,
+               "summary" => %{
+                 "passed" => 1,
+                 "failed" => 1,
+                 "total" => 2,
+                 "pass_rate" => 50.0,
+                 "avg_score" => "62.5",
+                 "avg_cost_usd" => "0.0042",
+                 "avg_latency_ms" => 125,
+                 "total_cost_usd" => "0.0084",
+                 "cost_sample_count" => 2,
+                 "total_latency_ms" => 250,
+                 "latency_sample_count" => 2
+               },
+               "results" => [%{"status" => "passed"}, %{"status" => "failed"}]
+             } = Report.to_map(report)
+    end
+
+    test "uses a quality policy as the report status" do
+      report =
+        suite_run(%{
+          failed: 1,
+          quality_policy_result: %{"status" => "passed", "rules" => []}
+        })
+        |> Report.from_suite_run()
+
+      assert report.status == "passed"
+    end
+
+    test "treats an empty policy-free run as failed" do
+      report =
+        suite_run(%{passed: 0, failed: 0, results: []})
+        |> Report.from_suite_run()
+
+      assert report.status == "failed"
+      assert report.summary["pass_rate"] == 0.0
+    end
+  end
+
+  describe "render/3" do
+    test "supports custom reporter modules and normalizes iodata" do
+      assert {:ok, "result=failed"} =
+               Reporter.render(suite_run(), CustomReporter, prefix: "result=")
+    end
+
+    test "rejects unknown reporters" do
+      assert {:error, :unknown_reporter} = Reporter.render(suite_run(), :missing)
+      assert {:error, :unknown_reporter} = Reporter.render(suite_run(), "json")
+    end
+
+    test "rejects invalid custom reporter output" do
+      assert {:error, :invalid_reporter_output} =
+               Reporter.render(suite_run(), InvalidReporter)
+    end
+  end
+
+  describe "JSON reporter" do
+    test "renders schema version 2 in compact and pretty forms" do
+      compact = Reporter.render!(suite_run(), :json)
+      pretty = Reporter.render!(suite_run(), :json, pretty: true)
+
+      assert Jason.decode!(compact)["schema_version"] == 2
+      assert pretty =~ "\n  \"provider_id\""
+    end
+  end
+
+  describe "console reporter" do
+    test "renders a plain-text summary without model output or control characters" do
+      output = Reporter.render!(suite_run(), :console)
+
+      assert output =~ "Aludel evaluation FAILED"
+      assert output =~ "Summary: 1 passed, 1 failed, 50.0% pass rate"
+      assert output =~ "[PASS] test case case-pass"
+      assert output =~ "[FAIL] test case case-fail"
+      refute output =~ "unsafe model output"
+      refute output =~ "\e"
+    end
+
+    test "renders policy status and rule evidence" do
+      run =
+        suite_run(%{
+          quality_policy_result: %{
+            "status" => "unavailable",
+            "rules" => [
+              %{
+                "id" => "latency\nrule",
+                "status" => "unavailable",
+                "reason" => "No latency\rwas recorded"
+              }
+            ]
+          }
+        })
+
+      output = Reporter.render!(run, :console)
+
+      assert output =~ "Policy: unavailable"
+      assert output =~ "[UNAVAILABLE] latency rule: No latency was recorded"
+    end
+  end
+
+  describe "JUnit reporter" do
+    test "renders valid XML with escaped identifiers, reasons, and model output" do
+      run =
+        suite_run(%{
+          suite_id: "suite<&\"",
+          results: [
+            result(%{
+              "test_case_id" => "case<&\"",
+              "passed" => false,
+              "output" => "unsafe <output> & \"quote\"\u0000",
+              "assertion_results" => [
+                %{"passed" => false, "reason" => "expected <safe> & sound"}
+              ]
+            })
+          ],
+          passed: 0,
+          failed: 1
+        })
+
+      xml = Reporter.render!(run, :junit, include_output: true)
+
+      assert xml =~ ~s(tests="1" failures="1")
+      assert xml =~ "case&lt;&amp;&quot;"
+      assert xml =~ "expected &lt;safe&gt; &amp; sound"
+      assert xml =~ "unsafe &lt;output&gt; &amp; &quot;quote&quot;"
+      refute xml =~ "\u0000"
+
+      assert {_document, []} = :xmerl_scan.string(String.to_charlist(xml), quiet: true)
+    end
+
+    test "omits generated model output by default" do
+      xml = Reporter.render!(suite_run(), :junit)
+
+      refute xml =~ "<system-out>"
+      refute xml =~ "unsafe model output"
+    end
+
+    test "adds a failing policy case when all evaluation cases pass" do
+      run =
+        suite_run(%{
+          results: [result()],
+          passed: 1,
+          failed: 0,
+          quality_policy_result: %{
+            "status" => "failed",
+            "rules" => [
+              %{"id" => "cost", "status" => "failed", "reason" => "Cost exceeded limit"}
+            ]
+          }
+        })
+
+      xml = Reporter.render!(run, :junit)
+
+      assert xml =~ ~s(tests="2" failures="1")
+      assert xml =~ ~s(name="quality-policy")
+      assert xml =~ "Cost exceeded limit"
+    end
+
+    test "represents an empty run as a failure" do
+      run = suite_run(%{results: [], passed: 0, failed: 0})
+
+      xml = Reporter.render!(run, :junit)
+
+      assert xml =~ ~s(tests="1" failures="1")
+      assert xml =~ ~s(name="evaluation")
+      assert xml =~ "No evaluation cases were available"
+    end
+  end
+
+  describe "GitHub reporter" do
+    test "emits a notice for a passing report" do
+      run = suite_run(%{results: [result()], passed: 1, failed: 0})
+
+      assert Reporter.render!(run, :github) ==
+               "::notice title=Aludel evaluation::Suite run run-123 passed"
+    end
+
+    test "escapes workflow commands in untrusted titles and messages" do
+      run =
+        suite_run(%{
+          results: [
+            result(%{
+              "test_case_id" => "case:one,two",
+              "passed" => false,
+              "assertion_results" => [
+                %{
+                  "passed" => false,
+                  "reason" => "first line\n::warning::injected%value\r"
+                }
+              ]
+            })
+          ],
+          passed: 0,
+          failed: 1
+        })
+
+      output = Reporter.render!(run, :github)
+
+      assert output =~ "title=Test case case%3Aone%2Ctwo"
+      assert output =~ "first line%0A::warning::injected%25value%0D"
+      refute output =~ "\n"
+    end
+
+    test "emits policy errors when case assertions passed" do
+      run =
+        suite_run(%{
+          results: [result()],
+          passed: 1,
+          failed: 0,
+          quality_policy_result: %{
+            "status" => "unavailable",
+            "rules" => [
+              %{
+                "id" => "latency",
+                "status" => "unavailable",
+                "reason" => "No latency was recorded"
+              }
+            ]
+          }
+        })
+
+      output = Reporter.render!(run, :github)
+
+      assert output =~ "::error title=Quality policy latency::No latency was recorded"
+    end
+  end
+
+  defp suite_run(overrides \\ %{}) do
+    defaults = %{
+      id: "run-123",
+      suite_id: "suite-123",
+      prompt_version_id: "version-123",
+      provider_id: "provider-123",
+      passed: 1,
+      failed: 1,
+      avg_score: Decimal.new("62.5"),
+      avg_cost_usd: Decimal.new("0.0042"),
+      avg_latency_ms: 125,
+      total_cost_usd: Decimal.new("0.0084"),
+      cost_sample_count: 2,
+      total_latency_ms: 250,
+      latency_sample_count: 2,
+      quality_policy_result: nil,
+      results: [result(), failed_result()]
+    }
+
+    struct!(SuiteRun, Map.merge(defaults, overrides))
+  end
+
+  defp result(overrides \\ %{}) do
+    Map.merge(
+      %{
+        "test_case_id" => "case-pass",
+        "test_case_metadata" => %{"group" => "smoke"},
+        "passed" => true,
+        "score" => 100.0,
+        "output" => "unsafe model output",
+        "assertion_results" => [%{"passed" => true, "reason" => "Matched"}],
+        "input_tokens" => 4,
+        "output_tokens" => 2,
+        "cost_usd" => 0.002,
+        "latency_ms" => 100
+      },
+      overrides
+    )
+  end
+
+  defp failed_result do
+    result(%{
+      "test_case_id" => "case-fail",
+      "passed" => false,
+      "score" => 25.0,
+      "assertion_results" => [%{"passed" => false, "reason" => "Did not match"}],
+      "latency_ms" => 150
+    })
+  end
+end

--- a/test/mix/tasks/aludel.eval_test.exs
+++ b/test/mix/tasks/aludel.eval_test.exs
@@ -27,7 +27,7 @@ defmodule Mix.Tasks.Aludel.EvalTest do
     payload = Jason.decode!(output)
 
     assert payload["type"] == "aludel_eval"
-    assert payload["schema_version"] == 1
+    assert payload["schema_version"] == 2
     assert payload["status"] == "passed"
     assert payload["suite_id"] == suite.id
     assert payload["prompt_version_id"] == prompt_version.id
@@ -174,7 +174,7 @@ defmodule Mix.Tasks.Aludel.EvalTest do
 
     assert payload == %{
              "type" => "aludel_eval",
-             "schema_version" => 1,
+             "schema_version" => 2,
              "status" => "error",
              "error" => %{
                "code" => "invalid_arguments",
@@ -200,6 +200,100 @@ defmodule Mix.Tasks.Aludel.EvalTest do
 
     assert payload["status"] == "error"
     assert payload["error"]["code"] == "prompt_version_mismatch"
+  end
+
+  test "emits console, JUnit, and GitHub reports" do
+    Enum.each(
+      [
+        {"console", "Aludel evaluation PASSED"},
+        {"junit", ~s(<testsuites tests="1" failures="0")},
+        {"github", "::notice title=Aludel evaluation::"}
+      ],
+      fn {format, expected} ->
+        %{suite: suite, prompt_version: prompt_version, provider: provider} =
+          evaluation_targets()
+
+        expect(HttpClientMock, :request, fn _model, _prompt, _options ->
+          {:ok, %{content: "Hello Alice", input_tokens: 5, output_tokens: 3}}
+        end)
+
+        output =
+          capture_io(fn ->
+            EvalTask.run(task_args(suite, prompt_version, provider) ++ ["--format", format])
+          end)
+
+        assert output =~ expected
+      end
+    )
+  end
+
+  test "includes generated responses in JUnit only when explicitly requested" do
+    %{suite: suite, prompt_version: prompt_version, provider: provider} = evaluation_targets()
+
+    expect(HttpClientMock, :request, fn _model, _prompt, _options ->
+      {:ok, %{content: "Hello Alice", input_tokens: 5, output_tokens: 3}}
+    end)
+
+    output =
+      capture_io(fn ->
+        EvalTask.run(
+          task_args(suite, prompt_version, provider) ++
+            ["--format", "junit", "--include-output"]
+        )
+      end)
+
+    assert output =~ "<system-out>Hello Alice</system-out>"
+  end
+
+  test "writes a report to the requested output path" do
+    %{suite: suite, prompt_version: prompt_version, provider: provider} = evaluation_targets()
+    output_path = Path.join(System.tmp_dir!(), "aludel-report-#{System.unique_integer()}.xml")
+
+    on_exit(fn -> File.rm(output_path) end)
+
+    expect(HttpClientMock, :request, fn _model, _prompt, _options ->
+      {:ok, %{content: "Hello Alice", input_tokens: 5, output_tokens: 3}}
+    end)
+
+    assert capture_io(fn ->
+             EvalTask.run(
+               task_args(suite, prompt_version, provider) ++
+                 ["--format", "junit", "--output", output_path]
+             )
+           end) == ""
+
+    assert File.read!(output_path) =~ ~s(<testsuites tests="1" failures="0")
+  end
+
+  test "rejects an unsupported report format before execution" do
+    %{suite: suite, prompt_version: prompt_version, provider: provider} = evaluation_targets()
+
+    output =
+      capture_io(fn ->
+        assert_raise Mix.Error, "format must be one of: console, github, json, junit", fn ->
+          EvalTask.run(task_args(suite, prompt_version, provider) ++ ["--format", "html"])
+        end
+      end)
+
+    assert Jason.decode!(output)["error"]["code"] == "invalid_format"
+  end
+
+  test "rejects format-specific options on other reporters before execution" do
+    %{suite: suite, prompt_version: prompt_version, provider: provider} = evaluation_targets()
+
+    for {options, message} <- [
+          {["--format", "console", "--pretty"], "--pretty requires --format json"},
+          {["--format", "json", "--include-output"], "--include-output requires --format junit"}
+        ] do
+      output =
+        capture_io(fn ->
+          assert_raise Mix.Error, message, fn ->
+            EvalTask.run(task_args(suite, prompt_version, provider) ++ options)
+          end
+        end)
+
+      assert Jason.decode!(output)["error"]["code"] == "invalid_options"
+    end
   end
 
   defp evaluation_targets do


### PR DESCRIPTION
## Motivation

Evaluation runs need to work equally well in local development, scripts, and CI systems. This adds one normalized report boundary and multiple output adapters without coupling persistence to any individual format.

## Behavior

- Adds the schema-version-2 `Aludel.Evals.Report` model with aggregate and total quality, cost, and latency fields.
- Adds the `Aludel.Evals.Reporter` behavior and built-in console, JSON, JUnit XML, and GitHub Actions reporters.
- Supports custom reporter modules with validated callback results and iodata normalization.
- Extends `mix aludel.eval` with `--format`, `--output`, JSON-only `--pretty`, and JUnit-only `--include-output`.
- Preserves policy-aware process exit behavior and machine-readable JSON error envelopes.

```mermaid
flowchart LR
  A[Persisted suite run] --> B[Normalized report v2]
  B --> C[Console]
  B --> D[JSON]
  B --> E[JUnit XML]
  B --> F[GitHub annotations]
  B --> G[Custom reporter]
```

## Safety and compatibility

- GitHub annotation titles and messages are bounded and workflow-command escaped.
- JUnit values are XML-escaped, forbidden controls are removed, and generated responses are omitted unless explicitly requested.
- Empty suites and policy-only rejections become synthetic JUnit failures so CI test views cannot show a false success.
- Reporter names and format-specific options are validated before suite execution.
- The default JSON envelope advances from schema version 1 to schema version 2; consumers can use `schema_version` for explicit compatibility handling.

## Test Plan

- Covers report normalization, every built-in reporter, custom reporter success and invalid output, XML parsing, workflow-command injection payloads, privacy defaults, empty runs, and policy-only failures.
- Covers every Mix task format, direct file output, opt-in JUnit responses, invalid formats, invalid option combinations, and existing quality-gate behavior.
- Covers compilation with warnings as errors, formatting, static analysis, the complete test suite, security scanning, documentation generation, and Hex package contents.

## Documentation

README, feature and evaluation guides, a dedicated HexDocs reporter guide, and a focused wiki page document every format, CLI usage, library usage, file output, security defaults, and custom reporters.
