### PR TITLE
feat(web): manage suite quality policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ See the [red-team guide](https://hexdocs.pm/aludel/red_team.html), [curated data
 
 Define what a suite must satisfy instead of treating every run as an all-or-nothing test count:
 
+In the dashboard, open a suite and choose **Manage policy**. The editor validates the JSON definition before saving, shows every immutable version, and uses the newest version for future runs. Suite results identify the snapshotted policy version and show the measured status, actual value, and requirement for every rule.
+
 ```elixir
 {:ok, policy} =
   Aludel.Evals.create_suite_policy(suite, %{
@@ -209,7 +211,7 @@ Define what a suite must satisfy instead of treating every run as an all-or-noth
 
 Policies can gate overall pass rate, metadata groups, evaluator scores, total cost, and average latency. Each update creates an immutable suite-local version. A run snapshots the latest version before execution, and retries continue to use that same version.
 
-Policy results report `passed`, `failed`, `invalid`, or `unavailable`; missing evidence never silently passes. `mix aludel.eval` uses the policy outcome as its exit gate and preserves the legacy all-cases-must-pass behavior for suites without a policy.
+Policy authoring and result inspection are available in the dashboard and through the Elixir API. `mix aludel.eval`, ExUnit gates, reporters, and exports consume the same stored policy outcome. Results report `passed`, `failed`, `invalid`, or `unavailable`; missing evidence never silently passes. Suites without a policy preserve the legacy all-cases-must-pass behavior.
 
 See the [evaluation guide](https://hexdocs.pm/aludel/evaluations.html#enforce-a-versioned-quality-policy) and [quality policies wiki guide](https://github.com/ccarvalho-eng/aludel/wiki/Quality-Policies) for every rule and result example.
 

--- a/guides/evaluations.md
+++ b/guides/evaluations.md
@@ -211,7 +211,9 @@ The dashboard renders the aggregate evidence in each sampled test case result an
 
 ### Enforce a versioned quality policy
 
-Create an immutable policy version for a suite:
+In the dashboard, open a suite and choose **Manage policy**. Start from the validated example or the active definition, add any combination of the five rule types, and choose **Create policy version**. Each save is immutable, and the version history keeps every definition inspectable. The suite page marks the active version and shows the snapshotted aggregate status and per-rule evidence on each historical run.
+
+To create the same immutable policy version through the Elixir API:
 
 ```elixir
 {:ok, policy} =
@@ -251,7 +253,7 @@ case suite_run.quality_policy_result do
 end
 ```
 
-`mix aludel.eval` uses a stored policy outcome as its process exit gate. Suites without a policy keep the legacy behavior: every test case must pass and an empty suite fails.
+Policy creation is available in the dashboard and Elixir API. `mix aludel.eval`, ExUnit, reporters, and exports read the persisted outcome; the CLI does not create policy versions. `mix aludel.eval` uses that outcome as its process exit gate. Suites without a policy keep the legacy behavior: every test case must pass and an empty suite fails.
 
 ## 5. Populate a suite
 

--- a/guides/features.md
+++ b/guides/features.md
@@ -73,7 +73,8 @@ The suite UI supports:
 - detailed assertion, field-comparison, metric-context, and evaluator execution results
 - custom rubric judges and versioned correctness, relevance, faithfulness, safety, refusal, PII, and hallucination templates
 - bounded repeated sampling with all, any, majority, and minimum pass-rate reducers
-- immutable versioned quality policies for overall and metadata-group pass rates, evaluator scores, total cost, and average latency
+- validated quality-policy authoring with immutable version history for overall and metadata-group pass rates, evaluator scores, total cost, and average latency
+- policy version, aggregate status, and per-rule evidence on historical suite results
 - retrying one test result without rerunning the entire suite
 - copy actions and raw JSON exports
 
@@ -82,6 +83,8 @@ Built-in metrics are `contains`, `not_contains`, `regex`, `exact_match`, `json_f
 The visual assertion editor configures either a built-in judge template or a custom rubric, a separate judge provider, a 0–100 pass threshold, an optional reference answer, and optional grounding context. The raw JSON editor exposes the same assertion contract. Once saved, judge assertions run through the dashboard, Mix CLI, ExUnit, file-based suites, and the Elixir API.
 
 The suite run panel configures one to 20 attempts per test case and all, any, strict-majority, or minimum pass-rate reduction. Sampled results expose the aggregate pass evidence and an expandable ordered attempt history. File-based suites provide the same settings to the Mix CLI, while ExUnit and the Elixir API accept them as execution options.
+
+From a suite page, **Manage policy** opens a JSON editor with live validation, a starter definition, rule guidance, and inspectable immutable history. The latest version applies to future runs. Historical result cards retain the version they used and display each rule's measured evidence. The dashboard and Elixir API create versions; the Mix CLI, ExUnit, reporters, and exports consume the resulting gate.
 
 ## Reusable datasets
 

--- a/lib/aludel/web/live/suite_live/policy.ex
+++ b/lib/aludel/web/live/suite_live/policy.ex
@@ -1,0 +1,145 @@
+defmodule Aludel.Web.SuiteLive.Policy do
+  @moduledoc """
+  LiveView for creating and inspecting immutable suite quality policies.
+  """
+
+  use Aludel.Web, :live_view
+
+  alias Aludel.Evals
+  alias Aludel.Evals.QualityPolicy
+
+  @max_definition_bytes 100_000
+  @starter_definition %{
+    "schema_version" => 1,
+    "rules" => [
+      %{"id" => "overall", "type" => "overall_pass_rate", "minimum" => 0.9}
+    ]
+  }
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_params(%{"id" => id}, _uri, socket) do
+    suite = Evals.get_suite!(id)
+    policies = Evals.list_suite_policies(suite)
+    definition = policies |> List.first() |> initial_definition()
+
+    {:noreply,
+     socket
+     |> assign(:page_title, "#{suite.name} quality policy")
+     |> assign(:suite, suite)
+     |> assign(:policies, policies)
+     |> assign_definition(definition)}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("validate", %{"policy" => params}, socket) do
+    {:noreply, assign_definition(socket, Map.get(params, "definition", ""))}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("save", %{"policy" => params}, socket) do
+    definition_json = Map.get(params, "definition", "")
+
+    case parse_definition(definition_json) do
+      {:ok, definition} ->
+        create_policy(socket, definition, definition_json)
+
+      {:error, errors} ->
+        {:noreply, assign_invalid_definition(socket, definition_json, errors)}
+    end
+  end
+
+  defp create_policy(socket, definition, definition_json) do
+    case Evals.create_suite_policy(socket.assigns.suite, definition) do
+      {:ok, policy} ->
+        policies = Evals.list_suite_policies(socket.assigns.suite)
+
+        {:noreply,
+         socket
+         |> assign(:policies, policies)
+         |> assign_definition(format_definition(policy.definition))
+         |> put_flash(:info, "Policy version #{policy.version} created")}
+
+      {:error, _changeset} ->
+        {:noreply,
+         socket
+         |> assign_invalid_definition(definition_json, ["Policy version could not be created"])
+         |> put_flash(:error, "Policy version could not be created")}
+    end
+  end
+
+  defp assign_definition(socket, definition_json) do
+    case parse_definition(definition_json) do
+      {:ok, definition} ->
+        socket
+        |> assign(:policy_form, policy_form(definition_json))
+        |> assign(:validation_errors, [])
+        |> assign(:rule_count, rule_count(definition))
+
+      {:error, errors} ->
+        assign_invalid_definition(socket, definition_json, errors)
+    end
+  end
+
+  defp assign_invalid_definition(socket, definition_json, errors) do
+    socket
+    |> assign(:policy_form, policy_form(definition_json))
+    |> assign(:validation_errors, errors)
+    |> assign(:rule_count, 0)
+  end
+
+  defp parse_definition(definition_json)
+       when is_binary(definition_json) and byte_size(definition_json) <= @max_definition_bytes do
+    with {:ok, definition} <- Jason.decode(definition_json),
+         :ok <- QualityPolicy.validate(definition) do
+      {:ok, definition}
+    else
+      {:error, %Jason.DecodeError{}} -> {:error, ["Definition must be valid JSON"]}
+      {:error, errors} when is_list(errors) -> {:error, errors}
+    end
+  end
+
+  defp parse_definition(definition_json) when is_binary(definition_json) do
+    {:error, ["Definition cannot exceed #{@max_definition_bytes} bytes"]}
+  end
+
+  defp parse_definition(_definition_json) do
+    {:error, ["Definition must be valid JSON"]}
+  end
+
+  defp initial_definition(nil) do
+    format_definition(@starter_definition)
+  end
+
+  defp initial_definition(policy) do
+    format_definition(policy.definition)
+  end
+
+  defp policy_form(definition) do
+    to_form(%{"definition" => definition}, as: :policy)
+  end
+
+  defp rule_count(%{"rules" => rules}) when is_list(rules) do
+    length(rules)
+  end
+
+  defp rule_count(_definition) do
+    0
+  end
+
+  defp rule_count_label(1) do
+    "1 rule"
+  end
+
+  defp rule_count_label(count) do
+    "#{count} rules"
+  end
+
+  defp format_definition(definition) do
+    Jason.encode!(definition, pretty: true)
+  end
+end

--- a/lib/aludel/web/live/suite_live/policy.html.heex
+++ b/lib/aludel/web/live/suite_live/policy.html.heex
@@ -1,0 +1,123 @@
+<Layouts.app flash={@flash} current_path={@current_path}>
+  <div class="page-container-wide" style="max-width: 1120px;">
+    <div style="display: flex; justify-content: space-between; align-items: start; gap: 24px; margin-bottom: 28px; padding-bottom: 20px; border-bottom: 1px solid var(--border);">
+      <div>
+        <.link
+          navigate={aludel_path("suites/#{@suite.id}")}
+          style="display: inline-flex; align-items: center; gap: 6px; color: var(--text-secondary); font-size: 13px; margin-bottom: 12px;"
+        >
+          <.icon name="hero-arrow-left" class="size-4" /> Back to suite
+        </.link>
+        <h1 style="margin: 0 0 8px; font-size: 28px;">Quality policy</h1>
+        <p style="margin: 0; color: var(--text-secondary);">
+          Define the release criteria for <strong>{@suite.name}</strong>.
+          Saving creates a new immutable version for future runs.
+        </p>
+      </div>
+    </div>
+
+    <div style="display: grid; grid-template-columns: minmax(0, 1.3fr) minmax(280px, 0.7fr); gap: 24px; align-items: start;">
+      <section class="aludel-card">
+        <h2 style="margin: 0 0 8px; font-size: 18px;">Create the next version</h2>
+        <p style="margin: 0 0 18px; color: var(--text-secondary); font-size: 13px; line-height: 1.6;">
+          Use decimal rates from 0 to 1, evaluator scores from 0 to 100, and non-negative cost or latency limits.
+        </p>
+
+        <.form
+          for={@policy_form}
+          id="quality-policy-form"
+          phx-change="validate"
+          phx-submit="save"
+        >
+          <.input
+            field={@policy_form[:definition]}
+            type="textarea"
+            label="Policy definition"
+            rows="20"
+            maxlength={100_000}
+            phx-debounce="250"
+            class="json-editor w-full textarea"
+          />
+
+          <div
+            :if={@validation_errors == []}
+            id="policy-validation-valid"
+            style="margin: 10px 0 14px; padding: 10px 12px; border-radius: 7px; color: #059669; background: color-mix(in srgb, #059669 10%, transparent); font-size: 13px;"
+          >
+            Valid policy · {rule_count_label(@rule_count)}
+          </div>
+
+          <div
+            :if={@validation_errors != []}
+            id="policy-validation-errors"
+            style="margin: 10px 0 14px; padding: 10px 12px; border-radius: 7px; color: #dc2626; background: color-mix(in srgb, #dc2626 10%, transparent); font-size: 13px;"
+          >
+            <div style="font-weight: 600; margin-bottom: 6px;">Fix this definition:</div>
+            <ul style="margin: 0; padding-left: 18px;">
+              <li :for={error <- @validation_errors}>{error}</li>
+            </ul>
+          </div>
+
+          <button
+            type="submit"
+            class="button-primary"
+            disabled={@validation_errors != []}
+            phx-disable-with="Creating..."
+            style="width: 100%;"
+          >
+            Create policy version
+          </button>
+        </.form>
+      </section>
+
+      <aside class="aludel-card">
+        <h2 style="margin: 0 0 12px; font-size: 18px;">Rule types</h2>
+        <div style="display: flex; flex-direction: column; gap: 14px; font-size: 13px;">
+          <div>
+            <strong>overall_pass_rate</strong><br /><span class="text-muted">Minimum pass rate across the suite.</span>
+          </div>
+          <div>
+            <strong>metadata_pass_rate</strong><br /><span class="text-muted">Minimum pass rate for cases matching metadata.</span>
+          </div>
+          <div>
+            <strong>evaluator_score</strong><br /><span class="text-muted">Minimum average score for a named metric.</span>
+          </div>
+          <div>
+            <strong>total_cost_usd</strong><br /><span class="text-muted">Maximum total cost for the suite run.</span>
+          </div>
+          <div>
+            <strong>average_latency_ms</strong><br /><span class="text-muted">Maximum average request latency.</span>
+          </div>
+        </div>
+      </aside>
+    </div>
+
+    <section id="policy-version-history" style="margin-top: 28px;">
+      <h2 style="font-size: 20px; margin-bottom: 14px;">Version history</h2>
+      <div
+        :if={@policies == []}
+        class="aludel-card"
+        style="padding: 28px; text-align: center; color: var(--text-muted);"
+      >
+        No policy versions yet
+      </div>
+      <div :if={@policies != []} style="display: flex; flex-direction: column; gap: 12px;">
+        <details
+          :for={{policy, index} <- Enum.with_index(@policies)}
+          id={"policy-version-#{policy.version}"}
+          class="aludel-card"
+          open={index == 0}
+        >
+          <summary style="cursor: pointer; display: flex; justify-content: space-between; gap: 16px; align-items: center;">
+            <span style="font-weight: 600;">Version {policy.version}</span>
+            <span style="display: inline-flex; align-items: center; gap: 10px; color: var(--text-secondary); font-size: 12px;">
+              <span>{rule_count_label(rule_count(policy.definition))}</span>
+              <span :if={index == 0} style="color: #059669; font-weight: 600;">Active</span>
+            </span>
+          </summary>
+          <pre style="margin: 16px 0 0; padding: 14px; border-radius: 7px; background: var(--bg-tertiary); border: 1px solid var(--border); overflow-x: auto; font-size: 12px; line-height: 1.55;">{format_definition(policy.definition)}</pre>
+        </details>
+      </div>
+    </section>
+  </div>
+</Layouts.app>

--- a/lib/aludel/web/live/suite_live/show.ex
+++ b/lib/aludel/web/live/suite_live/show.ex
@@ -49,6 +49,7 @@ defmodule Aludel.Web.SuiteLive.Show do
 
     # Load existing suite runs
     suite_runs = Evals.list_suite_runs_for_suite_with_associations(id)
+    active_policy = Evals.latest_suite_policy(suite)
 
     # Set default selections to first version and first provider
     default_version_id = List.first(prompt.versions) |> then(&if &1, do: &1.id, else: nil)
@@ -69,6 +70,7 @@ defmodule Aludel.Web.SuiteLive.Show do
       |> assign(:judge_templates, JudgeCatalog.all())
       |> assign(:execution_mode_label, Executor.execution_mode_label())
       |> assign(:suite_runs, suite_runs)
+      |> assign(:active_policy, active_policy)
       |> assign(:running, false)
       |> assign(:run_task_monitor_ref, nil)
       |> assign(:selected_version_id, default_version_id)
@@ -894,6 +896,137 @@ defmodule Aludel.Web.SuiteLive.Show do
 
   defp sampling_request_summary(samples) do
     "#{samples} requests"
+  end
+
+  defp policy_status_label(status)
+       when status in ["passed", "failed", "unavailable", "invalid"] do
+    String.capitalize(status)
+  end
+
+  defp policy_status_label(_status) do
+    "Unknown"
+  end
+
+  defp policy_status_color("passed") do
+    "#059669"
+  end
+
+  defp policy_status_color("failed") do
+    "#dc2626"
+  end
+
+  defp policy_status_color("unavailable") do
+    "#d97706"
+  end
+
+  defp policy_status_color(_status) do
+    "var(--text-secondary)"
+  end
+
+  defp policy_rules(%{"rules" => rules}) when is_list(rules) do
+    rules
+  end
+
+  defp policy_rules(_result) do
+    []
+  end
+
+  defp policy_rule_label("overall_pass_rate") do
+    "Overall pass rate"
+  end
+
+  defp policy_rule_label("metadata_pass_rate") do
+    "Metadata pass rate"
+  end
+
+  defp policy_rule_label("evaluator_score") do
+    "Evaluator score"
+  end
+
+  defp policy_rule_label("total_cost_usd") do
+    "Total cost"
+  end
+
+  defp policy_rule_label("average_latency_ms") do
+    "Average latency"
+  end
+
+  defp policy_rule_label(_type) do
+    "Policy rule"
+  end
+
+  defp policy_rule_actual(%{"actual" => nil, "reason" => reason}) when is_binary(reason) do
+    reason
+  end
+
+  defp policy_rule_actual(%{"type" => type, "actual" => actual})
+       when type in ["overall_pass_rate", "metadata_pass_rate"] and is_number(actual) do
+    format_percentage(actual)
+  end
+
+  defp policy_rule_actual(%{"type" => "evaluator_score", "actual" => actual})
+       when is_number(actual) do
+    "#{format_score(actual)} points"
+  end
+
+  defp policy_rule_actual(%{"type" => "total_cost_usd", "actual" => actual})
+       when is_number(actual) do
+    "$#{format_policy_number(actual)}"
+  end
+
+  defp policy_rule_actual(%{"type" => "average_latency_ms", "actual" => actual})
+       when is_number(actual) do
+    "#{format_policy_number(actual)} ms"
+  end
+
+  defp policy_rule_actual(_rule) do
+    "Evidence unavailable"
+  end
+
+  defp policy_rule_requirement(%{"type" => type, "minimum" => minimum})
+       when type in ["overall_pass_rate", "metadata_pass_rate"] and is_number(minimum) do
+    "at least #{format_percentage(minimum)}"
+  end
+
+  defp policy_rule_requirement(%{"type" => "evaluator_score", "minimum" => minimum})
+       when is_number(minimum) do
+    "at least #{format_policy_number(minimum)} points"
+  end
+
+  defp policy_rule_requirement(%{"type" => "total_cost_usd", "maximum" => maximum})
+       when is_number(maximum) do
+    "at most $#{format_policy_number(maximum)}"
+  end
+
+  defp policy_rule_requirement(%{"type" => "average_latency_ms", "maximum" => maximum})
+       when is_number(maximum) do
+    "at most #{format_policy_number(maximum)} ms"
+  end
+
+  defp policy_rule_requirement(_rule) do
+    "Invalid requirement"
+  end
+
+  defp policy_rule_dom_id(id) when is_binary(id) do
+    if Regex.match?(~r/\A[A-Za-z0-9_-]+\z/, id) do
+      id
+    else
+      Base.url_encode64(id, padding: false)
+    end
+  end
+
+  defp policy_rule_dom_id(_id) do
+    "unknown"
+  end
+
+  defp format_policy_number(number) when is_integer(number) do
+    Integer.to_string(number)
+  end
+
+  defp format_policy_number(number) when is_float(number) do
+    number
+    |> Float.round(4)
+    |> to_string()
   end
 
   defp format_percentage(rate) when is_number(rate) do

--- a/lib/aludel/web/live/suite_live/show.html.heex
+++ b/lib/aludel/web/live/suite_live/show.html.heex
@@ -72,6 +72,22 @@
           >
             Edit Suite Details
           </button>
+          <div style="margin-top: 8px; display: flex; flex-direction: column; gap: 8px;">
+            <.link
+              navigate={aludel_path("suites/#{@suite.id}/policy")}
+              class="button-secondary"
+              style="font-size: 13px; padding: 6px 12px; width: 100%; text-align: center;"
+            >
+              Manage policy
+            </.link>
+            <div
+              :if={@active_policy}
+              id="active-quality-policy"
+              style="padding: 8px 10px; border-radius: 6px; background: color-mix(in srgb, #059669 10%, transparent); color: #059669; font-size: 12px; font-weight: 600; text-align: center;"
+            >
+              Policy v{@active_policy.version} active
+            </div>
+          </div>
         </div>
       <% end %>
       <div style="margin-bottom: 24px;">
@@ -1166,6 +1182,37 @@
                     >
                       Export JSON
                     </a>
+                  </div>
+                </div>
+              </div>
+              <div
+                :if={is_map(suite_run.quality_policy_result)}
+                id={"suite-run-policy-#{suite_run.id}"}
+                style="margin-bottom: 12px; padding: 12px; border-radius: 7px; border: 1px solid var(--border); background: var(--bg-secondary);"
+              >
+                <div style="display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 10px;">
+                  <strong style="font-size: 13px;">
+                    Policy v{suite_run.quality_policy_result["policy_version"]}
+                  </strong>
+                  <span style={"font-size: 12px; font-weight: 600; color: #{policy_status_color(suite_run.quality_policy_result["status"])}"}>
+                    {policy_status_label(suite_run.quality_policy_result["status"])}
+                  </span>
+                </div>
+                <div style="display: flex; flex-direction: column; gap: 8px;">
+                  <div
+                    :for={rule <- policy_rules(suite_run.quality_policy_result)}
+                    id={"suite-run-policy-rule-#{suite_run.id}-#{policy_rule_dom_id(rule["id"])}"}
+                    style="padding: 9px 10px; border-radius: 6px; background: var(--bg-tertiary); font-size: 12px;"
+                  >
+                    <div style="display: flex; justify-content: space-between; gap: 10px; margin-bottom: 4px;">
+                      <strong>{policy_rule_label(rule["type"])}</strong>
+                      <span style={"font-weight: 600; color: #{policy_status_color(rule["status"])}"}>
+                        {policy_status_label(rule["status"])}
+                      </span>
+                    </div>
+                    <div style="color: var(--text-secondary);">
+                      {policy_rule_actual(rule)} · {policy_rule_requirement(rule)}
+                    </div>
                   </div>
                 </div>
               </div>

--- a/lib/aludel/web/router.ex
+++ b/lib/aludel/web/router.ex
@@ -74,6 +74,7 @@ defmodule Aludel.Web.Router do
           live "/suites", Aludel.Web.SuiteLive.Index, :index, route_opts
           live "/suites/new", Aludel.Web.SuiteLive.New, :new, route_opts
           get "/suites/runs/:id/export", Aludel.Web.ExportController, :suite_run
+          live "/suites/:id/policy", Aludel.Web.SuiteLive.Policy, :show, route_opts
           live "/suites/:id", Aludel.Web.SuiteLive.Show, :show, route_opts
 
           live "/datasets", Aludel.Web.DatasetLive.Index, :index, route_opts

--- a/test/aludel_web/live/suite_live/policy_test.exs
+++ b/test/aludel_web/live/suite_live/policy_test.exs
@@ -1,0 +1,89 @@
+defmodule Aludel.Web.SuiteLive.PolicyTest do
+  use Aludel.Web.ConnCase, async: false
+
+  import Aludel.EvalsFixtures
+  import Phoenix.LiveViewTest
+
+  alias Aludel.Evals
+
+  test "shows a validated starter policy and empty version history", %{conn: conn} do
+    suite = suite_fixture()
+
+    {:ok, view, _html} = live(conn, "/suites/#{suite.id}/policy")
+
+    assert has_element?(view, "#quality-policy-form")
+    assert has_element?(view, "#policy_definition")
+    assert has_element?(view, "#policy-validation-valid", "1 rule")
+    assert has_element?(view, "#policy-version-history", "No policy versions yet")
+    assert has_element?(view, "a[href='/suites/#{suite.id}']", "Back to suite")
+  end
+
+  test "rejects malformed and invalid policy definitions without creating a version", %{
+    conn: conn
+  } do
+    suite = suite_fixture()
+    {:ok, view, _html} = live(conn, "/suites/#{suite.id}/policy")
+
+    view
+    |> form("#quality-policy-form", policy: %{definition: ~s({"schema_version":1,)})
+    |> render_change()
+
+    assert has_element?(view, "#policy-validation-errors", "Definition must be valid JSON")
+
+    invalid_definition =
+      Jason.encode!(%{
+        "schema_version" => 1,
+        "rules" => [%{"id" => "overall", "type" => "overall_pass_rate", "minimum" => 1.1}]
+      })
+
+    view
+    |> form("#quality-policy-form", policy: %{definition: invalid_definition})
+    |> render_submit()
+
+    assert has_element?(
+             view,
+             "#policy-validation-errors",
+             "minimum must be a number between 0 and 1"
+           )
+
+    assert Evals.list_suite_policies(suite) == []
+  end
+
+  test "creates immutable policy versions and keeps their definitions inspectable", %{conn: conn} do
+    suite = suite_fixture()
+    {:ok, view, _html} = live(conn, "/suites/#{suite.id}/policy")
+
+    first_definition =
+      policy_json([
+        %{"id" => "overall", "type" => "overall_pass_rate", "minimum" => 0.9},
+        %{"id" => "cost", "type" => "total_cost_usd", "maximum" => 0.5}
+      ])
+
+    view
+    |> form("#quality-policy-form", policy: %{definition: first_definition})
+    |> render_submit()
+
+    assert has_element?(view, "#flash-info", "Policy version 1 created")
+    assert has_element?(view, "#policy-version-1", "2 rules")
+
+    second_definition =
+      policy_json([
+        %{"id" => "overall", "type" => "overall_pass_rate", "minimum" => 0.95}
+      ])
+
+    view
+    |> form("#quality-policy-form", policy: %{definition: second_definition})
+    |> render_submit()
+
+    assert has_element?(view, "#flash-info", "Policy version 2 created")
+    assert has_element?(view, "#policy-version-2", "Active")
+    assert has_element?(view, "#policy-version-2", ~s("minimum": 0.95))
+    assert has_element?(view, "#policy-version-1", ~s("maximum": 0.5))
+
+    assert Enum.map(Evals.list_suite_policies(suite), & &1.version) == [2, 1]
+  end
+
+  defp policy_json(rules) do
+    Jason.encode!(%{"schema_version" => 1, "rules" => rules}, pretty: true)
+  end
+end

--- a/test/aludel_web/live/suite_live/show_test.exs
+++ b/test/aludel_web/live/suite_live/show_test.exs
@@ -41,6 +41,60 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
     assert has_element?(view, "#run-suite-btn")
   end
 
+  test "links to policy management and renders snapshotted rule evidence", %{conn: conn} do
+    prompt = prompt_fixture_with_version()
+    suite = suite_fixture(%{prompt_id: prompt.id})
+    provider = provider_fixture()
+    version = List.first(prompt.versions)
+
+    definition = %{
+      "schema_version" => 1,
+      "rules" => [%{"id" => "overall", "type" => "overall_pass_rate", "minimum" => 0.9}]
+    }
+
+    assert {:ok, policy} = Evals.create_suite_policy(suite, definition)
+
+    suite_run =
+      suite_run_fixture(%{
+        suite_id: suite.id,
+        prompt_version_id: version.id,
+        provider_id: provider.id,
+        suite_policy_id: policy.id,
+        quality_policy_result: %{
+          "schema_version" => 1,
+          "policy_id" => policy.id,
+          "policy_version" => 1,
+          "status" => "failed",
+          "passed" => false,
+          "rules" => [
+            %{
+              "id" => "overall",
+              "type" => "overall_pass_rate",
+              "minimum" => 0.9,
+              "actual" => 0.75,
+              "sample_count" => 4,
+              "status" => "failed",
+              "passed" => false
+            }
+          ]
+        }
+      })
+
+    {:ok, view, _html} = live(conn, "/suites/#{suite.id}")
+
+    assert has_element?(view, "a[href='/suites/#{suite.id}/policy']", "Manage policy")
+    assert has_element?(view, "#active-quality-policy", "Policy v1 active")
+
+    policy_id = "#suite-run-policy-#{suite_run.id}"
+    assert has_element?(view, policy_id, "Policy v1")
+    assert has_element?(view, policy_id, "Failed")
+
+    rule_id = "#suite-run-policy-rule-#{suite_run.id}-overall"
+    assert has_element?(view, rule_id, "Overall pass rate")
+    assert has_element?(view, rule_id, "75.0%")
+    assert has_element?(view, rule_id, "at least 90.0%")
+  end
+
   describe "dataset population" do
     test "imports multi-turn entries once and renders their provenance", %{conn: conn} do
       suite = suite_fixture()


### PR DESCRIPTION
## Motivation

Quality policies could be created through the library API and consumed by automation, but dashboard users could not author versions or inspect policy evidence alongside suite results.

## Test Plan

- Added LiveView coverage for the starter definition, JSON validation, immutable version creation, and inspectable history.
- Added suite-result coverage for the active policy, snapshotted version, aggregate status, and per-rule evidence.
- Verified routing and the complete test suite.
- Passed static analysis, security scanning, dependency audit, documentation generation, production compilation, and package dry run.

## Next Steps

Update the quality-policy wiki with the dashboard workflow after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dashboard-based quality policy authoring with validation and immutable version history.
  * Added policy status and active version details to suite pages.
  * Added per-rule policy evidence, including actual results and requirements, to historical suite runs.
  * Added support for inspecting formatted policy definitions and supported rule types.

* **Documentation**
  * Clarified policy creation, versioning, validation, historical results, and CLI/API behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->