### PR TITLE
feat(web): configure repeated sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Aludel stores field-level comparison details, per-test match scores, and suite-r
 
 Nondeterministic model output can make a single response misleading. Run each test case up to 20 times and reduce the ordered attempts into one result:
 
+In the dashboard, open a suite and set **Attempts per test case** plus the **Pass rule** before running it. Choose all attempts, any attempt, a strict majority, or a minimum pass-rate percentage. Each sampled result expands to show the aggregate decision and every ordered attempt.
+
 ```elixir
 {:ok, suite_run} =
   Aludel.Evals.execute_suite(suite, prompt_version, provider,
@@ -126,6 +128,8 @@ Nondeterministic model output can make a single response misleading. Run each te
 ```
 
 Reducers support `:all`, `:any`, strict `:majority`, and a minimum pass rate. Aludel retains every attempt, sums token usage, cost, and latency, and reruns the complete sampling configuration when a result is retried.
+
+Dashboard percentages map to the API's `0.0`–`1.0` minimum pass rate. File-based suites expose the same configuration to `mix aludel.eval`, while the Elixir API and ExUnit accept the sampling options directly.
 
 See the [evaluation guide](https://hexdocs.pm/aludel/evaluations.html#repeat-nondeterministic-cases) and [repeated sampling wiki guide](https://github.com/ccarvalho-eng/aludel/wiki/Repeated-Sampling) for the full result shape and reducer examples.
 

--- a/guides/evaluations.md
+++ b/guides/evaluations.md
@@ -193,6 +193,8 @@ Evaluator status is one of `completed`, `error`, or `unavailable`. Failures use 
 
 Run each test case more than once when a single model response is not reliable enough to make a decision:
 
+From a suite page in the dashboard, choose **Attempts per test case** and a **Pass rule** before selecting **Run Suite**. The minimum pass-rate control uses a percentage from 0 through 100; the API form below uses the equivalent decimal rate from `0.0` through `1.0`.
+
 ```elixir
 {:ok, suite_run} =
   Aludel.Evals.execute_suite(suite, prompt_version, provider,
@@ -204,6 +206,8 @@ Run each test case more than once when a single model response is not reliable e
 `samples` accepts `1` through `20`. Reducers can require `:all`, `:any`, a strict `:majority`, or a minimum rate such as `{:minimum_pass_rate, 0.8}`. Invalid sampling configuration returns an error before any model request is made.
 
 Sampled results retain every ordered attempt and record passed and failed counts, pass rate, reducer configuration, and the representative attempt. Token usage, cost, and latency are summed across attempts; available scores are averaged. Retrying a sampled test case reruns the complete persisted sampling configuration and replaces the previous aggregate.
+
+The dashboard renders the aggregate evidence in each sampled test case result and provides an expandable list of attempt outcomes, scores, and outputs. The same persisted result shape is available through exports and reporters. For headless execution, put the sampling settings in a JSON or YAML suite file and run it with `mix aludel.eval`; ExUnit and the Elixir API accept the keyword options directly.
 
 ### Enforce a versioned quality policy
 

--- a/guides/features.md
+++ b/guides/features.md
@@ -81,6 +81,8 @@ Built-in metrics are `contains`, `not_contains`, `regex`, `exact_match`, `json_f
 
 The visual assertion editor configures either a built-in judge template or a custom rubric, a separate judge provider, a 0–100 pass threshold, an optional reference answer, and optional grounding context. The raw JSON editor exposes the same assertion contract. Once saved, judge assertions run through the dashboard, Mix CLI, ExUnit, file-based suites, and the Elixir API.
 
+The suite run panel configures one to 20 attempts per test case and all, any, strict-majority, or minimum pass-rate reduction. Sampled results expose the aggregate pass evidence and an expandable ordered attempt history. File-based suites provide the same settings to the Mix CLI, while ExUnit and the Elixir API accept them as execution options.
+
 ## Reusable datasets
 
 Datasets are ordered collections of evaluation examples that can be reused by multiple suites. A dataset entry can contain:

--- a/lib/aludel/web/live/suite_live/show.ex
+++ b/lib/aludel/web/live/suite_live/show.ex
@@ -13,6 +13,7 @@ defmodule Aludel.Web.SuiteLive.Show do
   alias Aludel.Evals.AssertionParser
   alias Aludel.Evals.DocumentIngestion
   alias Aludel.Evals.JudgeCatalog
+  alias Aludel.Evals.Sampling
   alias Aludel.Evals.TestCaseEditor
   alias Aludel.Evals.TestCaseImporter
   alias Aludel.Executor
@@ -141,7 +142,11 @@ defmodule Aludel.Web.SuiteLive.Show do
          |> assign(:page_title, suite.name)
          |> assign(
            :run_suite_form,
-           build_run_suite_form(default_version_id, socket.assigns.selected_provider_id)
+           build_run_suite_form(
+             default_version_id,
+             socket.assigns.selected_provider_id,
+             socket.assigns.run_suite_form.params
+           )
          )
          |> assign(:editing_suite_metadata, false)
          |> put_flash(:info, "Suite updated successfully")}
