### PR TITLE
feat(testing): add ExUnit evaluation helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Aludel gives teams a clean way to evaluate prompt and model behavior without inv
 - Inspect output, latency, token usage, and cost side by side.
 - Compare prompt versions and see pass-rate, cost, and latency changes over time.
 - Run evaluation suites with deterministic assertions, model-based judges, repeated sampling, document attachments, and CSV or JSON test case imports.
+- Assert generated output directly in ExUnit, or execute and gate persisted suites from application tests and CI.
 - Execute suites headlessly with console, versioned JSON, JUnit XML, or GitHub annotation reports for CI workflows.
 - Route runs and suites through your app's real LLM workflow with callback execution.
 - Reuse single-turn and multi-turn datasets across suites with provenance and metadata filtering.
@@ -44,7 +45,7 @@ Most teams evaluating LLM behavior end up with some combination of scripts, spre
 | Assertions | `contains`, `not_contains`, `regex`, `exact_match`, typed `json_field`, scored `json_deep_compare`, custom rubric judges, and seven versioned judge templates |
 | Imports and datasets | CSV and JSON import previews with row-level errors; reusable ordered datasets with variables, messages, assertions, metadata filters, provenance, and idempotent suite population |
 | Prompt evolution | Version and provider trends, version-over-version deltas, suite-scoped Pareto frontiers, failure-grounded prompt suggestions, and explicit accept or dismiss decisions |
-| Automation and exports | JSON run and suite exports, CSV or JSON evolution exports, a custom reporter behavior, console reports, versioned JSON, JUnit XML, GitHub annotations, and policy-aware `mix aludel.eval` quality gates |
+| Automation and exports | Native ExUnit assertions and persisted suite gates, JSON run and suite exports, CSV or JSON evolution exports, a custom reporter behavior, console reports, versioned JSON, JUnit XML, GitHub annotations, and policy-aware `mix aludel.eval` quality gates |
 | Execution and extension | Native provider calls, host-app callback execution, pluggable LLM, storage, and document-conversion boundaries, optional callback metadata, and configurable run concurrency |
 | Deployment | Embedded Phoenix dashboard, standalone app, Docker Compose, local/AWS S3/GCS document storage, custom auth/access resolvers, CSP nonce support, theming, and read-only mode |
 | Demo data | Deterministic prompts, providers, datasets, suites, runs, failures, artifacts, and 60 days of comparison history through `mix aludel.seed` |
@@ -327,6 +328,30 @@ mix aludel.eval \
 Supported formats are `console`, `json`, `junit`, and `github`; `--pretty` formats JSON for human review, while `--include-output` opts JUnit into generated responses. The task exits unsuccessfully when its arguments or targets are invalid, execution cannot complete, the suite is empty, or the active quality gate does not pass.
 
 The versioned `aludel_eval` JSON envelope includes suite and provider identifiers, aggregate and total score/cost/latency data, quality-policy evidence, and individual assertion results.
