### PR TITLE
fix(web): prevent dark theme navigation flash

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -46,6 +46,10 @@ const AutoDismissFlash = {
 
 // Theme switching logic
 function setTheme(theme) {
+  if (!['system', 'light', 'dark'].includes(theme)) {
+    theme = 'system'
+  }
+
   localStorage.setItem('theme', theme)
 
   let appliedTheme = theme
@@ -76,6 +80,13 @@ window.addEventListener('phx:set-theme', (e) => {
   const theme = e.target.getAttribute('data-phx-theme')
   if (theme) {
     setTheme(theme)
+  }
+})
+
+// Keep the theme in sync when another browser window changes it.
+window.addEventListener('storage', (e) => {
+  if (e.key === 'theme') {
+    setTheme(e.newValue || 'system')
   }
 })
 

--- a/lib/aludel/web/components/layouts.ex
+++ b/lib/aludel/web/components/layouts.ex
@@ -201,9 +201,9 @@ defmodule Aludel.Web.Layouts do
     assigns = assign(assigns, :active, active)
 
     ~H"""
-    <a href={@href} class={"aludel-nav-link #{@active}"}>
+    <.link navigate={@href} class={"aludel-nav-link #{@active}"}>
       {render_slot(@inner_block)}
-    </a>
+    </.link>
     """
   end
 end

--- a/lib/aludel/web/components/layouts/root.html.heex
+++ b/lib/aludel/web/components/layouts/root.html.heex
@@ -10,27 +10,26 @@
       {assigns[:page_title] || "Dashboard"}
     </.live_title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="stylesheet" href={asset_path(@conn, :css)} />
-    <script defer src={asset_path(@conn, :js)}>
-    </script>
     <script>
       (() => {
-        const setTheme = (theme) => {
-          if (theme === "system") {
-            localStorage.removeItem("phx:theme");
-            document.documentElement.removeAttribute("data-theme");
-          } else {
-            localStorage.setItem("phx:theme", theme);
-            document.documentElement.setAttribute("data-theme", theme);
-          }
-        };
-        if (!document.documentElement.hasAttribute("data-theme")) {
-          setTheme(localStorage.getItem("phx:theme") || "system");
+        let savedTheme = "system";
+
+        try {
+          savedTheme = localStorage.getItem("theme") || "system";
+        } catch (_error) {
+          // Storage can be unavailable in privacy-restricted browsing contexts.
         }
-        window.addEventListener("storage", (e) => e.key === "phx:theme" && setTheme(e.newValue || "system"));
-        
-        window.addEventListener("phx:set-theme", (e) => setTheme(e.target.dataset.phxTheme));
+
+        const theme = ["system", "light", "dark"].includes(savedTheme) ? savedTheme : "system";
+        const appliedTheme = theme === "system"
+          ? (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light")
+          : theme;
+
+        document.documentElement.setAttribute("data-theme", appliedTheme);
       })();
+    </script>
+    <link rel="stylesheet" href={asset_path(@conn, :css)} />
+    <script defer src={asset_path(@conn, :js)}>
     </script>
   </head>
   <body>

--- a/priv/static/app.js
+++ b/priv/static/app.js
@@ -22227,6 +22227,9 @@ removing illegal node: "${("outerHTML" in childNode && childNode.outerHTML || ch
     }
   };
   function setTheme(theme) {
+    if (!["system", "light", "dark"].includes(theme)) {
+      theme = "system";
+    }
     localStorage.setItem("theme", theme);
     let appliedTheme = theme;
     if (theme === "system") {
@@ -22249,6 +22252,11 @@ removing illegal node: "${("outerHTML" in childNode && childNode.outerHTML || ch
     const theme = e.target.getAttribute("data-phx-theme");
     if (theme) {
       setTheme(theme);
+    }
+  });
+  window.addEventListener("storage", (e) => {
+    if (e.key === "theme") {
+      setTheme(e.newValue || "system");
     }
   });
   window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", (e) => {

--- a/test/aludel_web/live/dashboard_live_test.exs
+++ b/test/aludel_web/live/dashboard_live_test.exs
@@ -13,6 +13,26 @@ defmodule Aludel.Web.DashboardLiveTest do
     assert render(view) =~ "Dashboard"
   end
 
+  test "applies the saved theme before loading styles", %{conn: conn} do
+    html = conn |> get("/") |> html_response(200)
+
+    theme_script_position =
+      html
+      |> :binary.match(~s|localStorage.getItem("theme")|)
+      |> elem(0)
+
+    stylesheet_position =
+      html
+      |> :binary.match(~s(rel="stylesheet"))
+      |> elem(0)
+
+    assert theme_script_position < stylesheet_position
+    assert html =~ ~s|document.documentElement.setAttribute("data-theme", appliedTheme)|
+    refute html =~ "phx:theme"
+    assert html =~ ~s|href="/prompts"|
+    assert html =~ ~s|data-phx-link="redirect"|
+  end
+
   test "shows recent runs", %{conn: conn} do
     _run = run_fixture(%{name: "Recent Test Run"})
 


### PR DESCRIPTION
## Motivation

Dark mode could briefly render the light theme while moving between dashboard pages. Navigation triggered full document loads, and the persisted theme was not applied until after the stylesheet loaded.

## Test Plan

- Added a regression test that verifies the saved theme is applied before stylesheet loading.
- Verified dashboard navigation uses LiveView navigation.
- Verified the source and compiled JavaScript assets remain synchronized.
- Passed the complete test suite, static analysis, dependency audit, documentation build, production compilation, and package dry run.

## Next Steps

None.