@@ -162,7 +167,11 @@ defmodule Aludel.Web.SuiteLive.Show do
      )
      |> assign(
        :run_suite_form,
-       build_run_suite_form(version_id, socket.assigns.selected_provider_id)
+       build_run_suite_form(
+         version_id,
+         socket.assigns.selected_provider_id,
+         socket.assigns.run_suite_form.params
+       )
      )}
   end
 
@@ -173,7 +182,11 @@ defmodule Aludel.Web.SuiteLive.Show do
      |> assign(:selected_provider_id, provider_id)
      |> assign(
        :run_suite_form,
-       build_run_suite_form(socket.assigns.selected_version_id, provider_id)
+       build_run_suite_form(
+         socket.assigns.selected_version_id,
+         provider_id,
+         socket.assigns.run_suite_form.params
+       )
      )}
   end
 
@@ -190,7 +203,10 @@ defmodule Aludel.Web.SuiteLive.Show do
        :selected_prompt_version,
        selected_prompt_version(socket.assigns.prompt, version_id)
      )
-     |> assign(:run_suite_form, to_form(run_suite_params, as: :run_suite))}
+     |> assign(
+       :run_suite_form,
+       build_run_suite_form(version_id, provider_id, run_suite_params)
+     )}
   end
 
   @impl Phoenix.LiveView
@@ -488,7 +504,20 @@ defmodule Aludel.Web.SuiteLive.Show do
     else
       version_id = Map.get(run_suite_params, "version_id", socket.assigns.selected_version_id)
       provider_id = Map.get(run_suite_params, "provider_id", socket.assigns.selected_provider_id)
-      {:noreply, start_suite_execution(socket, version_id, provider_id)}
+
+      case sampling_options(run_suite_params) do
+        {:ok, opts} ->
+          {:noreply, start_suite_execution(socket, version_id, provider_id, opts)}
+
+        {:error, message} ->
+          {:noreply,
+           socket
+           |> assign(
+             :run_suite_form,
+             build_run_suite_form(version_id, provider_id, run_suite_params)
+           )
+           |> put_flash(:error, message)}
+      end
     end
   end
 
@@ -651,14 +680,71 @@ defmodule Aludel.Web.SuiteLive.Show do
     end
   end
 
