### PR TITLE
feat(web): configure judge assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Use a rubric judge when correctness depends on meaning instead of an exact strin
 
 Replace the placeholder with the ID of a configured provider.
 
+In the dashboard, add or edit a suite test case, choose **rubric judge** in the visual assertion editor, then select a built-in judge or enter a custom rubric. The same controls set the judge provider, pass threshold, optional reference answer, and optional grounding context. JSON assertions remain available for direct editing, and persisted judge assertions run unchanged from the dashboard, `mix aludel.eval`, ExUnit, and the Elixir API.
+
 The catalog includes correctness, relevance, faithfulness, safety, refusal quality, PII protection, and hallucination checks. Aludel records the resolved rubric and template version alongside score, reasoning, duration, provider, model, token usage, cost, and structured evaluator status.
 
 See the [evaluation guide](https://hexdocs.pm/aludel/evaluations.html#custom-rubric-judge), [rubric judge guide](https://github.com/ccarvalho-eng/aludel/wiki/Rubric-Judges), and [judge catalog](https://github.com/ccarvalho-eng/aludel/wiki/Judge-Catalog).

--- a/guides/evaluations.md
+++ b/guides/evaluations.md
@@ -129,7 +129,7 @@ Use a rubric judge when correctness depends on meaning rather than an exact stri
 ]
 ```
 
-Author rubric assertions in the JSON assertion editor. Scores range from 0 to 100, and Aludel derives the pass or fail result from `threshold`; a model-provided verdict is never trusted. Evaluation evidence is bounded and sent as untrusted JSON data so content under test cannot replace the rubric or output contract.
+In the dashboard's visual assertion editor, choose `rubric judge`, select **Custom rubric**, and configure the rubric, judge provider, threshold, optional reference answer, and optional grounding context. The JSON assertion editor accepts the same fields. Scores range from 0 to 100, and Aludel derives the pass or fail result from `threshold`; a model-provided verdict is never trusted. Evaluation evidence is bounded and sent as untrusted JSON data so content under test cannot replace the rubric or output contract.
 
 For common checks, replace `rubric` with a versioned built-in `template`:
 
@@ -155,6 +155,8 @@ For common checks, replace `rubric` with a versioned built-in `template`:
 | `hallucination` | Fabricated facts, citations, entities, tool results, or outcomes |
 
 Templates and custom rubrics are mutually exclusive. Aludel records the resolved rubric and template version with each result, so a historical run retains the criteria it used.
+
+To configure a template visually, choose `rubric judge`, keep **Built-in judge** selected, choose one of the seven versioned templates, and select a configured judge provider. Persisted judge assertions have the same execution behavior in the dashboard, `mix aludel.eval`, ExUnit, file-based suites, and the Elixir API; the visual controls are a dashboard authoring feature.
 
 ### Inspect metric context and evaluator details
 

--- a/guides/features.md
+++ b/guides/features.md
@@ -79,6 +79,8 @@ The suite UI supports:
 
 Built-in metrics are `contains`, `not_contains`, `regex`, `exact_match`, `json_field`, `json_deep_compare`, and `rubric_judge`. See the [Evaluation Guide](evaluations.md) for examples and programmatic policy configuration.
 
+The visual assertion editor configures either a built-in judge template or a custom rubric, a separate judge provider, a 0–100 pass threshold, an optional reference answer, and optional grounding context. The raw JSON editor exposes the same assertion contract. Once saved, judge assertions run through the dashboard, Mix CLI, ExUnit, file-based suites, and the Elixir API.
+
 ## Reusable datasets
 
 Datasets are ordered collections of evaluation examples that can be reused by multiple suites. A dataset entry can contain:

--- a/lib/aludel/evals/assertion_parser.ex
+++ b/lib/aludel/evals/assertion_parser.ex
@@ -104,6 +104,17 @@ defmodule Aludel.Evals.AssertionParser do
     |> Map.put("assertion_threshold_#{idx}", format_threshold(assertion["threshold"]))
   end
 
+  defp maybe_put_assertion_value(params, idx, %{"type" => "rubric_judge"} = assertion) do
+    params
+    |> Map.put("assertion_rubric_source_#{idx}", rubric_source(assertion))
+    |> Map.put("assertion_template_#{idx}", assertion["template"] || "")
+    |> Map.put("assertion_rubric_#{idx}", assertion["rubric"] || "")
+    |> Map.put("assertion_provider_id_#{idx}", assertion["provider_id"] || "")
+    |> Map.put("assertion_threshold_#{idx}", format_threshold(assertion["threshold"]))
+    |> put_evidence_form_value(idx, "expected", assertion["expected"])
+    |> put_evidence_form_value(idx, "context", assertion["context"])
+  end
+
   defp maybe_put_assertion_value(params, idx, assertion) do
     Map.put(params, "assertion_value_#{idx}", assertion["value"] || "")
   end
@@ -131,11 +142,18 @@ defmodule Aludel.Evals.AssertionParser do
                  idx
                ),
              {:ok, threshold} <-
-               parse_threshold(Map.get(assertion_params, "assertion_threshold_#{idx}", ""), idx) do
+               parse_threshold(
+                 Map.get(assertion_params, "assertion_threshold_#{idx}", ""),
+                 idx,
+                 "json_deep_compare"
+               ) do
           {:ok,
            %{"type" => type, "expected" => expected}
            |> maybe_put_threshold(threshold)}
         end
+
+      "rubric_judge" ->
+        build_visual_rubric_judge(assertion_params, idx, :strict)
 
       _other ->
         {:ok,
@@ -171,6 +189,9 @@ defmodule Aludel.Evals.AssertionParser do
          |> maybe_put_preview_threshold(
            Map.get(assertion_params, "assertion_threshold_#{idx}", "")
          )}
+
+      "rubric_judge" ->
+        build_visual_rubric_judge(assertion_params, idx, :preview)
 
       _other ->
         {:ok,
@@ -363,22 +384,83 @@ defmodule Aludel.Evals.AssertionParser do
      "Assertion at index #{idx}: json_deep_compare type requires valid JSON in the expected payload"}
   end
 
-  defp parse_threshold("", _idx), do: {:ok, nil}
+  defp build_visual_rubric_judge(assertion_params, idx, :strict) do
+    with {:ok, source} <- parse_rubric_source(assertion_params, idx),
+         {:ok, threshold} <-
+           parse_threshold(
+             Map.get(assertion_params, "assertion_threshold_#{idx}", ""),
+             idx,
+             "rubric_judge"
+           ) do
+      assertion =
+        %{
+          "type" => "rubric_judge",
+          "provider_id" => Map.get(assertion_params, "assertion_provider_id_#{idx}", "")
+        }
+        |> Map.merge(source)
+        |> maybe_put_threshold(threshold)
+        |> maybe_put_evidence(assertion_params, idx, "expected")
+        |> maybe_put_evidence(assertion_params, idx, "context")
 
-  defp parse_threshold(value, idx) when is_binary(value) do
+      {:ok, assertion}
+    end
+  end
+
+  defp build_visual_rubric_judge(assertion_params, idx, :preview) do
+    source = preview_rubric_source(assertion_params, idx)
+
+    assertion =
+      %{
+        "type" => "rubric_judge",
+        "provider_id" => Map.get(assertion_params, "assertion_provider_id_#{idx}", "")
+      }
+      |> Map.merge(source)
+      |> maybe_put_preview_threshold(Map.get(assertion_params, "assertion_threshold_#{idx}", ""))
+      |> maybe_put_evidence(assertion_params, idx, "expected")
+      |> maybe_put_evidence(assertion_params, idx, "context")
+
+    {:ok, assertion}
+  end
+
+  defp parse_rubric_source(assertion_params, idx) do
+    case Map.get(assertion_params, "assertion_rubric_source_#{idx}", "template") do
+      "template" ->
+        {:ok, %{"template" => Map.get(assertion_params, "assertion_template_#{idx}", "")}}
+
+      "custom" ->
+        {:ok, %{"rubric" => Map.get(assertion_params, "assertion_rubric_#{idx}", "")}}
+
+      _other ->
+        {:error, "Assertion at index #{idx}: rubric_judge type requires a valid rubric source"}
+    end
+  end
+
+  defp preview_rubric_source(assertion_params, idx) do
+    case Map.get(assertion_params, "assertion_rubric_source_#{idx}", "template") do
+      "custom" ->
+        %{"rubric" => Map.get(assertion_params, "assertion_rubric_#{idx}", "")}
+
+      _other ->
+        %{"template" => Map.get(assertion_params, "assertion_template_#{idx}", "")}
+    end
+  end
+
+  defp parse_threshold("", _idx, _type) do
+    {:ok, nil}
+  end
+
+  defp parse_threshold(value, idx, type) when is_binary(value) do
     case Float.parse(String.trim(value)) do
       {threshold, ""} ->
         {:ok, threshold}
 
       _other ->
-        {:error,
-         "Assertion at index #{idx}: json_deep_compare type requires a threshold between 0 and 100"}
+        {:error, "Assertion at index #{idx}: #{type} type requires a threshold between 0 and 100"}
     end
   end
 
-  defp parse_threshold(_value, idx) do
-    {:error,
-     "Assertion at index #{idx}: json_deep_compare type requires a threshold between 0 and 100"}
+  defp parse_threshold(_value, idx, type) do
+    {:error, "Assertion at index #{idx}: #{type} type requires a threshold between 0 and 100"}
   end
 
   defp collect_visual_assertion(assertion_params, idx, {:ok, assertions}, mode) do
@@ -390,6 +472,40 @@ defmodule Aludel.Evals.AssertionParser do
 
   defp maybe_put_threshold(assertion, nil), do: assertion
   defp maybe_put_threshold(assertion, threshold), do: Map.put(assertion, "threshold", threshold)
+
+  defp put_evidence_form_value(params, idx, field, value) do
+    params
+    |> Map.put("assertion_#{field}_#{idx}", format_evidence(value))
+    |> Map.put("assertion_#{field}_json_value_#{idx}", Jason.encode!(value))
+  end
+
+  defp maybe_put_evidence(assertion, assertion_params, idx, field) do
+    text = Map.get(assertion_params, "assertion_#{field}_#{idx}", "")
+    encoded = Map.get(assertion_params, "assertion_#{field}_json_value_#{idx}", "")
+
+    case parse_optional_evidence(text, encoded) do
+      :omit -> assertion
+      {:put, value} -> Map.put(assertion, field, value)
+    end
+  end
+
+  defp parse_optional_evidence(value, _encoded) when value in [nil, ""] do
+    :omit
+  end
+
+  defp parse_optional_evidence(value, encoded) when is_binary(value) do
+    case Jason.decode(encoded) do
+      {:ok, decoded} ->
+        if value == format_evidence(decoded), do: {:put, decoded}, else: {:put, value}
+
+      _other ->
+        {:put, value}
+    end
+  end
+
+  defp parse_optional_evidence(value, _encoded) do
+    {:put, value}
+  end
 
   defp maybe_put_preview_expected(assertion, value) when is_binary(value) do
     case Jason.decode(value) do
@@ -451,6 +567,30 @@ defmodule Aludel.Evals.AssertionParser do
 
   defp format_threshold(nil), do: ""
   defp format_threshold(value), do: to_string(value)
+
+  defp rubric_source(%{"rubric" => rubric}) when is_binary(rubric) do
+    "custom"
+  end
+
+  defp rubric_source(_assertion) do
+    "template"
+  end
+
+  defp format_evidence(nil) do
+    ""
+  end
+
+  defp format_evidence(value) when is_binary(value) do
+    value
+  end
+
+  defp format_evidence(value) when is_map(value) or is_list(value) do
+    Jason.encode!(value)
+  end
+
+  defp format_evidence(value) do
+    to_string(value)
+  end
 
   defp blank_string?(value) when is_binary(value), do: String.trim(value) == ""
   defp blank_string?(_value), do: false

--- a/lib/aludel/web/live/suite_live/new.ex
+++ b/lib/aludel/web/live/suite_live/new.ex
@@ -8,9 +8,11 @@ defmodule Aludel.Web.SuiteLive.New do
   alias Aludel.Evals
   alias Aludel.Evals.AssertionParser
   alias Aludel.Evals.DocumentIngestion
+  alias Aludel.Evals.JudgeCatalog
   alias Aludel.Evals.Suite
   alias Aludel.Projects
   alias Aludel.Prompts
+  alias Aludel.Providers
 
   @document_upload_names Enum.map(0..49, &:"test_case_documents_#{&1}")
   @document_upload_accept ~w(.pdf .png .jpg .jpeg .csv .json .txt)
@@ -157,6 +159,7 @@ defmodule Aludel.Web.SuiteLive.New do
     changeset = Evals.change_suite(suite, initial_data)
     prompts = Prompts.list_prompts_with_versions()
     projects = Projects.list_projects(type: :suite)
+    providers = Providers.list_providers()
 
     socket
     |> assign(:page_title, "New Suite")
@@ -164,6 +167,8 @@ defmodule Aludel.Web.SuiteLive.New do
     |> assign(:form, to_form(changeset))
     |> assign(:prompts, prompts)
     |> assign(:projects, projects)
+    |> assign(:providers, providers)
+    |> assign(:judge_templates, JudgeCatalog.all())
     |> assign(:test_cases, [])
     |> assign(:selected_prompt, nil)
     |> assign(:assertion_edit_mode, %{})
@@ -175,6 +180,7 @@ defmodule Aludel.Web.SuiteLive.New do
     changeset = Evals.change_suite(suite)
     prompts = Prompts.list_prompts_with_versions()
     projects = Projects.list_projects(type: :suite)
+    providers = Providers.list_providers()
 
     # Get the selected prompt if suite has one
     selected_prompt =
@@ -202,6 +208,8 @@ defmodule Aludel.Web.SuiteLive.New do
     |> assign(:form, to_form(changeset))
     |> assign(:prompts, prompts)
     |> assign(:projects, projects)
+    |> assign(:providers, providers)
+    |> assign(:judge_templates, JudgeCatalog.all())
     |> assign(:test_cases, test_cases)
     |> assign(:selected_prompt, selected_prompt)
     |> assign(:assertion_edit_mode, %{})
@@ -611,6 +619,36 @@ defmodule Aludel.Web.SuiteLive.New do
 
       value ->
         value
+    end
+  end
+
+  defp assertion_rubric_source_value(test_case_id, idx, form_params, assertion) do
+    case assertion_form_value(test_case_id, idx, "rubric_source", form_params) do
+      nil -> if is_binary(assertion["rubric"]), do: "custom", else: "template"
+      value -> value
+    end
+  end
+
+  defp assertion_evidence_json_value(
+         test_case_id,
+         idx,
+         field_name,
+         form_params,
+         assertion
+       ) do
+    case assertion_form_value(test_case_id, idx, "#{field_name}_json_value", form_params) do
+      nil -> Jason.encode!(Map.get(assertion, field_name))
+      value -> value
+    end
+  end
+
+  defp judge_provider_options(providers, selected_id) do
+    options = Enum.map(providers, &{&1.name, &1.id})
+
+    if selected_id == "" or Enum.any?(providers, &(&1.id == selected_id)) do
+      options
+    else
+      [{"Unavailable provider (#{selected_id})", selected_id} | options]
     end
   end
 

--- a/lib/aludel/web/live/suite_live/new.html.heex
+++ b/lib/aludel/web/live/suite_live/new.html.heex
@@ -192,7 +192,8 @@
                                 {"regex", "regex"},
                                 {"exact", "exact_match"},
                                 {"json field", "json_field"},
-                                {"json deep compare", "json_deep_compare"}
+                                {"json deep compare", "json_deep_compare"},
+                                {"rubric judge", "rubric_judge"}
                               ]}
                               class="w-full select text-[13px]"
                             />
@@ -321,6 +322,173 @@
                                 />
                               </div>
                             </div>
+                          <% current_type == "rubric_judge" -> %>
+                            <% rubric_source =
+                              assertion_rubric_source_value(
+                                test_case.id,
+                                idx,
+                                @test_case_form_params,
+                                assertion
+                              ) %>
+                            <% judge_provider_id =
+                              assertion_text_value(
+                                test_case.id,
+                                idx,
+                                "provider_id",
+                                "provider_id",
+                                @test_case_form_params,
+                                assertion
+                              ) %>
+                            <div
+                              id={"judge-fields-#{test_case.id}-#{idx}"}
+                              style="display: flex; flex-direction: column; gap: 10px;"
+                            >
+                              <.input
+                                type="select"
+                                name={"suite[test_cases][#{test_case.id}][assertions][assertion_rubric_source_#{idx}]"}
+                                value={rubric_source}
+                                options={[
+                                  {"Built-in judge", "template"},
+                                  {"Custom rubric", "custom"}
+                                ]}
+                                id={"test_case_#{test_case.id}_assertion_rubric_source_#{idx}"}
+                                label="Judge criteria"
+                              />
+                              <%= if rubric_source == "custom" do %>
+                                <.input
+                                  type="textarea"
+                                  name={"suite[test_cases][#{test_case.id}][assertions][assertion_rubric_#{idx}]"}
+                                  value={
+                                    assertion_text_value(
+                                      test_case.id,
+                                      idx,
+                                      "rubric",
+                                      "rubric",
+                                      @test_case_form_params,
+                                      assertion
+                                    )
+                                  }
+                                  id={"test_case_#{test_case.id}_assertion_rubric_#{idx}"}
+                                  label="Custom rubric"
+                                  maxlength="4000"
+                                  rows="5"
+                                  placeholder="Describe exactly how the response should be scored."
+                                />
+                              <% else %>
+                                <.input
+                                  type="select"
+                                  name={"suite[test_cases][#{test_case.id}][assertions][assertion_template_#{idx}]"}
+                                  value={
+                                    assertion_text_value(
+                                      test_case.id,
+                                      idx,
+                                      "template",
+                                      "template",
+                                      @test_case_form_params,
+                                      assertion
+                                    )
+                                  }
+                                  options={
+                                    Enum.map(
+                                      @judge_templates,
+                                      &{"#{&1.name} — #{&1.description}", &1.id}
+                                    )
+                                  }
+                                  prompt="Choose a built-in judge"
+                                  id={"test_case_#{test_case.id}_assertion_template_#{idx}"}
+                                  label="Built-in judge"
+                                />
+                              <% end %>
+                              <.input
+                                type="select"
+                                name={"suite[test_cases][#{test_case.id}][assertions][assertion_provider_id_#{idx}]"}
+                                value={judge_provider_id}
+                                options={judge_provider_options(@providers, judge_provider_id)}
+                                prompt="Choose a judge provider"
+                                id={"test_case_#{test_case.id}_assertion_provider_id_#{idx}"}
+                                label="Judge provider"
+                              />
+                              <.input
+                                type="number"
+                                name={"suite[test_cases][#{test_case.id}][assertions][assertion_threshold_#{idx}]"}
+                                value={
+                                  assertion_threshold_value(
+                                    test_case.id,
+                                    idx,
+                                    @test_case_form_params,
+                                    assertion
+                                  )
+                                }
+                                min="0"
+                                max="100"
+                                step="0.1"
+                                placeholder="80"
+                                id={"test_case_#{test_case.id}_assertion_threshold_#{idx}"}
+                                label="Pass threshold (defaults to 80)"
+                              />
+                              <.input
+                                type="textarea"
+                                name={"suite[test_cases][#{test_case.id}][assertions][assertion_expected_#{idx}]"}
+                                value={
+                                  assertion_text_value(
+                                    test_case.id,
+                                    idx,
+                                    "expected",
+                                    "expected",
+                                    @test_case_form_params,
+                                    assertion
+                                  )
+                                }
+                                id={"test_case_#{test_case.id}_assertion_expected_#{idx}"}
+                                label="Reference answer (optional)"
+                                rows="3"
+                              />
+                              <input
+                                type="hidden"
+                                name={"suite[test_cases][#{test_case.id}][assertions][assertion_expected_json_value_#{idx}]"}
+                                value={
+                                  assertion_evidence_json_value(
+                                    test_case.id,
+                                    idx,
+                                    "expected",
+                                    @test_case_form_params,
+                                    assertion
+                                  )
+                                }
+                                id={"test_case_#{test_case.id}_assertion_expected_json_value_#{idx}"}
+                              />
+                              <.input
+                                type="textarea"
+                                name={"suite[test_cases][#{test_case.id}][assertions][assertion_context_#{idx}]"}
+                                value={
+                                  assertion_text_value(
+                                    test_case.id,
+                                    idx,
+                                    "context",
+                                    "context",
+                                    @test_case_form_params,
+                                    assertion
+                                  )
+                                }
+                                id={"test_case_#{test_case.id}_assertion_context_#{idx}"}
+                                label="Grounding context (optional)"
+                                rows="3"
+                              />
+                              <input
+                                type="hidden"
+                                name={"suite[test_cases][#{test_case.id}][assertions][assertion_context_json_value_#{idx}]"}
+                                value={
+                                  assertion_evidence_json_value(
+                                    test_case.id,
+                                    idx,
+                                    "context",
+                                    @test_case_form_params,
+                                    assertion
+                                  )
+                                }
+                                id={"test_case_#{test_case.id}_assertion_context_json_value_#{idx}"}
+                              />
+                            </div>
                           <% true -> %>
                             <div
                               id={"value-field-#{test_case.id}-#{idx}"}
@@ -361,7 +529,7 @@
                       class="json-editor"
                     />
                     <div style="font-size: 11px; color: var(--text-muted); margin-top: 4px;">
-                      Types: contains, not_contains, regex, exact_match, json_field, json_deep_compare
+                      Types: contains, not_contains, regex, exact_match, json_field, json_deep_compare, rubric_judge
                     </div>
                   <% end %>
                 </div>

--- a/lib/aludel/web/live/suite_live/show.ex
+++ b/lib/aludel/web/live/suite_live/show.ex
@@ -12,6 +12,7 @@ defmodule Aludel.Web.SuiteLive.Show do
   alias Aludel.Evals
   alias Aludel.Evals.AssertionParser
   alias Aludel.Evals.DocumentIngestion
+  alias Aludel.Evals.JudgeCatalog
   alias Aludel.Evals.TestCaseEditor
   alias Aludel.Evals.TestCaseImporter
   alias Aludel.Executor
@@ -64,6 +65,7 @@ defmodule Aludel.Web.SuiteLive.Show do
       |> assign(:dataset_import_form, to_form(%{"dataset_id" => ""}, as: :dataset_import))
       |> assign(:dataset_import_status, nil)
       |> assign(:providers, providers)
+      |> assign(:judge_templates, JudgeCatalog.all())
       |> assign(:execution_mode_label, Executor.execution_mode_label())
       |> assign(:suite_runs, suite_runs)
       |> assign(:running, false)
@@ -699,6 +701,28 @@ defmodule Aludel.Web.SuiteLive.Show do
     ]
   end
 
+  defp judge_source_label(%{"template" => template_id}) do
+    case JudgeCatalog.fetch(template_id) do
+      {:ok, template} -> template.name
+      :error -> template_id
+    end
+  end
+
+  defp judge_source_label(%{"rubric" => _rubric}) do
+    "Custom rubric"
+  end
+
+  defp judge_source_label(_assertion) do
+    "Invalid configuration"
+  end
+
+  defp judge_provider_name(providers, provider_id) do
+    case Enum.find(providers, &(&1.id == provider_id)) do
+      nil -> "Unavailable provider (#{provider_id})"
+      provider -> provider.name
+    end
+  end
+
   defp deep_compare_rows(comparisons) when is_map(comparisons) do
     comparisons
     |> Enum.sort_by(fn {path, _details} -> path end)
@@ -866,6 +890,30 @@ defmodule Aludel.Web.SuiteLive.Show do
 
       value ->
         value
+    end
+  end
+
+  defp assertion_rubric_source_value(assertion, test_case_params, idx) do
+    case assertion_form_value(test_case_params, idx, "rubric_source") do
+      nil -> if is_binary(assertion["rubric"]), do: "custom", else: "template"
+      value -> value
+    end
+  end
+
+  defp assertion_evidence_json_value(assertion, test_case_params, idx, field_name) do
+    case assertion_form_value(test_case_params, idx, "#{field_name}_json_value") do
+      nil -> Jason.encode!(Map.get(assertion, field_name))
+      value -> value
+    end
+  end
+
+  defp judge_provider_options(providers, selected_id) do
+    options = Enum.map(providers, &{&1.name, &1.id})
+
+    if selected_id == "" or Enum.any?(providers, &(&1.id == selected_id)) do
+      options
+    else
+      [{"Unavailable provider (#{selected_id})", selected_id} | options]
     end
   end
 

--- a/lib/aludel/web/live/suite_live/show.html.heex
+++ b/lib/aludel/web/live/suite_live/show.html.heex
@@ -486,7 +486,8 @@
                                     {"regex", "regex"},
                                     {"exact", "exact_match"},
                                     {"json field", "json_field"},
-                                    {"json deep compare", "json_deep_compare"}
+                                    {"json deep compare", "json_deep_compare"},
+                                    {"rubric judge", "rubric_judge"}
                                   ]}
                                   class="w-full select text-[13px]"
                                 />
@@ -612,6 +613,166 @@
                                     />
                                   </div>
                                 </div>
+                              <% current_type == "rubric_judge" -> %>
+                                <% rubric_source =
+                                  assertion_rubric_source_value(
+                                    assertion,
+                                    @editing_test_case_params,
+                                    idx
+                                  ) %>
+                                <% judge_provider_id =
+                                  assertion_text_value(
+                                    assertion,
+                                    @editing_test_case_params,
+                                    idx,
+                                    "provider_id",
+                                    "provider_id"
+                                  ) %>
+                                <div
+                                  id={"judge-fields-#{test_case.id}-#{idx}"}
+                                  style="display: flex; flex-direction: column; gap: 10px;"
+                                >
+                                  <.input
+                                    type="select"
+                                    name={"#{@test_case_form.name}[assertions][assertion_rubric_source_#{idx}]"}
+                                    value={rubric_source}
+                                    options={[
+                                      {"Built-in judge", "template"},
+                                      {"Custom rubric", "custom"}
+                                    ]}
+                                    id={"#{@test_case_form.id}_assertion_rubric_source_#{idx}"}
+                                    label="Judge criteria"
+                                  />
+                                  <%= if rubric_source == "custom" do %>
+                                    <.input
+                                      type="textarea"
+                                      name={"#{@test_case_form.name}[assertions][assertion_rubric_#{idx}]"}
+                                      value={
+                                        assertion_text_value(
+                                          assertion,
+                                          @editing_test_case_params,
+                                          idx,
+                                          "rubric",
+                                          "rubric"
+                                        )
+                                      }
+                                      id={"#{@test_case_form.id}_assertion_rubric_#{idx}"}
+                                      label="Custom rubric"
+                                      maxlength="4000"
+                                      rows="5"
+                                      placeholder="Describe exactly how the response should be scored."
+                                    />
+                                  <% else %>
+                                    <.input
+                                      type="select"
+                                      name={"#{@test_case_form.name}[assertions][assertion_template_#{idx}]"}
+                                      value={
+                                        assertion_text_value(
+                                          assertion,
+                                          @editing_test_case_params,
+                                          idx,
+                                          "template",
+                                          "template"
+                                        )
+                                      }
+                                      options={
+                                        Enum.map(
+                                          @judge_templates,
+                                          &{"#{&1.name} — #{&1.description}", &1.id}
+                                        )
+                                      }
+                                      prompt="Choose a built-in judge"
+                                      id={"#{@test_case_form.id}_assertion_template_#{idx}"}
+                                      label="Built-in judge"
+                                    />
+                                  <% end %>
+                                  <.input
+                                    type="select"
+                                    name={"#{@test_case_form.name}[assertions][assertion_provider_id_#{idx}]"}
+                                    value={judge_provider_id}
+                                    options={
+                                      judge_provider_options(@providers, judge_provider_id)
+                                    }
+                                    prompt="Choose a judge provider"
+                                    id={"#{@test_case_form.id}_assertion_provider_id_#{idx}"}
+                                    label="Judge provider"
+                                  />
+                                  <.input
+                                    type="number"
+                                    name={"#{@test_case_form.name}[assertions][assertion_threshold_#{idx}]"}
+                                    value={
+                                      assertion_threshold_value(
+                                        assertion,
+                                        @editing_test_case_params,
+                                        idx
+                                      )
+                                    }
+                                    min="0"
+                                    max="100"
+                                    step="0.1"
+                                    placeholder="80"
+                                    id={"#{@test_case_form.id}_assertion_threshold_#{idx}"}
+                                    label="Pass threshold (defaults to 80)"
+                                  />
+                                  <.input
+                                    type="textarea"
+                                    name={"#{@test_case_form.name}[assertions][assertion_expected_#{idx}]"}
+                                    value={
+                                      assertion_text_value(
+                                        assertion,
+                                        @editing_test_case_params,
+                                        idx,
+                                        "expected",
+                                        "expected"
+                                      )
+                                    }
+                                    id={"#{@test_case_form.id}_assertion_expected_#{idx}"}
+                                    label="Reference answer (optional)"
+                                    rows="3"
+                                  />
+                                  <input
+                                    type="hidden"
+                                    name={"#{@test_case_form.name}[assertions][assertion_expected_json_value_#{idx}]"}
+                                    value={
+                                      assertion_evidence_json_value(
+                                        assertion,
+                                        @editing_test_case_params,
+                                        idx,
+                                        "expected"
+                                      )
+                                    }
+                                    id={"#{@test_case_form.id}_assertion_expected_json_value_#{idx}"}
+                                  />
+                                  <.input
+                                    type="textarea"
+                                    name={"#{@test_case_form.name}[assertions][assertion_context_#{idx}]"}
+                                    value={
+                                      assertion_text_value(
+                                        assertion,
+                                        @editing_test_case_params,
+                                        idx,
+                                        "context",
+                                        "context"
+                                      )
+                                    }
+                                    id={"#{@test_case_form.id}_assertion_context_#{idx}"}
+                                    label="Grounding context (optional)"
+                                    rows="3"
+                                  />
+                                  <input
+                                    type="hidden"
+                                    name={"#{@test_case_form.name}[assertions][assertion_context_json_value_#{idx}]"}
+                                    value={
+                                      assertion_evidence_json_value(
+                                        assertion,
+                                        @editing_test_case_params,
+                                        idx,
+                                        "context"
+                                      )
+                                    }
+                                    id={"#{@test_case_form.id}_assertion_context_json_value_#{idx}"}
+                                  />
+                                </div>
                               <% true -> %>
                                 <div
                                   id={"value-field-#{test_case.id}-#{idx}"}
@@ -651,7 +812,7 @@
                           class="json-editor w-full textarea"
                         />
                         <div style="font-size: 11px; color: var(--text-muted); margin-top: 4px;">
-                          Types: contains, not_contains, regex, exact_match, json_field, json_deep_compare
+                          Types: contains, not_contains, regex, exact_match, json_field, json_deep_compare, rubric_judge
                         </div>
                       <% end %>
                       <%= if @test_case_form[:assertions_json].errors != [] do %>
@@ -797,7 +958,7 @@
                         No assertions
                       </div>
                     <% else %>
-                      <%= for assertion <- test_case.assertions do %>
+                      <%= for {assertion, assertion_idx} <- Enum.with_index(test_case.assertions) do %>
                         <div style="font-size: 13px; margin-bottom: 6px; padding: 6px 8px; background: var(--bg-secondary); border-radius: 4px;">
                           <%= cond do %>
                             <% assertion["type"] == "json_field" -> %>
@@ -836,6 +997,59 @@
                                   </span>
                                 </div>
                               <% end %>
+                            <% assertion["type"] == "rubric_judge" -> %>
+                              <div
+                                id={"rubric-judge-#{test_case.id}-#{assertion_idx}"}
+                                style="display: flex; flex-direction: column; gap: 4px;"
+                              >
+                                <div>
+                                  <span style="font-weight: 600; color: var(--accent);">
+                                    rubric judge:
+                                  </span>
+                                  <span style="color: var(--text-primary);">
+                                    {judge_source_label(assertion)}
+                                  </span>
+                                </div>
+                                <div style="font-size: 12px; padding-left: 8px;">
+                                  <span style="color: var(--text-secondary);">provider:</span>
+                                  <span style="color: var(--text-primary);">
+                                    {judge_provider_name(@providers, assertion["provider_id"])}
+                                  </span>
+                                </div>
+                                <div style="font-size: 12px; padding-left: 8px;">
+                                  <span style="color: var(--text-secondary);">threshold:</span>
+                                  <span style="font-family: monospace; color: var(--text-primary);">
+                                    {assertion["threshold"] || 80}%
+                                  </span>
+                                </div>
+                                <div
+                                  :if={assertion["rubric"]}
+                                  style="font-size: 12px; padding-left: 8px;"
+                                >
+                                  <span style="color: var(--text-secondary);">rubric:</span>
+                                  <span style="color: var(--text-primary);">
+                                    {assertion["rubric"]}
+                                  </span>
+                                </div>
+                                <div
+                                  :if={assertion["expected"]}
+                                  style="font-size: 12px; padding-left: 8px;"
+                                >
+                                  <span style="color: var(--text-secondary);">reference:</span>
+                                  <span style="color: var(--text-primary);">
+                                    {display_value(assertion["expected"])}
+                                  </span>
+                                </div>
+                                <div
+                                  :if={assertion["context"]}
+                                  style="font-size: 12px; padding-left: 8px;"
+                                >
+                                  <span style="color: var(--text-secondary);">context:</span>
+                                  <span style="color: var(--text-primary);">
+                                    {display_value(assertion["context"])}
+                                  </span>
+                                </div>
+                              </div>
                             <% true -> %>
                               <span style="font-weight: 600; color: var(--accent);">
                                 {assertion["type"]}:

--- a/test/aludel/evals/assertion_parser_test.exs
+++ b/test/aludel/evals/assertion_parser_test.exs
@@ -123,6 +123,59 @@ defmodule Aludel.Evals.AssertionParserTest do
       assert assertion["template"] == "correctness"
     end
 
+    test "parses built-in rubric judges in visual mode" do
+      provider_id = Ecto.UUID.generate()
+
+      params = %{
+        "assertions" => %{
+          "assertion_type_0" => "rubric_judge",
+          "assertion_rubric_source_0" => "template",
+          "assertion_template_0" => "faithfulness",
+          "assertion_provider_id_0" => provider_id,
+          "assertion_threshold_0" => "85",
+          "assertion_expected_0" => "Reference answer",
+          "assertion_context_0" => "Grounding evidence"
+        }
+      }
+
+      assert {:ok,
+              [
+                %{
+                  "type" => "rubric_judge",
+                  "template" => "faithfulness",
+                  "provider_id" => ^provider_id,
+                  "threshold" => 85.0,
+                  "expected" => "Reference answer",
+                  "context" => "Grounding evidence"
+                }
+              ]} = AssertionParser.parse(:visual, params)
+    end
+
+    test "parses custom rubric judges in visual mode" do
+      provider_id = Ecto.UUID.generate()
+
+      params = %{
+        "assertions" => %{
+          "assertion_type_0" => "rubric_judge",
+          "assertion_rubric_source_0" => "custom",
+          "assertion_rubric_0" => "Score factual correctness.",
+          "assertion_provider_id_0" => provider_id,
+          "assertion_threshold_0" => "",
+          "assertion_expected_0" => "",
+          "assertion_context_0" => ""
+        }
+      }
+
+      assert {:ok,
+              [
+                %{
+                  "type" => "rubric_judge",
+                  "rubric" => "Score factual correctness.",
+                  "provider_id" => ^provider_id
+                }
+              ]} = AssertionParser.parse(:visual, params)
+    end
+
     test "rejects unknown or ambiguous rubric judge templates" do
       provider_id = Ecto.UUID.generate()
 
@@ -319,6 +372,55 @@ defmodule Aludel.Evals.AssertionParserTest do
 
       assert assertions_json =~ "\"type\": \"json_deep_compare\""
       assert expected_json =~ "\"status\": \"ok\""
+    end
+
+    test "builds visual params for rubric judge assertions" do
+      provider_id = Ecto.UUID.generate()
+
+      assertions = [
+        %{
+          "type" => "rubric_judge",
+          "template" => "correctness",
+          "provider_id" => provider_id,
+          "threshold" => 90,
+          "expected" => "Paris",
+          "context" => "The question asks for France's capital."
+        },
+        %{
+          "type" => "rubric_judge",
+          "rubric" => "Prefer concise, correct answers.",
+          "provider_id" => provider_id
+        }
+      ]
+
+      assert %{
+               "assertions" => %{
+                 "assertion_rubric_source_0" => "template",
+                 "assertion_template_0" => "correctness",
+                 "assertion_provider_id_0" => ^provider_id,
+                 "assertion_threshold_0" => "90",
+                 "assertion_expected_0" => "Paris",
+                 "assertion_context_0" => "The question asks for France's capital.",
+                 "assertion_rubric_source_1" => "custom",
+                 "assertion_rubric_1" => "Prefer concise, correct answers."
+               }
+             } = AssertionParser.build_form_params(assertions)
+    end
+
+    test "preserves typed rubric evidence through visual form params" do
+      assertions = [
+        %{
+          "type" => "rubric_judge",
+          "template" => "faithfulness",
+          "provider_id" => Ecto.UUID.generate(),
+          "expected" => %{"answer" => "Paris"},
+          "context" => ["Grounding", %{"source" => "atlas"}]
+        }
+      ]
+
+      params = AssertionParser.build_form_params(assertions)
+
+      assert {:ok, ^assertions} = AssertionParser.parse(:visual, params)
     end
   end
 

--- a/test/aludel_web/live/suite_live/new_test.exs
+++ b/test/aludel_web/live/suite_live/new_test.exs
@@ -3,6 +3,7 @@ defmodule Aludel.Web.SuiteLive.NewTest do
 
   import Phoenix.LiveViewTest
   import Aludel.PromptsFixtures
+  import Aludel.ProvidersFixtures
 
   alias Aludel.Evals
   alias Aludel.Projects
@@ -154,6 +155,86 @@ defmodule Aludel.Web.SuiteLive.NewTest do
       assert has_element?(view, "#test_case_#{test_case_id}_assertion_expected_json_0")
       assert has_element?(view, "#test_case_#{test_case_id}_assertion_threshold_0[value='80.0']")
       refute has_element?(view, "#value-field-#{test_case_id}-0")
+    end
+
+    test "creates a suite with a visually configured built-in judge", %{conn: conn} do
+      prompt = prompt_fixture_with_version(%{template: "Question: {{question}}"})
+      provider = provider_fixture(%{name: "Judge provider"})
+      {:ok, view, _html} = live(conn, "/suites/new")
+
+      view
+      |> form("#suite-form", suite: %{name: "Judge Suite", prompt_id: prompt.id})
+      |> render_change()
+
+      view
+      |> element("[phx-click='add_test_case']")
+      |> render_click()
+
+      test_case_id = List.first(:sys.get_state(view.pid).socket.assigns.test_cases).id
+      render_click(view, "add_assertion", %{"id" => test_case_id})
+
+      assert has_element?(view, "#assertion-type-#{test_case_id}-0", "rubric judge")
+
+      view
+      |> form("#suite-form",
+        suite: %{
+          name: "Judge Suite",
+          prompt_id: prompt.id,
+          test_cases: %{
+            test_case_id => %{
+              variable_values: %{question: "What is the capital of France?"},
+              assertions: %{assertion_type_0: "rubric_judge"}
+            }
+          }
+        }
+      )
+      |> render_change()
+
+      assert has_element?(view, "#judge-fields-#{test_case_id}-0")
+      assert has_element?(view, "#test_case_#{test_case_id}_assertion_template_0")
+      assert has_element?(view, "#test_case_#{test_case_id}_assertion_provider_id_0")
+
+      params = %{
+        name: "Judge Suite",
+        prompt_id: prompt.id,
+        test_cases: %{
+          test_case_id => %{
+            variable_values: %{question: "What is the capital of France?"},
+            assertions: %{
+              assertion_type_0: "rubric_judge",
+              assertion_rubric_source_0: "template",
+              assertion_template_0: "correctness",
+              assertion_provider_id_0: provider.id,
+              assertion_threshold_0: "90",
+              assertion_expected_0: "Paris",
+              assertion_context_0: "Geography question"
+            }
+          }
+        }
+      }
+
+      view
+      |> form("#suite-form", suite: params)
+      |> render_change()
+
+      view
+      |> form("#suite-form", suite: params)
+      |> render_submit()
+
+      {path, _flash} = assert_redirect(view)
+      [_, suite_id] = Regex.run(~r{/suites/([^/]+)$}, path)
+      [test_case] = Evals.get_suite_with_test_cases_and_prompt!(suite_id).test_cases
+
+      assert test_case.assertions == [
+               %{
+                 "type" => "rubric_judge",
+                 "template" => "correctness",
+                 "provider_id" => provider.id,
+                 "threshold" => 90.0,
+                 "expected" => "Paris",
+                 "context" => "Geography question"
+               }
+             ]
     end
 
     test "switches from deep compare to json_field controls", %{conn: conn} do

--- a/test/aludel_web/live/suite_live/show_test.exs
+++ b/test/aludel_web/live/suite_live/show_test.exs
@@ -12,6 +12,7 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
   alias Aludel.Datasets
   alias Aludel.Evals
   alias Aludel.Interfaces.HttpClientMock
+  alias Aludel.Providers
 
   test "displays suite details", %{conn: conn} do
     prompt = prompt_fixture(%{name: "Test Prompt"})
@@ -508,6 +509,140 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
   end
 
   describe "assertion editing" do
+    test "preserves an unavailable judge provider while editing", %{conn: conn} do
+      suite = suite_fixture()
+      provider = provider_fixture(%{name: "Removed judge"})
+
+      test_case =
+        test_case_fixture(%{
+          suite_id: suite.id,
+          assertions: [
+            %{
+              "type" => "rubric_judge",
+              "template" => "correctness",
+              "provider_id" => provider.id
+            }
+          ]
+        })
+
+      assert {:ok, _provider} = Providers.delete_provider(provider)
+      {:ok, view, _html} = live(conn, "/suites/#{suite.id}")
+
+      view
+      |> element("[phx-click='edit_test_case'][phx-value-id='#{test_case.id}']")
+      |> render_click()
+
+      assert has_element?(
+               view,
+               "#test_case_assertion_provider_id_0 option[value='#{provider.id}']",
+               "Unavailable provider"
+             )
+
+      view
+      |> form("#test-case-form-#{test_case.id}",
+        test_case: %{
+          id: test_case.id,
+          variable_values: %{},
+          assertions: %{
+            assertion_type_0: "rubric_judge",
+            assertion_rubric_source_0: "template",
+            assertion_template_0: "correctness",
+            assertion_provider_id_0: provider.id,
+            assertion_threshold_0: ""
+          }
+        }
+      )
+      |> render_submit()
+
+      [assertion] = Evals.get_test_case!(test_case.id).assertions
+      assert assertion["provider_id"] == provider.id
+    end
+
+    test "edits a custom rubric judge through visual controls", %{conn: conn} do
+      suite = suite_fixture()
+      provider = provider_fixture(%{name: "Review provider"})
+
+      test_case =
+        test_case_fixture(%{
+          suite_id: suite.id,
+          assertions: [
+            %{
+              "type" => "rubric_judge",
+              "template" => "relevance",
+              "provider_id" => provider.id,
+              "threshold" => 80
+            }
+          ]
+        })
+
+      {:ok, view, _html} = live(conn, "/suites/#{suite.id}")
+
+      assert has_element?(view, "#rubric-judge-#{test_case.id}-0", "Relevance")
+      assert has_element?(view, "#rubric-judge-#{test_case.id}-0", "Review provider")
+
+      view
+      |> element("[phx-click='edit_test_case'][phx-value-id='#{test_case.id}']")
+      |> render_click()
+
+      assert has_element?(view, "#judge-fields-#{test_case.id}-0")
+      assert has_element?(view, "#test_case_assertion_template_0")
+
+      view
+      |> form("#test-case-form-#{test_case.id}",
+        test_case: %{
+          id: test_case.id,
+          variable_values: %{},
+          assertions: %{
+            assertion_type_0: "rubric_judge",
+            assertion_rubric_source_0: "custom",
+            assertion_template_0: "relevance",
+            assertion_provider_id_0: provider.id,
+            assertion_threshold_0: "80",
+            assertion_expected_0: "",
+            assertion_context_0: ""
+          }
+        }
+      )
+      |> render_change()
+
+      assert has_element?(view, "#test_case_assertion_rubric_0")
+
+      view
+      |> form("#test-case-form-#{test_case.id}",
+        test_case: %{
+          id: test_case.id,
+          variable_values: %{},
+          assertions: %{
+            assertion_type_0: "rubric_judge",
+            assertion_rubric_source_0: "custom",
+            assertion_rubric_0: "The answer must be accurate and concise.",
+            assertion_provider_id_0: provider.id,
+            assertion_threshold_0: "85",
+            assertion_expected_0: "Reference",
+            assertion_context_0: "Grounding"
+          }
+        }
+      )
+      |> render_submit()
+
+      updated = Evals.get_test_case!(test_case.id)
+
+      assert updated.assertions == [
+               %{
+                 "type" => "rubric_judge",
+                 "rubric" => "The answer must be accurate and concise.",
+                 "provider_id" => provider.id,
+                 "threshold" => 85.0,
+                 "expected" => "Reference",
+                 "context" => "Grounding"
+               }
+             ]
+
+      assert has_element?(view, "#rubric-judge-#{test_case.id}-0", "Custom rubric")
+      assert has_element?(view, "#rubric-judge-#{test_case.id}-0", "Reference")
+      assert has_element?(view, "#rubric-judge-#{test_case.id}-0", "Grounding")
+    end
+
     test "edits a test case with deep compare assertions without crashing", %{conn: conn} do
       suite = suite_fixture()
 


### PR DESCRIPTION
## Motivation

Suite authors could execute rubric judges but had to write assertion JSON. This adds complete dashboard authoring and inspection for built-in and custom judges while preserving the same persisted assertion contract across interfaces.

## Test Plan

- Added parser coverage for built-in and custom judge forms, default thresholds, validation, and typed evidence round trips.
- Added LiveView coverage for creating, editing, inspecting, and preserving an unavailable judge provider.
- Verified the full test suite, formatting, static analysis, security checks, production compilation, documentation build, dependency advisories, and Hex package dry run.

## Next Steps

Repeated-run sampling controls will follow in a separate focused pull request.