### PR TITLE
feat(web): export evaluation reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ See the [evaluation guide](https://hexdocs.pm/aludel/evaluations.html#enforce-a-
 
 Render the same persisted suite result for local review, API consumers, and CI systems without coupling those formats to persistence:
 
+In the dashboard, open a suite result and choose **Reports** to preview or download console text, schema-version-2 JSON, JUnit XML, or GitHub Actions annotations. Browser previews are bounded, downloads are not cached, and JUnit excludes generated responses unless **Include generated output** is explicitly enabled. The existing full run export remains available for complete persisted evidence.
+
 ```elixir
 alias Aludel.Evals.Reporter
 
@@ -230,7 +232,7 @@ github_annotations = Reporter.render!(suite_run, :github)
 
 `Aludel.Evals.Report` defines the stable schema-version-2 model. Built-in reporters cover concise console text, JSON interchange, JUnit test reports, and GitHub Actions annotations. Custom modules can implement the `Aludel.Evals.Reporter` behavior.
 
-The GitHub reporter escapes and bounds untrusted evaluator text before emitting workflow commands. JUnit output escapes identifiers and reasons, omits model output by default, and represents a policy-only rejection as a failed test case. Pass `include_output: true` or `--include-output` only when the target artifact is appropriate for generated responses.
+The dashboard, Mix CLI, and Elixir API expose the same four built-in formats. The GitHub reporter escapes and bounds untrusted evaluator text before emitting workflow commands. JUnit output escapes identifiers and reasons, omits model output by default, and represents a policy-only rejection as a failed test case. Pass `include_output: true`, enable it in the dashboard, or use `--include-output` only when the target artifact is appropriate for generated responses.
 
 See the [reporter guide](https://hexdocs.pm/aludel/reporters.html) and [evaluation reporters wiki guide](https://github.com/ccarvalho-eng/aludel/wiki/Evaluation-Reporters) for CLI, library, CI, and custom reporter examples.
 

--- a/guides/features.md
+++ b/guides/features.md
@@ -76,7 +76,7 @@ The suite UI supports:
 - validated quality-policy authoring with immutable version history for overall and metadata-group pass rates, evaluator scores, total cost, and average latency
 - policy version, aggregate status, and per-rule evidence on historical suite results
 - retrying one test result without rerunning the entire suite
-- copy actions and raw JSON exports
+- copy actions, raw JSON exports, and previewable console, JSON v2, JUnit XML, and GitHub annotation reports
 
 Built-in metrics are `contains`, `not_contains`, `regex`, `exact_match`, `json_field`, `json_deep_compare`, and `rubric_judge`. See the [Evaluation Guide](evaluations.md) for examples and programmatic policy configuration.
 
@@ -85,6 +85,8 @@ The visual assertion editor configures either a built-in judge template or a cus
 The suite run panel configures one to 20 attempts per test case and all, any, strict-majority, or minimum pass-rate reduction. Sampled results expose the aggregate pass evidence and an expandable ordered attempt history. File-based suites provide the same settings to the Mix CLI, while ExUnit and the Elixir API accept them as execution options.
 
 From a suite page, **Manage policy** opens a JSON editor with live validation, a starter definition, rule guidance, and inspectable immutable history. The latest version applies to future runs. Historical result cards retain the version they used and display each rule's measured evidence. The dashboard and Elixir API create versions; the Mix CLI, ExUnit, reporters, and exports consume the resulting gate.
+
+Each suite result links to a report workspace for safe browser previews and downloads. Console and GitHub formats omit generated responses, JSON includes them as part of its stable interchange schema, and JUnit requires explicit output opt-in. The dashboard bounds previews while keeping downloads complete and uncached. The same formats are available through `mix aludel.eval` and `Aludel.Evals.Reporter`.
 
 ## Reusable datasets
 

--- a/guides/reporters.md
+++ b/guides/reporters.md
@@ -2,6 +2,12 @@
 
 Aludel turns every persisted suite run into one normalized report before formatting it. This gives local tools and CI systems the same status, identifiers, summaries, quality-policy evidence, and case results without tying an output format to the database schema.
 
+## Preview and download reports in the dashboard
+
+Open a suite, find a completed result, and choose **Reports**. Select console text, JSON v2, JUnit XML, or GitHub annotations to update the preview and download the complete rendered report. Previews are limited to 100,000 characters so a large result cannot overwhelm the page; the downloaded report is not truncated and uses no-store response headers.
+
+Console and GitHub formats omit generated responses. JSON includes them in its stable result schema. JUnit omits them until **Include generated output** is enabled, and keeps the choice in the download URL so preview and file content match. The full persisted suite-run JSON export remains available separately from the normalized report.
+
 ## Render reports in Elixir
 
 Pass a persisted `Aludel.Evals.SuiteRun` or an existing `Aludel.Evals.Report` to `Aludel.Evals.Reporter`:

--- a/lib/aludel/web/export_controller.ex
+++ b/lib/aludel/web/export_controller.ex
@@ -6,6 +6,7 @@ defmodule Aludel.Web.ExportController do
   import Plug.Conn
 
   alias Aludel.Evals
+  alias Aludel.Evals.Reporter
   alias Aludel.Evals.SuitePolicy
   alias Aludel.Prompts
   alias Aludel.Prompts.Evolution.Export, as: EvolutionExport
@@ -28,6 +29,29 @@ defmodule Aludel.Web.ExportController do
       |> serialize_suite_run_export()
 
     send_json_download(conn, payload, "suite-run-#{id}.json")
+  end
+
+  @doc false
+  @spec suite_report(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def suite_report(conn, %{"id" => id, "format" => format} = path_params) do
+    conn = fetch_query_params(conn)
+    params = Map.merge(path_params, conn.query_params)
+
+    with {:ok, reporter, extension, content_type} <- report_config(format),
+         suite_run <- Evals.get_suite_run_for_export!(id),
+         {:ok, rendered} <- Reporter.render(suite_run, reporter, report_options(format, params)) do
+      send_report_download(conn, rendered, id, extension, content_type)
+    else
+      :error ->
+        conn
+        |> put_status(400)
+        |> send_resp(400, "Unsupported report format")
+
+      {:error, _reason} ->
+        conn
+        |> put_status(500)
+        |> send_resp(500, "Report could not be rendered")
+    end
   end
 
   @doc """
@@ -80,6 +104,49 @@ defmodule Aludel.Web.ExportController do
       filename: filename,
       content_type: "application/json"
     )
+  end
+
+  defp send_report_download(conn, rendered, id, extension, content_type) do
+    conn
+    |> put_resp_header("cache-control", "no-store, max-age=0")
+    |> put_resp_header("pragma", "no-cache")
+    |> put_resp_header("expires", "0")
+    |> send_download({:binary, rendered},
+      filename: "evaluation-report-#{id}#{extension}",
+      content_type: content_type
+    )
+  end
+
+  defp report_config("console") do
+    {:ok, :console, ".txt", "text/plain; charset=utf-8"}
+  end
+
+  defp report_config("json") do
+    {:ok, :json, ".json", "application/json"}
+  end
+
+  defp report_config("junit") do
+    {:ok, :junit, ".xml", "application/xml"}
+  end
+
+  defp report_config("github") do
+    {:ok, :github, ".txt", "text/plain; charset=utf-8"}
+  end
+
+  defp report_config(_format) do
+    :error
+  end
+
+  defp report_options("json", _params) do
+    [pretty: true]
+  end
+
+  defp report_options("junit", params) do
+    [include_output: Map.get(params, "include_output") == "true"]
+  end
+
+  defp report_options(_format, _params) do
+    []
   end
 
   defp serialize_run_result_export(result) do

--- a/lib/aludel/web/live/suite_live/report.ex
+++ b/lib/aludel/web/live/suite_live/report.ex
@@ -1,0 +1,151 @@
+defmodule Aludel.Web.SuiteLive.Report do
+  @moduledoc """
+  LiveView for previewing and downloading a persisted suite run report.
+  """
+
+  use Aludel.Web, :live_view
+
+  alias Aludel.Evals
+  alias Aludel.Evals.Reporter
+
+  @formats ~w(console json junit github)
+  @max_preview_characters 100_000
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_params(%{"id" => id}, _uri, socket) do
+    suite_run = Evals.get_suite_run_for_export!(id)
+
+    {:noreply,
+     socket
+     |> assign(:page_title, "Evaluation report")
+     |> assign(:suite_run, suite_run)
+     |> assign_report("console", false)}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("preview", %{"report" => params}, socket) do
+    format = normalize_format(Map.get(params, "format"))
+    include_output = include_output?(Map.get(params, "include_output"))
+
+    {:noreply, assign_report(socket, format, include_output)}
+  end
+
+  defp assign_report(socket, format, include_output) do
+    options = report_options(format, include_output)
+
+    case Reporter.render(socket.assigns.suite_run, format_atom(format), options) do
+      {:ok, rendered} ->
+        {preview, truncated?} = bounded_preview(rendered)
+
+        socket
+        |> assign(:report_form, report_form(format, include_output))
+        |> assign(:format, format)
+        |> assign(:include_output, include_output)
+        |> assign(:preview, preview)
+        |> assign(:preview_truncated, truncated?)
+        |> assign(:render_error, nil)
+
+      {:error, _reason} ->
+        socket
+        |> assign(:report_form, report_form(format, include_output))
+        |> assign(:format, format)
+        |> assign(:include_output, include_output)
+        |> assign(:preview, "")
+        |> assign(:preview_truncated, false)
+        |> assign(:render_error, "This report could not be rendered")
+    end
+  end
+
+  defp normalize_format(format) when format in @formats do
+    format
+  end
+
+  defp normalize_format(_format) do
+    "console"
+  end
+
+  defp format_atom("console") do
+    :console
+  end
+
+  defp format_atom("json") do
+    :json
+  end
+
+  defp format_atom("junit") do
+    :junit
+  end
+
+  defp format_atom("github") do
+    :github
+  end
+
+  defp report_options("json", _include_output) do
+    [pretty: true]
+  end
+
+  defp report_options("junit", include_output) do
+    [include_output: include_output]
+  end
+
+  defp report_options(_format, _include_output) do
+    []
+  end
+
+  defp include_output?(value) do
+    value in [true, "true", "1", "on"]
+  end
+
+  defp report_form(format, include_output) do
+    to_form(
+      %{"format" => format, "include_output" => include_output},
+      as: :report
+    )
+  end
+
+  defp bounded_preview(rendered) do
+    if String.length(rendered) > @max_preview_characters do
+      {String.slice(rendered, 0, @max_preview_characters), true}
+    else
+      {rendered, false}
+    end
+  end
+
+  defp format_options do
+    [
+      {"Console text", "console"},
+      {"JSON v2", "json"},
+      {"JUnit XML", "junit"},
+      {"GitHub annotations", "github"}
+    ]
+  end
+
+  defp format_label("console") do
+    "console report"
+  end
+
+  defp format_label("json") do
+    "JSON report"
+  end
+
+  defp format_label("junit") do
+    "JUnit XML"
+  end
+
+  defp format_label("github") do
+    "GitHub annotations"
+  end
+
+  defp download_params("junit", true) do
+    %{"include_output" => "true"}
+  end
+
+  defp download_params(_format, _include_output) do
+    %{}
+  end
+end

--- a/lib/aludel/web/live/suite_live/report.html.heex
+++ b/lib/aludel/web/live/suite_live/report.html.heex
@@ -1,0 +1,96 @@
+<Layouts.app flash={@flash} current_path={@current_path}>
+  <div class="page-container-wide" style="max-width: 1120px;">
+    <div style="display: flex; justify-content: space-between; align-items: start; gap: 24px; margin-bottom: 28px; padding-bottom: 20px; border-bottom: 1px solid var(--border);">
+      <div>
+        <.link
+          navigate={aludel_path("suites/#{@suite_run.suite_id}")}
+          style="display: inline-flex; align-items: center; gap: 6px; color: var(--text-secondary); font-size: 13px; margin-bottom: 12px;"
+        >
+          <.icon name="hero-arrow-left" class="size-4" /> Back to suite
+        </.link>
+        <h1 style="margin: 0 0 8px; font-size: 28px;">Evaluation report</h1>
+        <p style="margin: 0; color: var(--text-secondary);">
+          {@suite_run.suite.name} · run {@suite_run.id}
+        </p>
+      </div>
+    </div>
+
+    <div style="display: grid; grid-template-columns: minmax(260px, 0.35fr) minmax(0, 1fr); gap: 24px; align-items: start;">
+      <aside class="aludel-card">
+        <h2 style="margin: 0 0 14px; font-size: 18px;">Report options</h2>
+        <.form for={@report_form} id="evaluation-report-form" phx-change="preview">
+          <.input
+            field={@report_form[:format]}
+            type="select"
+            label="Format"
+            options={format_options()}
+          />
+          <div :if={@format == "junit"} id="junit-output-option">
+            <.input
+              field={@report_form[:include_output]}
+              type="checkbox"
+              label="Include generated output"
+            />
+            <p style="margin: -6px 0 14px; color: var(--text-muted); font-size: 11px; line-height: 1.5;">
+              Generated responses may contain sensitive data. JUnit excludes them by default.
+            </p>
+          </div>
+        </.form>
+
+        <a
+          id="download-evaluation-report"
+          href={
+            aludel_path(
+              "suites/runs/#{@suite_run.id}/report/#{@format}",
+              download_params(@format, @include_output)
+            )
+          }
+          download
+          class="button-primary"
+          style="width: 100%; justify-content: center;"
+        >
+          Download {format_label(@format)}
+        </a>
+
+        <a
+          href={aludel_path("suites/runs/#{@suite_run.id}/export")}
+          download
+          class="button-secondary"
+          style="width: 100%; justify-content: center; margin-top: 8px;"
+        >
+          Download full run export
+        </a>
+
+        <p style="margin: 14px 0 0; color: var(--text-muted); font-size: 11px; line-height: 1.5;">
+          JSON reports contain generated outputs. Console and GitHub formats omit them. Downloads are not cached.
+        </p>
+      </aside>
+
+      <section class="aludel-card" style="min-width: 0;">
+        <div style="display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 12px;">
+          <h2 style="margin: 0; font-size: 18px;">Preview</h2>
+          <span style="font-size: 12px; color: var(--text-muted);">{format_label(@format)}</span>
+        </div>
+        <div
+          :if={@render_error}
+          id="report-render-error"
+          style="padding: 12px; border-radius: 7px; color: #dc2626; background: color-mix(in srgb, #dc2626 10%, transparent);"
+        >
+          {@render_error}
+        </div>
+        <pre
+          :if={!@render_error}
+          id="report-preview"
+          style="margin: 0; padding: 16px; border-radius: 7px; background: var(--bg-tertiary); border: 1px solid var(--border); overflow: auto; max-height: 70vh; white-space: pre-wrap; overflow-wrap: anywhere; font-size: 12px; line-height: 1.55;"
+        >{@preview}</pre>
+        <p
+          :if={@preview_truncated}
+          id="report-preview-truncated"
+          style="margin: 10px 0 0; color: var(--text-muted); font-size: 12px;"
+        >
+          Preview limited to 100,000 characters. The download contains the complete report.
+        </p>
+      </section>
+    </div>
+  </div>
+</Layouts.app>

--- a/lib/aludel/web/live/suite_live/show.html.heex
+++ b/lib/aludel/web/live/suite_live/show.html.heex
@@ -1173,7 +1173,14 @@
                       {format_score(suite_run.avg_score)}% avg score
                     </div>
                   <% end %>
-                  <div style="margin-top: 8px;">
+                  <div style="margin-top: 8px; display: flex; justify-content: flex-end; gap: 6px;">
+                    <.link
+                      id={"open-suite-report-#{suite_run.id}"}
+                      navigate={aludel_path("suites/runs/#{suite_run.id}/report")}
+                      style="display: inline-flex; border: 1px solid var(--border); background: var(--bg-secondary); color: var(--text-secondary); border-radius: 8px; padding: 4px 10px; font-size: 11px; font-weight: 600; cursor: pointer; text-decoration: none; transition: background-color 0.2s ease, color 0.2s ease;"
+                    >
+                      Reports
+                    </.link>
                     <a
                       id={"export-suite-run-#{suite_run.id}"}
                       href={aludel_path("suites/runs/#{suite_run.id}/export")}

--- a/lib/aludel/web/router.ex
+++ b/lib/aludel/web/router.ex
@@ -74,6 +74,8 @@ defmodule Aludel.Web.Router do
           live "/suites", Aludel.Web.SuiteLive.Index, :index, route_opts
           live "/suites/new", Aludel.Web.SuiteLive.New, :new, route_opts
           get "/suites/runs/:id/export", Aludel.Web.ExportController, :suite_run
+          get "/suites/runs/:id/report/:format", Aludel.Web.ExportController, :suite_report
+          live "/suites/runs/:id/report", Aludel.Web.SuiteLive.Report, :show, route_opts
           live "/suites/:id/policy", Aludel.Web.SuiteLive.Policy, :show, route_opts
           live "/suites/:id", Aludel.Web.SuiteLive.Show, :show, route_opts
 

--- a/test/aludel_web/export_controller_test.exs
+++ b/test/aludel_web/export_controller_test.exs
@@ -234,6 +234,67 @@ defmodule Aludel.Web.ExportControllerTest do
     end
   end
 
+  describe "GET /suites/runs/:id/report/:format" do
+    test "downloads each built-in evaluation report with safe response headers", %{conn: conn} do
+      suite_run = suite_run_fixture(%{passed: 1, failed: 0, results: []})
+
+      formats = [
+        {"console", "text/plain", ".txt", "Aludel evaluation"},
+        {"json", "application/json", ".json", ~s("schema_version": 2)},
+        {"junit", "application/xml", ".xml", "<testsuites"},
+        {"github", "text/plain", ".txt", "::notice title=Aludel evaluation"}
+      ]
+
+      Enum.each(formats, fn {format, content_type, extension, expected} ->
+        response = get(recycle(conn), "/suites/runs/#{suite_run.id}/report/#{format}")
+
+        assert response.status == 200
+        assert response.resp_body =~ expected
+        assert List.first(get_resp_header(response, "content-type")) =~ content_type
+        assert get_resp_header(response, "cache-control") == ["no-store, max-age=0"]
+
+        assert get_resp_header(response, "content-disposition") == [
+                 "attachment; filename=\"evaluation-report-#{suite_run.id}#{extension}\""
+               ]
+      end)
+    end
+
+    test "includes generated output in JUnit only after explicit opt-in", %{conn: conn} do
+      output = "Generated response"
+
+      suite_run =
+        suite_run_fixture(%{
+          passed: 1,
+          failed: 0,
+          results: [
+            %{
+              "test_case_id" => Ecto.UUID.generate(),
+              "passed" => true,
+              "output" => output,
+              "assertion_results" => []
+            }
+          ]
+        })
+
+      default_response = get(conn, "/suites/runs/#{suite_run.id}/report/junit")
+      refute default_response.resp_body =~ output
+
+      opted_in_response =
+        get(recycle(conn), "/suites/runs/#{suite_run.id}/report/junit?include_output=true")
+
+      assert opted_in_response.resp_body =~ output
+    end
+
+    test "rejects unsupported report formats without resolving arbitrary modules", %{conn: conn} do
+      suite_run = suite_run_fixture()
+
+      response = get(conn, "/suites/runs/#{suite_run.id}/report/Elixir.System")
+
+      assert response.status == 400
+      assert response.resp_body == "Unsupported report format"
+    end
+  end
+
   describe "GET /prompts/:id/evolution/export/:format" do
     test "downloads evolution metrics as JSON", %{conn: conn} do
       prompt = prompt_fixture_with_version(%{name: "Evolution Export Prompt"})

--- a/test/aludel_web/live/suite_live/report_test.exs
+++ b/test/aludel_web/live/suite_live/report_test.exs
@@ -1,0 +1,97 @@
+defmodule Aludel.Web.SuiteLive.ReportTest do
+  use Aludel.Web.ConnCase, async: false
+
+  import Aludel.EvalsFixtures
+  import Aludel.PromptsFixtures
+  import Aludel.ProvidersFixtures
+  import Phoenix.LiveViewTest
+
+  test "previews and downloads every built-in report format", %{conn: conn} do
+    %{suite_run: suite_run, output: output} = report_fixture()
+
+    {:ok, view, _html} = live(conn, "/suites/runs/#{suite_run.id}/report")
+
+    assert has_element?(view, "#evaluation-report-form")
+    assert has_element?(view, "#report-preview", "Aludel evaluation PASSED")
+
+    assert has_element?(
+             view,
+             "#download-evaluation-report[href='/suites/runs/#{suite_run.id}/report/console']",
+             "Download console report"
+           )
+
+    view
+    |> form("#evaluation-report-form", report: %{format: "json"})
+    |> render_change()
+
+    assert has_element?(view, "#report-preview", ~s("schema_version": 2))
+    assert has_element?(view, "#report-preview", output)
+
+    view
+    |> form("#evaluation-report-form", report: %{format: "junit"})
+    |> render_change()
+
+    assert has_element?(view, "#junit-output-option")
+    assert has_element?(view, "#report-preview", "<testsuites")
+    refute has_element?(view, "#report-preview", output)
+
+    view
+    |> form("#evaluation-report-form", report: %{format: "junit", include_output: "true"})
+    |> render_change()
+
+    assert has_element?(view, "#report-preview", output)
+
+    assert has_element?(
+             view,
+             "#download-evaluation-report[href='/suites/runs/#{suite_run.id}/report/junit?include_output=true']",
+             "Download JUnit XML"
+           )
+
+    view
+    |> form("#evaluation-report-form", report: %{format: "github"})
+    |> render_change()
+
+    assert has_element?(view, "#report-preview", "::notice title=Aludel evaluation")
+  end
+
+  test "falls back to the safe console preview for an unsupported format", %{conn: conn} do
+    %{suite_run: suite_run} = report_fixture()
+    {:ok, view, _html} = live(conn, "/suites/runs/#{suite_run.id}/report")
+
+    render_hook(view, "preview", %{
+      "report" => %{"format" => "Elixir.System", "include_output" => "true"}
+    })
+
+    assert has_element?(view, "#report-preview", "Aludel evaluation PASSED")
+    refute has_element?(view, "#junit-output-option")
+  end
+
+  defp report_fixture do
+    prompt = prompt_fixture_with_version()
+    suite = suite_fixture(%{prompt_id: prompt.id})
+    version = List.first(prompt.versions)
+    provider = provider_fixture()
+    test_case = test_case_fixture(%{suite_id: suite.id})
+    output = "A model response that may contain sensitive data"
+
+    suite_run =
+      suite_run_fixture(%{
+        suite_id: suite.id,
+        prompt_version_id: version.id,
+        provider_id: provider.id,
+        passed: 1,
+        failed: 0,
+        results: [
+          %{
+            "test_case_id" => test_case.id,
+            "passed" => true,
+            "output" => output,
+            "assertion_results" => [],
+            "latency_ms" => 120
+          }
+        ]
+      })
+
+    %{suite_run: suite_run, output: output}
+  end
+end

--- a/test/aludel_web/live/suite_live/show_test.exs
+++ b/test/aludel_web/live/suite_live/show_test.exs
@@ -1523,6 +1523,12 @@ defmodule Aludel.Web.SuiteLive.ShowTest do
                "#export-suite-run-#{suite_run.id}[href='/suites/runs/#{suite_run.id}/export']",
                "Export JSON"
              )
+
+      assert has_element?(
+               view,
+               "#open-suite-report-#{suite_run.id}[href='/suites/runs/#{suite_run.id}/report']",
+               "Reports"
+             )
     end
 
     test "renders deep compare score details for suite results", %{conn: conn} do


### PR DESCRIPTION
## Motivation

Evaluation reporters were available through the library API and Mix task, but completed suite runs could only download the full raw JSON export from the dashboard.

## Test Plan

- Added LiveView coverage for console, JSON v2, JUnit XML, and GitHub annotation previews and downloads.
- Verified JUnit excludes generated output by default and includes it only after explicit opt-in.
- Added controller coverage for fixed content types, filenames, no-store headers, query parsing, and unsupported-format rejection.
- Verified suite navigation, the complete test suite, static analysis, security scanning, dependency audit, documentation generation, production compilation, and package dry run.

## Next Steps

Publish the prepared reporter wiki workflow after merge.