-  defp build_run_suite_form(version_id, provider_id) do
-    to_form(
+  defp build_run_suite_form(version_id, provider_id, params \\ %{}) do
+    params =
       %{
+        "samples" => "1",
+        "reducer" => "all",
+        "minimum_pass_rate" => "80"
+      }
+      |> Map.merge(Map.take(params, ~w(samples reducer minimum_pass_rate)))
+      |> Map.merge(%{
         "version_id" => version_id,
         "provider_id" => provider_id
-      },
-      as: :run_suite
-    )
+      })
+
+    to_form(params, as: :run_suite)
+  end
+
+  defp sampling_options(params) do
+    with {:ok, samples} <- parse_samples(params["samples"]),
+         {:ok, reducer} <- parse_reducer(params["reducer"], params["minimum_pass_rate"]),
+         {:ok, _sampling} <- Sampling.new(samples: samples, reducer: reducer) do
+      {:ok, [samples: samples, reducer: reducer]}
+    else
+      {:error, {:invalid_sampling, message}} ->
+        {:error, "Invalid sampling configuration: #{message}"}
+
+      {:error, message} ->
+        {:error, message}
+    end
+  end
+
+  defp parse_samples(value) when is_binary(value) do
+    case Integer.parse(String.trim(value)) do
+      {samples, ""} when samples >= 1 and samples <= 20 -> {:ok, samples}
+      _other -> {:error, "Samples must be an integer between 1 and 20"}
+    end
+  end
+
+  defp parse_samples(_value) do
+    {:error, "Samples must be an integer between 1 and 20"}
+  end
+
+  defp parse_reducer(reducer, _minimum) when reducer in ~w(all any majority) do
+    {:ok, String.to_existing_atom(reducer)}
+  end
+
+  defp parse_reducer("minimum_pass_rate", minimum) do
+    case parse_percentage(minimum) do
+      {:ok, percentage} -> {:ok, {:minimum_pass_rate, percentage / 100}}
+      :error -> {:error, "Minimum pass rate must be a number between 0 and 100"}
+    end
+  end
+
+  defp parse_reducer(_reducer, _minimum) do
+    {:error, "Reducer must be all, any, majority, or minimum pass rate"}
+  end
+
+  defp parse_percentage(value) when is_binary(value) do
+    case Float.parse(String.trim(value)) do
+      {percentage, ""} when percentage >= 0 and percentage <= 100 -> {:ok, percentage}
+      _other -> :error
+    end
+  end
+
+  defp parse_percentage(_value) do
+    :error
   end
 
   defp selected_prompt_version(%{versions: versions}, version_id) when is_list(versions) do
@@ -747,6 +833,76 @@ defmodule Aludel.Web.SuiteLive.Show do
   defp format_score(score) when is_integer(score), do: format_score(score / 1)
   defp format_score(score) when is_float(score), do: :erlang.float_to_binary(score, decimals: 1)
   defp format_score(_score), do: nil
+
+  defp sampled_result?(%{
+         "sampling" => %{"samples" => samples},
+         "attempts" => attempts
+       })
+       when is_integer(samples) and samples > 1 and is_list(attempts) do
+    true
+  end
+
+  defp sampled_result?(_result) do
+    false
+  end
+
+  defp sampling_pass_summary(%{
+         "samples" => samples,
+         "passed_attempts" => passed_attempts
+       }) do
+    "#{passed_attempts} of #{samples} attempts passed"
+  end
+
+  defp sampling_pass_summary(_sampling) do
+    "Attempt summary unavailable"
+  end
+
+  defp sampling_reducer_label(%{
+         "reducer" => "minimum_pass_rate",
+         "minimum_pass_rate" => minimum_pass_rate
+       }) do
+    "At least #{format_percentage(minimum_pass_rate)}"
+  end
+
+  defp sampling_reducer_label(%{"reducer" => "all"}) do
+    "All attempts"
+  end
+
+  defp sampling_reducer_label(%{"reducer" => "any"}) do
+    "Any attempt"
+  end
+
+  defp sampling_reducer_label(%{"reducer" => "majority"}) do
+    "Strict majority"
+  end
+
+  defp sampling_reducer_label(_sampling) do
+    "Unknown pass rule"
+  end
+
+  defp sampling_pass_rate(%{"pass_rate" => pass_rate}) do
+    format_percentage(pass_rate)
+  end
+
+  defp sampling_pass_rate(_sampling) do
+    "N/A"
+  end
+
+  defp sampling_request_summary("1") do
+    "1 request"
+  end
+
+  defp sampling_request_summary(samples) do
+    "#{samples} requests"
+  end
+
+  defp format_percentage(rate) when is_number(rate) do
+    format_score(rate * 100) <> "%"
+  end
+
+  defp format_percentage(_rate) do
+    "N/A"
+  end
 
   defp display_value(nil), do: "null"
   defp display_value(value) when is_binary(value), do: value