+
+### ExUnit evaluation assertions
+
+Use `Aludel.ExUnit` to keep focused model checks beside application tests:
+
+```elixir
+defmodule MyApp.AnswerTest do
+  use ExUnit.Case
+  use Aludel.ExUnit
+
+  test "answers with the expected city" do
+    output = MyApp.answer("What is the capital of France?")
+
+    assert_evaluation(output, %{
+      "type" => "exact_match",
+      "value" => "Paris"
+    })
+  end
+end
+```
+
+Use `assert_evaluations/2` for several metrics, `assert_suite_run/1` for an existing persisted result, or `assert_suite/3` and `assert_suite/4` to execute, persist, and gate a suite. Stored quality policies determine the effective suite status when present; otherwise every case must pass and empty runs fail. Failure messages include bounded metric, case, and policy evidence without copying generated output into test logs.
+
+See the [ExUnit evaluation guide](https://hexdocs.pm/aludel/ex_unit.html) and [ExUnit wiki examples](https://github.com/ccarvalho-eng/aludel/wiki/ExUnit-Evaluations).
 
 ### Standalone mode
 

--- a/guides/evaluations.md
+++ b/guides/evaluations.md
@@ -314,3 +314,27 @@ The command emits one schema-version-2 JSON object by default:
 The task exits unsuccessfully when arguments or targets are invalid, the prompt version belongs to another prompt, execution cannot be persisted, the suite is empty, or the active quality gate does not pass.
 
 Choose `--format console`, `--format junit`, or `--format github` for a human-readable log, CI test report, or GitHub Actions annotations. Add `--output PATH` to write the report to a file, `--pretty` to pretty-print JSON, or JUnit-only `--include-output` when the artifact is appropriate for generated responses. See the [reporter guide](reporters.html) for complete examples and the custom reporter behavior.
+
+## 10. Gate evaluations in ExUnit
+
+Use `Aludel.ExUnit` when an evaluation belongs beside application behavior tests:
+
+```elixir
+defmodule MyApp.SupportAnswerTest do
+  use ExUnit.Case
+  use Aludel.ExUnit
+
+  test "keeps the response concise and grounded" do
+    output = MyApp.Support.answer("How do I reset my password?")
+
+    assert_evaluations(output, [
+      %{"type" => "contains", "value" => "reset link"},
+      %{"type" => "not_contains", "value" => "share your password"}
+    ])
+  end
+end
+```
+
+For a stored suite, `assert_suite_run/1` gates an existing result and `assert_suite/3` or `assert_suite/4` executes, persists, and gates a new run. Both use the same effective status as reporters and `mix aludel.eval`: a stored policy result wins when present, otherwise all cases must pass and the run must not be empty.
+
+Failure messages omit generated output and expected values. They include bounded, control-character-sanitized metric reasons, failed case identifiers, and non-passing policy rules. See the [ExUnit evaluation guide](ex_unit.html) for each helper, database sandbox guidance, and complete examples.

--- a/guides/ex_unit.md
+++ b/guides/ex_unit.md
@@ -1,0 +1,111 @@
+# ExUnit Evaluations
+
+`Aludel.ExUnit` lets application tests use the same metrics, persisted suite results, and versioned quality policies as the Aludel workbench and headless Mix task. Add `use Aludel.ExUnit` to import the helpers, or call them through the module directly.
+
+## Assert one generated response
+
+`assert_evaluation/2` accepts generated output and one assertion map:
+
+```elixir
+defmodule MyApp.AnswerTest do
+  use ExUnit.Case
+  use Aludel.ExUnit
+
+  test "returns the canonical city" do
+    output = MyApp.answer("What is the capital of France?")
+
+    result =
+      assert_evaluation(output, %{
+        "type" => "exact_match",
+        "value" => "Paris"
+      })
+
+    assert result["score"] == 100.0
+  end
+end
+```
+
+The helper returns the normalized assertion result when it passes. A failed, invalid, unsupported, or unavailable evaluator raises `ExUnit.AssertionError`.
+
+All built-in metrics are available: `contains`, `not_contains`, `regex`, `exact_match`, `json_field`, `json_deep_compare`, and `rubric_judge`. Model-based judge assertions use their configured Aludel provider and retain separate evaluator evidence.
+
+## Assert several metrics
+
+`assert_evaluations/2` runs every assertion against the same response and returns results in authoring order:
+
+```elixir
+results =
+  assert_evaluations(output, [
+    %{"type" => "contains", "value" => "reset link"},
+    %{"type" => "not_contains", "value" => "share your password"},
+    %{"type" => "regex", "value" => "(?i)expires? in 15 minutes"}
+  ])
+
+assert Enum.all?(results, & &1["passed"])
+```
+
+An empty assertion list fails instead of passing vacuously. When several assertions fail, one error lists each non-passing metric up to a bounded diagnostic limit.
+
+## Supply metric context
+
+Pass `Aludel.Evals.Metric.Context` when a custom metric or rubric judge needs input, expected output, documents, messages, metadata, or execution evidence:
+
+```elixir
+alias Aludel.Evals.Metric.Context
+
+context =
+  Context.new(output,
+    expected: "Paris",
+    rendered_input: "What is the capital of France?",
+    metadata: %{"category" => "geography"}
+  )
+
+assert_evaluation(context, %{
+  "type" => "contains",
+  "value" => "Paris"
+})
+```
+
+## Gate an existing suite run
+
+`assert_suite_run/1` applies the normalized report status to an existing `Aludel.Evals.SuiteRun`:
+
+```elixir
+suite_run = Aludel.Evals.get_suite_run!(run_id)
+
+assert_suite_run(suite_run)
+```
+
+When the run has a stored quality-policy result, its `passed`, `failed`, `invalid`, or `unavailable` status is authoritative. Without a policy, every case must pass and the suite must contain at least one result. The unchanged suite-run struct is returned on success.
+
+## Execute, persist, and gate a suite
+
+`assert_suite/3` runs with default sampling. `assert_suite/4` accepts sampling options. Both run the provider-backed evaluation through `Aludel.Evals.execute_suite/4`, persist the result, and then apply `assert_suite_run/1`:
+
+```elixir
+suite = Aludel.Evals.get_suite!(suite_id)
+prompt_version = Aludel.Prompts.get_prompt_version!(prompt_version_id)
+provider = Aludel.Providers.get_provider!(provider_id)
+
+suite_run =
+  assert_suite(suite, prompt_version, provider,
+    samples: 5,
+    reducer: :majority
+  )
+
+assert suite_run.passed >= 1
+```
+
+A completed non-passing run stays persisted before the assertion is raised, preserving the evidence for the dashboard and later comparison. The prompt version must belong to the suite's prompt. Pre-execution errors such as a prompt mismatch or invalid sampling configuration fail with a stable category and do not create a suite run.
+
+## Failure messages and sensitive output
+
+Failures identify the metric type, evaluator status, score, failed case IDs, and non-passing policy rules. Diagnostic text is bounded and control characters are normalized. Generated model output and expected values are not copied into the assertion message, keeping ordinary test and CI logs smaller and reducing accidental disclosure.
+
+Inspect the returned or persisted result explicitly when a trusted local workflow needs the complete output.
+
+## Database and provider setup
+
+Inline deterministic assertions do not need a database or running Aludel application. Rubric judges and the `assert_suite` helpers use configured providers; suite execution also uses the configured Aludel repository.
+
+In a Phoenix application, keep normal Ecto SQL sandbox ownership around tests that execute or load persisted suites. Provider adapters should be replaced only at their documented application boundary in tests. Avoid global mocks in asynchronous cases, and choose normal ExUnit timeouts that cover the bounded provider requests and sampling count used by the suite.

--- a/guides/features.md
+++ b/guides/features.md
@@ -124,12 +124,13 @@ Aludel provides:
 - JSON exports for individual run results
 - JSON exports for suite runs, including assertions, retries, callback metadata, and artifacts
 - JSON and CSV exports for prompt evolution metrics and provider breakdowns
+- `Aludel.ExUnit` assertions for inline generated output, existing suite runs, and execute-and-persist quality gates
 - `Aludel.Evals.Reporter` with console, schema-version-2 JSON, JUnit XML, GitHub annotation, and custom reporter support
 - `mix aludel.eval` for headless suite execution and optional report file output
 
 The Mix task emits JSON by default and accepts `--format console|json|junit|github`, `--output PATH`, JSON-only `--pretty`, and JUnit-only `--include-output`. It exits unsuccessfully for invalid targets, execution errors, empty suites, or a non-passing active quality gate. The normalized report model keeps each output format independent from suite-run persistence.
 
-See the [reporter guide](reporters.html) for output examples, CI configuration, and custom reporter modules.
+See the [ExUnit evaluation guide](ex_unit.html) for application-test examples and the [reporter guide](reporters.html) for output formats, CI configuration, and custom reporter modules.
 
 ## Execution modes
 

--- a/lib/aludel/ex_unit.ex
+++ b/lib/aludel/ex_unit.ex
@@ -1,0 +1,325 @@
+defmodule Aludel.ExUnit do
+  @moduledoc """
+  Adds evaluation assertions to ExUnit tests.
+
+  Use `assert_evaluation/2` for one generated response, or
+  `assert_evaluations/2` when the same response must satisfy several metrics.
+  Persisted suite runs can be checked with `assert_suite_run/1`.
+  `assert_suite/3` or `assert_suite/4` executes and persists a suite before
+  applying the same gate.
+
+  Failure messages identify the metric, failed test case, or quality-policy
+  rule without copying generated model output into test logs.
+
+  ## Usage
+
+      defmodule MyApp.AnswerTest do
+        use ExUnit.Case
+        use Aludel.ExUnit
+
+        test "answers with the expected city" do
+          output = MyApp.answer("What is the capital of France?")
+
+          assert_evaluation(output, %{
+            "type" => "exact_match",
+            "value" => "Paris"
+          })
+        end
+      end
+
+  The helpers can also be called as qualified functions without `use`.
+  """
+
+  alias Aludel.Evals
+  alias Aludel.Evals.AssertionEvaluator
+  alias Aludel.Evals.Metric.Context
+  alias Aludel.Evals.Report
+  alias Aludel.Evals.Suite
+  alias Aludel.Evals.SuiteRun
+  alias Aludel.Prompts.PromptVersion
+  alias Aludel.Providers.Provider
+
+  @max_failure_items 20
+  @max_text_characters 1_000
+
+  @typedoc "An assertion accepted by `Aludel.Evals.AssertionEvaluator`."
+  @type evaluation_assertion :: map()
+
+  @doc false
+  defmacro __using__(_options) do
+    quote do
+      import Aludel.ExUnit,
+        only: [
+          assert_evaluation: 2,
+          assert_evaluations: 2,
+          assert_suite: 3,
+          assert_suite: 4,
+          assert_suite_run: 1
+        ]
+    end
+  end
+
+  @doc """
+  Evaluates one assertion and returns its normalized result when it passes.
+
+  The input can be generated output text or an `Aludel.Evals.Metric.Context`.
+  A failed, invalid, unsupported, or unavailable evaluator raises
+  `ExUnit.AssertionError` with bounded diagnostic evidence. Generated output
+  and expected values are omitted from the failure message.
+  """
+  @spec assert_evaluation(Context.t() | String.t(), evaluation_assertion()) :: map()
+  def assert_evaluation(input, assertion) when is_map(assertion) do
+    result = AssertionEvaluator.evaluate(input, assertion)
+
+    if result["passed"] do
+      result
+    else
+      fail_assertion(evaluation_failure_message(result))
+    end
+  end
+
+  @doc """
+  Evaluates a non-empty list of assertions and returns the ordered results.
+
+  All assertions run so one failure reports every non-passing metric, up to a
+  bounded diagnostic limit. Raises `ExUnit.AssertionError` when the list is
+  empty or any assertion does not pass.
+  """
+  @spec assert_evaluations(Context.t() | String.t(), [evaluation_assertion()]) :: [map()]
+  def assert_evaluations(_input, []) do
+    fail_assertion("Evaluation requires at least one assertion")
+  end
+
+  def assert_evaluations(input, assertions) when is_list(assertions) do
+    results = Enum.map(assertions, &AssertionEvaluator.evaluate(input, &1))
+
+    failures =
+      results
+      |> Enum.with_index(1)
+      |> Enum.reject(fn {result, _index} -> result["passed"] end)
+
+    if failures == [] do
+      results
+    else
+      fail_assertion(evaluations_failure_message(results, failures))
+    end
+  end
+
+  @doc """
+  Requires an existing persisted suite run to have an effective passing status.
+
+  A stored quality-policy result determines the effective status when present.
+  Otherwise, every test case must pass and an empty run fails. The passing run
+  is returned unchanged so callers can make additional assertions about it.
+  """
+  @spec assert_suite_run(SuiteRun.t()) :: SuiteRun.t()
+  def assert_suite_run(%SuiteRun{} = suite_run) do
+    report = Report.from_suite_run(suite_run)
+
+    if report.status == "passed" do
+      suite_run
+    else
+      fail_assertion(suite_failure_message(report))
+    end
+  end
+
+  @doc """
+  Executes, persists, and gates an evaluation suite from an ExUnit test.
+
+  Sampling options are forwarded to `Aludel.Evals.execute_suite/4`. A completed
+  non-passing run remains persisted before this helper raises. Configuration or
+  execution errors raise with a stable error category.
+  """
+  @spec assert_suite(Suite.t(), PromptVersion.t(), Provider.t(), keyword()) :: SuiteRun.t()
+  def assert_suite(suite, prompt_version, provider, options \\ [])
+
+  def assert_suite(
+        %Suite{} = suite,
+        %PromptVersion{} = prompt_version,
+        %Provider{} = provider,
+        options
+      )
+      when is_list(options) do
+    with :ok <- validate_prompt_version(suite, prompt_version),
+         {:ok, suite_run} <- execute_suite(suite, prompt_version, provider, options) do
+      assert_suite_run(suite_run)
+    else
+      {:error, reason} ->
+        fail_assertion("Evaluation suite could not run: #{execution_error_category(reason)}")
+    end
+  end
+
+  defp validate_prompt_version(suite, prompt_version) do
+    if suite.prompt_id == prompt_version.prompt_id do
+      :ok
+    else
+      {:error, :prompt_version_mismatch}
+    end
+  end
+
+  defp execute_suite(suite, prompt_version, provider, options) do
+    Evals.execute_suite(suite, prompt_version, provider, options)
+  rescue
+    _error ->
+      {:error, :execution_failed}
+  catch
+    _kind, _reason ->
+      {:error, :execution_failed}
+  end
+
+  defp evaluation_failure_message(result) do
+    [
+      "Evaluation assertion failed",
+      "Metric: #{display_text(result["type"], "unknown")}",
+      "Score: #{display_text(result["score"], "unavailable")}",
+      "Evaluator: #{evaluator_status(result)}",
+      "Reason: #{display_text(result["reason"], "Assertion did not pass")}"
+    ]
+    |> Enum.join("\n")
+  end
+
+  defp evaluations_failure_message(results, failures) do
+    failure_lines =
+      failures
+      |> Enum.take(@max_failure_items)
+      |> Enum.map(fn {failure, index} ->
+        "[#{index}] #{display_text(failure["type"], "unknown")} " <>
+          "(score #{display_text(failure["score"], "unavailable")}, " <>
+          "evaluator #{evaluator_status(failure)}): " <>
+          display_text(failure["reason"], "Assertion did not pass")
+      end)
+
+    omitted_count = length(failures) - length(failure_lines)
+
+    [
+      "#{length(failures)} of #{length(results)} evaluation assertions failed",
+      failure_lines,
+      omitted_line(omitted_count)
+    ]
+    |> List.flatten()
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join("\n")
+  end
+
+  defp suite_failure_message(report) do
+    failed_cases =
+      report.results
+      |> Enum.reject(& &1["passed"])
+      |> Enum.flat_map(&failed_case_lines/1)
+
+    all_details = failed_cases ++ policy_failure_lines(report.quality_policy)
+    details = Enum.take(all_details, @max_failure_items)
+    omitted_count = length(all_details) - length(details)
+
+    [
+      "Evaluation suite did not pass",
+      "Status: #{report.status}",
+      "Suite run: #{display_text(report.suite_run_id, "unknown")}",
+      suite_summary(report.summary),
+      empty_run_line(report.summary),
+      details,
+      omitted_line(omitted_count)
+    ]
+    |> List.flatten()
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join("\n")
+  end
+
+  defp failed_case_lines(result) do
+    failures =
+      result
+      |> Map.get("assertion_results", [])
+      |> Enum.reject(& &1["passed"])
+
+    case failures do
+      [] ->
+        ["Test case #{display_text(result["test_case_id"], "unknown")}: Evaluation failed"]
+
+      failures ->
+        Enum.map(failures, fn failure ->
+          "Test case #{display_text(result["test_case_id"], "unknown")}: " <>
+            "#{display_text(failure["type"], "assertion")} - " <>
+            display_text(failure["reason"], "Assertion did not pass")
+        end)
+    end
+  end
+
+  defp policy_failure_lines(nil) do
+    []
+  end
+
+  defp policy_failure_lines(policy) do
+    policy
+    |> Map.get("rules", [])
+    |> Enum.reject(&(&1["status"] == "passed"))
+    |> Enum.map(fn rule ->
+      "Policy #{display_text(rule["id"], "rule")} " <>
+        "[#{display_text(rule["status"], "unknown")}]: " <>
+        display_text(rule["reason"], "Quality policy rule did not pass")
+    end)
+  end
+
+  defp suite_summary(summary) do
+    "Summary: #{summary["passed"]} passed, #{summary["failed"]} failed, " <>
+      "#{summary["pass_rate"]}% pass rate"
+  end
+
+  defp empty_run_line(%{"total" => 0}) do
+    "No evaluation cases were available"
+  end
+
+  defp empty_run_line(_summary) do
+    nil
+  end
+
+  defp evaluator_status(%{"evaluator" => %{"status" => status}}) do
+    display_text(status, "unavailable")
+  end
+
+  defp evaluator_status(_result) do
+    "unavailable"
+  end
+
+  defp execution_error_category(reason) when is_atom(reason) do
+    Atom.to_string(reason)
+  end
+
+  defp execution_error_category(reason) when is_tuple(reason) and tuple_size(reason) > 0 do
+    reason
+    |> elem(0)
+    |> execution_error_category()
+  end
+
+  defp execution_error_category(_reason) do
+    "execution_failed"
+  end
+
+  defp omitted_line(count) when count > 0 do
+    "... and #{count} more failures"
+  end
+
+  defp omitted_line(_count) do
+    nil
+  end
+
+  defp display_text(nil, fallback) do
+    fallback
+  end
+
+  defp display_text(value, fallback) do
+    value
+    |> to_string()
+    |> String.replace(~r/[\x00-\x1F\x7F]/u, " ")
+    |> String.replace(~r/\s+/u, " ")
+    |> String.trim()
+    |> String.slice(0, @max_text_characters)
+    |> case do
+      "" -> fallback
+      text -> text
+    end
+  end
+
+  defp fail_assertion(message) do
+    raise ExUnit.AssertionError, message: message
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -33,6 +33,7 @@ defmodule Aludel.MixProject do
           "README.md",
           "guides/features.md",
           "guides/evaluations.md",
+          "guides/ex_unit.md",
           "guides/reporters.md",
           "guides/embedding.md",
           "CHANGELOG.md",
@@ -43,6 +44,7 @@ defmodule Aludel.MixProject do
           Guides: [
             "guides/features.md",
             "guides/evaluations.md",
+            "guides/ex_unit.md",
             "guides/reporters.md",
             "guides/embedding.md"
           ],

--- a/test/aludel/ex_unit_test.exs
+++ b/test/aludel/ex_unit_test.exs
@@ -1,0 +1,292 @@
+defmodule Aludel.ExUnitTest do
+  use Aludel.DataCase
+  use Aludel.ExUnit
+
+  import Mox
+
+  alias Aludel.Evals
+  alias Aludel.Evals.Metric.Context
+  alias Aludel.Evals.SuiteRun
+  alias Aludel.Interfaces.HttpClientMock
+
+  setup :set_mox_from_context
+  setup :verify_on_exit!
+
+  describe "assert_evaluation/2" do
+    test "returns the normalized result when the assertion passes" do
+      result =
+        assert_evaluation("Paris", %{
+          "type" => "exact_match",
+          "value" => "Paris"
+        })
+
+      assert result["passed"]
+      assert result["type"] == "exact_match"
+      assert result["score"] == 100.0
+    end
+
+    test "accepts contextual metric input" do
+      context =
+        Context.new("Paris",
+          expected: "Paris",
+          rendered_input: "What is the capital of France?"
+        )
+
+      result =
+        assert_evaluation(context, %{
+          "type" => "contains",
+          "value" => "Paris"
+        })
+
+      assert result["passed"]
+    end
+
+    test "raises a concise assertion error without including generated output" do
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_evaluation("private generated response", %{
+            "type" => "exact_match",
+            "value" => "expected response"
+          })
+        end
+
+      assert error.message =~ "Evaluation assertion failed"
+      assert error.message =~ "Metric: exact_match"
+      assert error.message =~ "Score: 0.0"
+      refute error.message =~ "private generated response"
+      refute error.message =~ "expected response"
+    end
+
+    test "reports unsupported assertion types as evaluation failures" do
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_evaluation("response", %{"type" => "missing_metric"})
+        end
+
+      assert error.message =~ "Metric: missing_metric"
+      assert error.message =~ "Evaluator: unavailable"
+      assert error.message =~ "Unsupported metric type"
+    end
+  end
+
+  describe "assert_evaluations/2" do
+    test "returns ordered results when every assertion passes" do
+      results =
+        assert_evaluations("Paris, France", [
+          %{"type" => "contains", "value" => "Paris"},
+          %{"type" => "not_contains", "value" => "London"}
+        ])
+
+      assert Enum.map(results, & &1["type"]) == ["contains", "not_contains"]
+    end
+
+    test "reports every failed assertion with bounded, sanitized reasons" do
+      long_reason = String.duplicate("x", 3_000) <> "\nsecond line"
+
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_evaluations("output", [
+            %{"type" => "exact_match", "value" => "different"},
+            %{"type" => "missing_metric", "value" => long_reason}
+          ])
+        end
+
+      assert error.message =~ "2 of 2 evaluation assertions failed"
+      assert error.message =~ "[1] exact_match"
+      assert error.message =~ "[2] missing_metric"
+      refute error.message =~ "\nsecond line"
+      assert String.length(error.message) < 2_500
+    end
+
+    test "rejects an empty assertion list" do
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_evaluations("output", [])
+        end
+
+      assert error.message == "Evaluation requires at least one assertion"
+    end
+  end
+
+  describe "assert_suite_run/1" do
+    test "returns a suite run when its effective quality status passes" do
+      suite_run =
+        suite_run(%{
+          passed: 0,
+          failed: 1,
+          quality_policy_result: %{"status" => "passed", "rules" => []}
+        })
+
+      assert assert_suite_run(suite_run) == suite_run
+    end
+
+    test "raises with failed cases and policy evidence but no generated output" do
+      policy_reason =
+        "Cost exceeded\rthe configured limit " <>
+          String.duplicate("detail ", 300) <> "\nprivate trailing detail"
+
+      suite_run =
+        suite_run(%{
+          quality_policy_result: %{
+            "status" => "failed",
+            "rules" => [
+              %{
+                "id" => "cost\nlimit",
+                "status" => "failed",
+                "reason" => policy_reason
+              }
+            ]
+          }
+        })
+
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_suite_run(suite_run)
+        end
+
+      assert error.message =~ "Evaluation suite did not pass"
+      assert error.message =~ "Status: failed"
+      assert error.message =~ "Summary: 0 passed, 1 failed"
+      assert error.message =~ "Test case case-fail: exact_match"
+      assert error.message =~ "Policy cost limit [failed]: Cost exceeded the configured limit"
+      refute error.message =~ "private generated response"
+      refute error.message =~ "private trailing detail"
+      assert String.length(error.message) < 1_500
+    end
+
+    test "treats an empty policy-free run as a failure" do
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_suite_run(suite_run(%{passed: 0, failed: 0, results: []}))
+        end
+
+      assert error.message =~ "No evaluation cases were available"
+    end
+  end
+
+  describe "assert_suite/3 and assert_suite/4" do
+    test "executes, persists, and returns a passing suite run" do
+      stub(HttpClientMock, :request, fn _model, _prompt, _options ->
+        eval_response("Paris")
+      end)
+
+      {suite, version, provider} = executable_suite("Paris")
+
+      suite_run = assert_suite(suite, version, provider)
+
+      assert suite_run.passed == 1
+      assert Evals.get_suite_run!(suite_run.id).id == suite_run.id
+    end
+
+    test "persists a failed run before raising the quality-gate assertion" do
+      stub(HttpClientMock, :request, fn _model, _prompt, _options ->
+        eval_response("London")
+      end)
+
+      {suite, version, provider} = executable_suite("Paris")
+
+      assert_raise ExUnit.AssertionError, ~r/Evaluation suite did not pass/, fn ->
+        assert_suite(suite, version, provider)
+      end
+
+      assert [%SuiteRun{failed: 1}] = Evals.list_suite_runs()
+    end
+
+    test "turns pre-execution configuration errors into assertion failures" do
+      {suite, version, provider} = executable_suite("Paris")
+
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_suite(suite, version, provider, samples: 0)
+        end
+
+      assert error.message == "Evaluation suite could not run: invalid_sampling"
+      assert Evals.list_suite_runs() == []
+    end
+
+    test "rejects a prompt version from another prompt before execution" do
+      {suite, _version, provider} = executable_suite("Paris")
+      other_prompt = prompt_fixture()
+      {:ok, other_version} = Aludel.Prompts.create_prompt_version(other_prompt, "Other prompt")
+
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_suite(suite, other_version, provider)
+        end
+
+      assert error.message == "Evaluation suite could not run: prompt_version_mismatch"
+      assert Evals.list_suite_runs() == []
+    end
+
+    test "does not expose exception details from suite execution" do
+      stub(HttpClientMock, :request, fn _model, _prompt, _options ->
+        raise "private provider detail"
+      end)
+
+      {suite, version, provider} = executable_suite("Paris")
+
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_suite(suite, version, provider)
+        end
+
+      assert error.message == "Evaluation suite could not run: execution_failed"
+      refute error.message =~ "private provider detail"
+    end
+  end
+
+  defp executable_suite(expected) do
+    prompt = prompt_fixture()
+    suite = suite_fixture(%{prompt_id: prompt.id})
+    {:ok, version} = Aludel.Prompts.create_prompt_version(prompt, "Answer {{question}}")
+    provider = provider_fixture()
+
+    _test_case =
+      test_case_fixture(%{
+        suite_id: suite.id,
+        variable_values: %{"question" => "Capital of France?"},
+        assertions: [%{"type" => "exact_match", "value" => expected}]
+      })
+
+    {suite, version, provider}
+  end
+
+  defp suite_run(overrides) do
+    defaults = %{
+      id: "run-123",
+      suite_id: "suite-123",
+      prompt_version_id: "version-123",
+      provider_id: "provider-123",
+      passed: 0,
+      failed: 1,
+      avg_score: Decimal.new("0"),
+      avg_cost_usd: nil,
+      avg_latency_ms: nil,
+      total_cost_usd: nil,
+      cost_sample_count: 0,
+      total_latency_ms: nil,
+      latency_sample_count: 0,
+      quality_policy_result: nil,
+      results: [
+        %{
+          "test_case_id" => "case-fail",
+          "test_case_metadata" => %{},
+          "passed" => false,
+          "score" => 0.0,
+          "output" => "private generated response",
+          "assertion_results" => [
+            %{
+              "type" => "exact_match",
+              "passed" => false,
+              "score" => 0.0,
+              "reason" => "Output did not match exactly",
+              "evaluator" => %{"status" => "completed"}
+            }
+          ]
+        }
+      ]
+    }
+
+    struct!(SuiteRun, Map.merge(defaults, overrides))
+  end
+end


### PR DESCRIPTION
## Motivation

Application teams need to evaluate generated output inside ordinary ExUnit tests and apply the same stored quality decisions used by Aludel's dashboard, reporters, and headless task. Previously, callers had to assemble those checks and failure messages themselves.

## What changed

- Added `Aludel.ExUnit` with single and multiple inline metric assertions.
- Added a gate for existing persisted suite runs using the normalized report status.
- Added an execute-and-persist suite assertion with sampling options and prompt-version ownership validation.
- Kept completed failed suite runs persisted for later inspection while rejecting invalid pre-execution configuration without creating a run.
- Bounded and normalized diagnostic text while omitting generated output, expected values, and exception details from failure messages.
- Added README discovery, a focused HexDocs guide, evaluation and feature-guide cross-links, and complete wiki examples.

## Test Plan

- Added 15 focused tests covering successful and failed inline assertions, contextual inputs, multiple failures, empty assertions, policy-aware suite status, empty runs, persistence timing, sampling validation, prompt ownership, and exception privacy.
- The full suite passes with 822 tests and no failures.
- Compile, formatting, unused dependency, Credo, Sobelow, and Dialyzer checks pass.
- Production-environment compilation, HexDocs generation, Hex package assembly, wiki link validation, runtime-durability review, and security diff review pass.

## Next Steps

This pull request is limited to native ExUnit evaluation helpers and their documentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ExUnit assertions for evaluating generated output, multiple evaluations, persisted suite runs, and complete evaluation suites.
  * Added support for executing and persisting suite results as quality gates in application tests and CI.
  * Added concise, sanitized failure diagnostics that identify failed metrics, cases, and policy rules without exposing generated or expected values.

* **Documentation**
  * Added an ExUnit integration guide and updated evaluation and feature documentation with usage examples and setup guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->