@@ -987,12 +1143,13 @@ defmodule Aludel.Web.SuiteLive.Show do
     end
   end
 
-  defp start_suite_execution(socket, version_id, provider_id) do
+  defp start_suite_execution(socket, version_id, provider_id, opts) do
     case Evals.launch_suite_execution(
            self(),
            socket.assigns.suite.id,
            version_id,
-           provider_id
+           provider_id,
+           opts
          ) do
       {:ok, monitor_ref} ->
         socket

--- a/lib/aludel/web/live/suite_live/show.html.heex
+++ b/lib/aludel/web/live/suite_live/show.html.heex
@@ -111,6 +111,51 @@
               options={Enum.map(@providers, &{&1.name, &1.id})}
             />
           </div>
+          <div>
+            <.input
+              field={@run_suite_form[:samples]}
+              type="number"
+              label="Attempts per test case"
+              required
+              disabled={@running}
+              min="1"
+              max="20"
+              step="1"
+            />
+          </div>
+          <div>
+            <.input
+              field={@run_suite_form[:reducer]}
+              type="select"
+              label="Pass rule"
+              required
+              disabled={@running}
+              options={[
+                {"All attempts must pass", "all"},
+                {"Any attempt may pass", "any"},
+                {"Strict majority must pass", "majority"},
+                {"Minimum pass rate", "minimum_pass_rate"}
+              ]}
+            />
+          </div>
+          <div :if={@run_suite_form[:reducer].value == "minimum_pass_rate"}>
+            <.input
+              field={@run_suite_form[:minimum_pass_rate]}
+              type="number"
+              label="Minimum pass rate (%)"
+              required
+              disabled={@running}
+              min="0"
+              max="100"
+              step="0.1"
+            />
+          </div>
+          <div
+            id="sampling-request-count"
+            style="padding: 8px 10px; border-radius: 6px; background: var(--bg-tertiary); color: var(--text-secondary); font-size: 12px;"
+          >
+            {sampling_request_summary(@run_suite_form[:samples].value)} per test case. Every attempt is retained; judge assertions can add requests.
+          </div>
           <button
             id="run-suite-btn"
             type="submit"
@@ -1127,6 +1172,38 @@
               <div style="background-color: var(--bg-tertiary); padding: 16px; border-radius: 6px;">
                 <%= for result <- suite_run.results do %>
                   <div style="margin-bottom: 12px; border-radius: 8px; background: var(--bg-secondary); border: 1px solid var(--border); overflow: hidden;">
+                    <details
+                      :if={sampled_result?(result)}
+                      id={"suite-result-sampling-#{suite_run.id}-#{result["test_case_id"]}"}
+                      style="padding: 12px; border-bottom: 1px solid var(--border); background: color-mix(in srgb, var(--accent) 6%, transparent);"
+                    >
+                      <summary style="cursor: pointer; color: var(--text-primary); font-size: 12px; font-weight: 600;">
+                        {sampling_pass_summary(result["sampling"])} · {sampling_reducer_label(
+                          result["sampling"]
+                        )} · {sampling_pass_rate(result["sampling"])} pass rate
+                      </summary>
+                      <div style="display: flex; flex-direction: column; gap: 8px; margin-top: 10px;">
+                        <div
+                          :for={
+                            {attempt, attempt_number} <-
+                              Enum.with_index(result["attempts"], 1)
+                          }
+                          id={"suite-result-attempt-#{suite_run.id}-#{result["test_case_id"]}-#{attempt_number}"}
+                          style="padding: 10px; border-radius: 6px; background: var(--bg-secondary); border: 1px solid var(--border);"
+                        >
+                          <div style="display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 6px;">
+                            <strong style="font-size: 12px;">Attempt {attempt_number}</strong>
+                            <span style={"font-size: 11px; font-weight: 600; color: #{if attempt["passed"], do: "#10b981", else: "#f85149"}"}>
+                              {if attempt["passed"], do: "Passed", else: "Failed"}
+                              <%= if score = format_score(attempt["score"]) do %>
+                                · {score}%
+                              <% end %>
+                            </span>
+                          </div>
+                          <pre style="font-size: 12px; margin: 0; white-space: pre-wrap; color: var(--text-primary); line-height: 1.5;">{attempt["output"]}</pre>
+                        </div>
+                      </div>
+                    </details>
                     <%= if result["assertion_results"] && result["assertion_results"] != [] do %>
                       <div
                         id={"suite-result-assertions-#{suite_run.id}-#{result["test_case_id"]}"}

--- a/test/aludel_web/live/suite_live/show_test.exs
+++ b/test/aludel_web/live/suite_live/show_test.exs
@@ -1137,6 +1137,154 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
   end
 
   describe "suite execution" do
+    test "configures repeated sampling and minimum pass-rate reducers", %{conn: conn} do
+      prompt = prompt_fixture_with_version()
+      suite = suite_fixture(%{prompt_id: prompt.id})
+      provider = provider_fixture()
+      other_provider = provider_fixture(%{name: "Second provider"})
+      version = List.first(prompt.versions)
+
+      {:ok, view, _html} = live(conn, "/suites/#{suite.id}")
+
+      assert has_element?(view, "#run_suite_samples")
+      assert has_element?(view, "#run_suite_reducer-select[phx-hook='CustomSelect']")
+      refute has_element?(view, "#run_suite_minimum_pass_rate")
+
+      view
+      |> form("#run-suite-form",
+        run_suite: %{
+          version_id: version.id,
+          provider_id: provider.id,
+          samples: "5",
+          reducer: "minimum_pass_rate"
+        }
+      )
+      |> render_change()
+
+      assert has_element?(view, "#run_suite_minimum_pass_rate")
+
+      view
+      |> form("#run-suite-form",
+        run_suite: %{
+          version_id: version.id,
+          provider_id: provider.id,
+          samples: "5",
+          reducer: "minimum_pass_rate",
+          minimum_pass_rate: "80"
+        }
+      )
+      |> render_change()
+
+      assert has_element?(view, "#run_suite_minimum_pass_rate[value='80']")
+      assert has_element?(view, "#sampling-request-count", "5 requests per test case")
+
+      render_click(view, "select_provider", %{"provider_id" => other_provider.id})
+
+      assert has_element?(view, "#run_suite_samples[value='5']")
+      assert has_element?(view, "#run_suite_minimum_pass_rate[value='80']")
+    end
+
+    test "rejects invalid repeated sampling before starting execution", %{conn: conn} do
+      prompt = prompt_fixture_with_version()
+      suite = suite_fixture(%{prompt_id: prompt.id})
+      provider = provider_fixture()
+      version = List.first(prompt.versions)
+
+      {:ok, view, _html} = live(conn, "/suites/#{suite.id}")
+
+      view
+      |> form("#run-suite-form",
+        run_suite: %{
+          version_id: version.id,
+          provider_id: provider.id,
+          samples: "21",
+          reducer: "all"
+        }
+      )
+      |> render_submit()
+
+      assert has_element?(view, "#flash-error", "Samples must be an integer between 1 and 20")
+      refute has_element?(view, "#run-suite-btn[disabled]")
+      assert Evals.list_suite_runs_for_suite_with_associations(suite.id) == []
+
+      render_hook(view, "run_suite", %{
+        "run_suite" => %{
+          "version_id" => version.id,
+          "provider_id" => provider.id,
+          "samples" => "3",
+          "reducer" => "unknown"
+        }
+      })
+
+      assert has_element?(
+               view,
+               "#flash-error",
+               "Reducer must be all, any, majority, or minimum pass rate"
+             )
+
+      assert Evals.list_suite_runs_for_suite_with_associations(suite.id) == []
+    end
+
+    test "runs and inspects every sampled attempt", %{conn: conn} do
+      Mox.set_mox_global()
+      Aludel.DataCase.setup_mox_stub()
+
+      prompt = prompt_fixture_with_version(%{template: "Return a greeting"})
+      suite = suite_fixture(%{prompt_id: prompt.id})
+      provider = provider_fixture()
+      version = List.first(prompt.versions)
+
+      test_case =
+        test_case_fixture(%{
+          suite_id: suite.id,
+          assertions: [%{"type" => "contains", "value" => "Test response"}]
+        })
+
+      {:ok, view, _html} = live(conn, "/suites/#{suite.id}")
+
+      view
+      |> form("#run-suite-form",
+        run_suite: %{
+          version_id: version.id,
+          provider_id: provider.id,
+          samples: "3",
+          reducer: "minimum_pass_rate"
+        }
+      )
+      |> render_change()
+
+      view
+      |> form("#run-suite-form",
+        run_suite: %{
+          version_id: version.id,
+          provider_id: provider.id,
+          samples: "3",
+          reducer: "minimum_pass_rate",
+          minimum_pass_rate: "80"
+        }
+      )
+      |> render_submit()
+
+      assert_eventually(fn ->
+        has_element?(view, "#flash-info", "Suite executed successfully")
+      end)
+
+      [suite_run] = Evals.list_suite_runs_for_suite_with_associations(suite.id)
+      [result] = suite_run.results
+
+      assert result["sampling"]["samples"] == 3
+      assert result["sampling"]["reducer"] == "minimum_pass_rate"
+      assert result["sampling"]["minimum_pass_rate"] == 0.8
+      assert Enum.map(result["attempts"], & &1["attempt"]) == [1, 2, 3]
+
+      sampling_id = "#suite-result-sampling-#{suite_run.id}-#{test_case.id}"
+      assert has_element?(view, sampling_id, "3 of 3 attempts passed")
+      assert has_element?(view, sampling_id, "At least 80.0%")
+      assert has_element?(view, sampling_id, "100.0% pass rate")
+      assert has_element?(view, "#suite-result-attempt-#{suite_run.id}-#{test_case.id}-1")
+      assert has_element?(view, "#suite-result-attempt-#{suite_run.id}-#{test_case.id}-3")
+    end
+
     test "recovers when the background execution task fails", %{conn: conn} do
       prompt = prompt_fixture_with_version()
       suite = suite_fixture(%{prompt_id: prompt.id})


### PR DESCRIPTION
## Motivation

Repeated sampling was available through code and suite manifests but not through the dashboard. This adds bounded sampling controls to suite execution and makes aggregate evidence and every ordered attempt inspectable in the result UI.

## Test Plan

- Added LiveView coverage for defaults, conditional minimum-rate controls, selection preservation, invalid and unknown input rejection, and request-count guidance.
- Added an end-to-end three-attempt execution that verifies percentage conversion, persisted sampling metadata, ordered attempts, and rendered inspection details.
- Verified the full test suite, formatting, static analysis, security checks, production compilation, documentation build, dependency advisories, and Hex package dry run.
- Reviewed supervised-task lifecycle, duplicate submission handling, retry compatibility, historical result rendering, and request amplification bounds.

## Next Steps

Suite quality-policy management and result inspection will follow in a separate focused pull request.