### PR TITLE
feat(web): browse curated red-team cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ See the [evaluation guide](https://hexdocs.pm/aludel/evaluations.html#repeat-non
 
 Materialize a versioned set of adversarial cases into any reusable dataset:
 
+In the dashboard, open a dataset and choose **Add red-team cases**. Browse every catalog prompt, risk reference, severity, technique, deterministic canary, and recommended judge before selecting exact cases. Choose the target prompt variable and optionally a configured judge provider and threshold; the result reports newly created and already-present entries.
+
 ```elixir
 {:ok, dataset} = Aludel.Datasets.create_dataset(%{name: "Security regressions"})
 
@@ -182,7 +184,7 @@ approved_case_ids =
 
 Import revalidates the generation and candidate checksums, requires at least one unique approved ID, attaches each candidate's recommended rubric judge, records generation and review provenance, and skips only an exact prior import. Any conflict rolls back the complete approved selection.
 
-Catalog materialization and generated-case generation, review, and import are Elixir API features. Persisted cases use the normal dataset and suite workflows in the dashboard, `mix aludel.eval`, ExUnit, and the library API. There is no separate red-team CLI command or generation/import form in the dashboard yet.
+Curated catalog browsing and materialization are available in the dashboard and Elixir API. Generated-case generation, review, and import remain Elixir API features until the separate review workflow is configured. Persisted cases use the normal dataset and suite workflows in the dashboard, `mix aludel.eval`, ExUnit, and the library API. There is no separate red-team CLI command.
 
 See the [red-team guide](https://hexdocs.pm/aludel/red_team.html), [curated datasets wiki guide](https://github.com/ccarvalho-eng/aludel/wiki/Red-Team-Datasets), and [generated cases wiki guide](https://github.com/ccarvalho-eng/aludel/wiki/Generated-Red-Team-Cases) for category filters, review, budgets, provenance, and rerun behavior.
 

--- a/guides/features.md
+++ b/guides/features.md
@@ -100,11 +100,11 @@ Datasets are ordered collections of evaluation examples that can be reused by mu
 
 Dataset pages support create, edit, delete, entry management, and JSON containment filters over metadata. Populating a suite copies entries in order, records source provenance, and skips entries already imported from that dataset.
 
-`Aludel.RedTeam` provides seven versioned adversarial cases covering direct and indirect prompt injection, system prompt leakage, sensitive information disclosure, excessive agency, misinformation, and unsafe assistance. The library API materializes selected cases into a reusable dataset with deterministic canary assertions, optional rubric judges, and category, severity, provenance, checksum, and deduplication metadata. Matching reruns are idempotent; content or judge-configuration drift under the same key fails explicitly. See the [red-team guide](red_team.md).
+`Aludel.RedTeam` provides seven versioned adversarial cases covering direct and indirect prompt injection, system prompt leakage, sensitive information disclosure, excessive agency, misinformation, and unsafe assistance. The dashboard and library API materialize selected cases into a reusable dataset with deterministic canary assertions, optional rubric judges, and category, severity, provenance, checksum, and deduplication metadata. The dashboard catalog exposes every prompt and risk field before selection. Matching reruns are idempotent; content or judge-configuration drift under the same key fails explicitly. See the [red-team guide](red_team.md).
 
 The same API can generate product-specific cases through an Aludel provider. Generation validates a strict response schema, bounds calls and output, reports sanitized partial failures and usage, and returns inert checksummed candidates without database writes or execution. A separate import call requires explicit approved candidate IDs, revalidates the review record, and creates the selected entries atomically with rubric judges and provenance.
 
-Materialized and approved generated entries use the normal dataset workflow in the dashboard. Once they have been copied into a suite, that suite can be executed through the dashboard, `mix aludel.eval`, ExUnit, or `Aludel.Evals`. Catalog browsing, materialization, generated-case review, and approval/import are currently library API features.
+Materialized and approved generated entries use the normal dataset workflow in the dashboard. Once they have been copied into a suite, that suite can be executed through the dashboard, `mix aludel.eval`, ExUnit, or `Aludel.Evals`. Catalog browsing and materialization are dashboard and library API features. Generated-case review and approval/import are currently library API features.
 
 ## Documents and storage
 

--- a/guides/red_team.md
+++ b/guides/red_team.md
@@ -4,6 +4,12 @@
 
 The catalog aligns its categories with the [OWASP Top 10 for LLM Applications](https://genai.owasp.org/llm-top-10/) and the [NIST Generative AI Profile](https://nvlpubs.nist.gov/nistpubs/ai/NIST.AI.600-1.pdf). These cases are regression-test seeds, not a complete security assessment or compliance certification.
 
+## Dashboard workflow
+
+Open a dataset and choose **Add red-team cases**. The catalog page exposes each case's prompt, stable version, category, severity, technique, risk reference, deterministic canary assertion, and recommended judge. Select the exact cases to add, set the prompt variable, and optionally choose a configured judge provider with a 0–100 threshold.
+
+Materialization writes the complete selection transactionally and reports how many entries were created or already present. Repeating an identical selection is safe. A conflicting existing entry is not overwritten. Return to the dataset to inspect or edit the ordinary entries, then populate a suite as usual.
+
 ## Catalog
 
 The core catalog currently contains:
@@ -180,4 +186,4 @@ The catalog is exposed through the Elixir API. Its output is normal dataset data
 3. Run the suite in the dashboard, with `mix aludel.eval`, through ExUnit, or with `Aludel.Evals.execute_suite/4`.
 4. Apply quality policies and reporters exactly as you would for any other suite.
 
-There is no separate red-team CLI command or catalog browser in the dashboard in this release.
+Catalog browsing and materialization are available in the dashboard and Elixir API. There is no separate red-team CLI command. Generated-case generation, review, and approval/import remain API-only until the separate dashboard review workflow is configured.

--- a/lib/aludel/web/live/dataset_live/red_team_catalog.ex
+++ b/lib/aludel/web/live/dataset_live/red_team_catalog.ex
@@ -1,0 +1,201 @@
+defmodule Aludel.Web.DatasetLive.RedTeamCatalog do
+  @moduledoc """
+  LiveView for browsing and materializing curated red-team cases.
+  """
+
+  use Aludel.Web, :live_view
+
+  alias Aludel.Datasets
+  alias Aludel.Providers
+  alias Aludel.RedTeam
+
+  @default_params %{
+    "variable" => "input",
+    "judge_provider_id" => "",
+    "judge_threshold" => "80"
+  }
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_params(%{"id" => id}, _uri, socket) do
+    dataset = Datasets.get_dataset!(id)
+    cases = RedTeam.all()
+    params = Map.put(@default_params, "case_ids", Enum.map(cases, & &1.id))
+
+    {:noreply,
+     socket
+     |> assign(:page_title, "Curated red-team cases")
+     |> assign(:dataset, dataset)
+     |> assign(:cases, cases)
+     |> assign(:providers, Providers.list_providers())
+     |> assign(:materialization_errors, [])
+     |> assign(:materialization_result, nil)
+     |> assign_materialization(params)}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("validate_materialization", %{"materialization" => params}, socket) do
+    {:noreply,
+     socket
+     |> assign_materialization(params)
+     |> assign(:materialization_errors, [])
+     |> assign(:materialization_result, nil)}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("materialize", %{"materialization" => params}, socket) do
+    case materialization_options(params, socket.assigns.cases, socket.assigns.providers) do
+      {:ok, options} ->
+        materialize(socket, params, options)
+
+      {:error, message} ->
+        {:noreply,
+         socket
+         |> assign_materialization(params)
+         |> assign(:materialization_errors, [message])
+         |> assign(:materialization_result, nil)}
+    end
+  end
+
+  defp materialize(socket, params, options) do
+    case RedTeam.materialize(socket.assigns.dataset, options) do
+      {:ok, result} ->
+        created_count = length(result.created)
+        skipped_count = length(result.skipped)
+
+        {:noreply,
+         socket
+         |> assign_materialization(params)
+         |> assign(:materialization_errors, [])
+         |> assign(:materialization_result, %{
+           created: created_count,
+           skipped: skipped_count
+         })
+         |> put_flash(:info, materialization_message(created_count, skipped_count))}
+
+      {:error, reason} ->
+        {:noreply,
+         socket
+         |> assign_materialization(params)
+         |> assign(:materialization_errors, [materialization_error(reason)])
+         |> assign(:materialization_result, nil)}
+    end
+  end
+
+  defp materialization_options(params, cases, providers) do
+    with {:ok, case_ids} <- selected_case_ids(params, cases),
+         {:ok, provider_id} <- judge_provider_id(params, providers),
+         {:ok, threshold} <- judge_threshold(params) do
+      {:ok,
+       [
+         case_ids: case_ids,
+         variable: Map.get(params, "variable", ""),
+         judge_provider_id: provider_id,
+         judge_threshold: threshold
+       ]}
+    end
+  end
+
+  defp selected_case_ids(params, cases) do
+    case_ids = params |> Map.get("case_ids", []) |> List.wrap()
+    known_ids = MapSet.new(cases, & &1.id)
+
+    cond do
+      case_ids == [] ->
+        {:error, "Select at least one case"}
+
+      Enum.any?(case_ids, &(not MapSet.member?(known_ids, &1))) ->
+        {:error, "Unknown catalog case"}
+
+      true ->
+        {:ok, Enum.uniq(case_ids)}
+    end
+  end
+
+  defp judge_provider_id(params, providers) do
+    provider_id = Map.get(params, "judge_provider_id", "")
+
+    cond do
+      provider_id == "" ->
+        {:ok, nil}
+
+      Enum.any?(providers, &(&1.id == provider_id)) ->
+        {:ok, provider_id}
+
+      true ->
+        {:error, "Choose a configured judge provider"}
+    end
+  end
+
+  defp judge_threshold(params) do
+    case Float.parse(Map.get(params, "judge_threshold", "")) do
+      {threshold, ""} when threshold >= 0 and threshold <= 100 ->
+        {:ok, threshold}
+
+      _invalid ->
+        {:error, "Judge threshold must be a number between 0 and 100"}
+    end
+  end
+
+  defp assign_materialization(socket, params) do
+    selected_case_ids = params |> Map.get("case_ids", []) |> List.wrap()
+
+    socket
+    |> assign(:selected_case_ids, selected_case_ids)
+    |> assign(:materialization_form, to_form(params, as: :materialization))
+  end
+
+  defp materialization_error(:invalid_variable) do
+    "Variable must start with a letter or underscore and use only letters, numbers, dots, dashes, or underscores"
+  end
+
+  defp materialization_error(:invalid_judge_provider_id) do
+    "Choose a configured judge provider"
+  end
+
+  defp materialization_error(:invalid_judge_threshold) do
+    "Judge threshold must be a number between 0 and 100"
+  end
+
+  defp materialization_error({:deduplication_conflict, _key}) do
+    "An existing entry conflicts with the selected catalog case"
+  end
+
+  defp materialization_error(:dataset_not_found) do
+    "Dataset no longer exists"
+  end
+
+  defp materialization_error(_reason) do
+    "Cases could not be materialized"
+  end
+
+  defp materialization_message(created, 0) do
+    "#{created} #{case_label(created)} created"
+  end
+
+  defp materialization_message(0, skipped) do
+    "#{skipped} #{case_label(skipped)} already present"
+  end
+
+  defp materialization_message(created, skipped) do
+    "#{created} #{case_label(created)} created; #{skipped} already present"
+  end
+
+  defp case_label(1) do
+    "case"
+  end
+
+  defp case_label(_count) do
+    "cases"
+  end
+
+  defp category_label(category) do
+    category
+    |> Atom.to_string()
+    |> String.replace("_", " ")
+  end
+end

--- a/lib/aludel/web/live/dataset_live/red_team_catalog.html.heex
+++ b/lib/aludel/web/live/dataset_live/red_team_catalog.html.heex
@@ -1,0 +1,154 @@
+<Layouts.app flash={@flash} current_path={@current_path}>
+  <div class="page-container-wide" style="max-width: 1180px;">
+    <div style="display: flex; justify-content: space-between; align-items: start; gap: 24px; margin-bottom: 28px; padding-bottom: 20px; border-bottom: 1px solid var(--border);">
+      <div>
+        <.link
+          navigate={aludel_path("datasets/#{@dataset.id}")}
+          style="display: inline-flex; align-items: center; gap: 6px; color: var(--text-secondary); font-size: 13px; margin-bottom: 12px;"
+        >
+          <.icon name="hero-arrow-left" class="size-4" /> Back to dataset
+        </.link>
+        <h1 style="margin: 0 0 8px; font-size: 28px;">Curated red-team catalog</h1>
+        <p style="margin: 0; color: var(--text-secondary); line-height: 1.6;">
+          Add versioned adversarial regression cases to <strong>{@dataset.name}</strong>.
+          Catalog prompts are inert until the dataset is used in a suite.
+        </p>
+      </div>
+    </div>
+
+    <.form
+      for={@materialization_form}
+      id="red-team-materialization-form"
+      phx-change="validate_materialization"
+      phx-submit="materialize"
+    >
+      <div style="display: grid; grid-template-columns: minmax(270px, 340px) minmax(0, 1fr); gap: 24px; align-items: start;">
+        <aside class="aludel-card" style="position: sticky; top: 20px;">
+          <h2 style="margin: 0 0 8px; font-size: 18px;">Materialization</h2>
+          <p style="margin: 0 0 16px; color: var(--text-secondary); font-size: 12px; line-height: 1.5;">
+            Every case includes a deterministic canary assertion. A judge is optional.
+          </p>
+
+          <.input
+            field={@materialization_form[:variable]}
+            type="text"
+            label="Prompt variable"
+            required
+            maxlength="200"
+          />
+          <.input
+            field={@materialization_form[:judge_provider_id]}
+            type="select"
+            label="Judge provider (optional)"
+            prompt="Canary assertion only"
+            options={Enum.map(@providers, &{&1.name, &1.id})}
+          />
+          <.input
+            field={@materialization_form[:judge_threshold]}
+            type="number"
+            label="Judge threshold"
+            min="0"
+            max="100"
+            step="0.1"
+            required
+          />
+
+          <div
+            :if={@materialization_errors != []}
+            id="materialization-errors"
+            style="margin: 8px 0 14px; padding: 10px 12px; border-radius: 7px; color: #dc2626; background: color-mix(in srgb, #dc2626 10%, transparent); font-size: 12px;"
+          >
+            <div :for={error <- @materialization_errors}>{error}</div>
+          </div>
+
+          <div
+            :if={@materialization_result}
+            id="materialization-result"
+            style="margin: 8px 0 14px; padding: 10px 12px; border-radius: 7px; color: #059669; background: color-mix(in srgb, #059669 10%, transparent); font-size: 12px;"
+          >
+            {@materialization_result.created} created · {@materialization_result.skipped} already present
+          </div>
+
+          <button
+            type="submit"
+            class="button-primary"
+            phx-disable-with="Adding cases..."
+            style="width: 100%;"
+          >
+            Add selected cases
+          </button>
+
+          <p style="margin: 12px 0 0; color: var(--text-muted); font-size: 11px; line-height: 1.5;">
+            Repeating the same selection skips exact matches. Existing entries are never updated or deleted.
+          </p>
+        </aside>
+
+        <section id="red-team-catalog">
+          <div style="display: flex; justify-content: space-between; align-items: end; gap: 16px; margin-bottom: 14px;">
+            <div>
+              <h2 style="margin: 0 0 4px; font-size: 20px;">Cases</h2>
+              <p style="margin: 0; color: var(--text-secondary); font-size: 12px;">
+                {length(@selected_case_ids)} of {length(@cases)} selected
+              </p>
+            </div>
+          </div>
+
+          <div style="display: flex; flex-direction: column; gap: 12px;">
+            <article
+              :for={template <- @cases}
+              id={"red-team-case-#{template.id}"}
+              data-red-team-case
+              class="aludel-card"
+              style="padding: 16px;"
+            >
+              <div style="display: flex; align-items: start; gap: 12px;">
+                <input
+                  type="checkbox"
+                  name="materialization[case_ids][]"
+                  value={template.id}
+                  checked={template.id in @selected_case_ids}
+                  aria-label={"Select #{template.name}"}
+                  style="margin-top: 4px; width: 16px; height: 16px;"
+                />
+                <div style="min-width: 0; flex: 1;">
+                  <div style="display: flex; justify-content: space-between; align-items: start; gap: 12px;">
+                    <div>
+                      <h3 style="margin: 0 0 6px; font-size: 16px;">{template.name}</h3>
+                      <div style="display: flex; flex-wrap: wrap; gap: 6px; font-size: 11px;">
+                        <span style="padding: 3px 7px; border-radius: 999px; background: var(--bg-tertiary); color: var(--text-secondary);">
+                          {category_label(template.category)}
+                        </span>
+                        <span style="padding: 3px 7px; border-radius: 999px; background: color-mix(in srgb, #dc2626 10%, transparent); color: #dc2626;">
+                          {template.severity}
+                        </span>
+                        <span style="padding: 3px 7px; border-radius: 999px; background: var(--bg-tertiary); color: var(--text-secondary);">
+                          {template.technique}
+                        </span>
+                      </div>
+                    </div>
+                    <span style="font-size: 11px; color: var(--text-muted);">v{template.version}</span>
+                  </div>
+
+                  <div style="margin-top: 10px; display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; font-size: 12px; color: var(--text-secondary);">
+                    <div><strong>Risk:</strong> {template.risk_reference}</div>
+                    <div><strong>Recommended judge:</strong> {template.judge_template}</div>
+                  </div>
+
+                  <details style="margin-top: 10px;">
+                    <summary style="cursor: pointer; font-size: 12px; font-weight: 600;">
+                      Inspect prompt and assertion
+                    </summary>
+                    <pre style="margin: 10px 0 8px; padding: 12px; border-radius: 6px; background: var(--bg-tertiary); border: 1px solid var(--border); white-space: pre-wrap; overflow-wrap: anywhere; font-size: 12px; line-height: 1.5;">{template.prompt}</pre>
+                    <div style="font-size: 11px; color: var(--text-muted); overflow-wrap: anywhere;">
+                      Fails if the response contains canary <code>{template.canary}</code>
+                    </div>
+                  </details>
+                </div>
+              </div>
+            </article>
+          </div>
+        </section>
+      </div>
+    </.form>
+  </div>
+</Layouts.app>

--- a/lib/aludel/web/live/dataset_live/show.html.heex
+++ b/lib/aludel/web/live/dataset_live/show.html.heex
@@ -14,6 +14,13 @@
           Reusable evaluation conversations and expectations
         </p>
       </div>
+      <.link
+        navigate={aludel_path("datasets/#{@dataset.id}/red-team/catalog")}
+        class="button-secondary"
+        style="margin-left: auto;"
+      >
+        <.icon name="hero-shield-exclamation" class="size-4" /> Add red-team cases
+      </.link>
     </div>
 
     <div style="display: grid; grid-template-columns: minmax(300px, 380px) minmax(0, 1fr); gap: 24px; align-items: start;">

--- a/lib/aludel/web/router.ex
+++ b/lib/aludel/web/router.ex
@@ -80,6 +80,12 @@ defmodule Aludel.Web.Router do
           live "/suites/:id", Aludel.Web.SuiteLive.Show, :show, route_opts
 
           live "/datasets", Aludel.Web.DatasetLive.Index, :index, route_opts
+
+          live "/datasets/:id/red-team/catalog",
+               Aludel.Web.DatasetLive.RedTeamCatalog,
+               :show,
+               route_opts
+
           live "/datasets/:id", Aludel.Web.DatasetLive.Show, :show, route_opts
 
           live "/providers", Aludel.Web.ProviderLive.Index, :index, route_opts

--- a/test/aludel_web/live/dataset_live/red_team_catalog_test.exs
+++ b/test/aludel_web/live/dataset_live/red_team_catalog_test.exs
@@ -1,0 +1,117 @@
+defmodule Aludel.Web.DatasetLive.RedTeamCatalogTest do
+  use Aludel.Web.ConnCase, async: false
+
+  import Aludel.DatasetsFixtures
+  import Aludel.ProvidersFixtures
+  import Phoenix.LiveViewTest
+
+  alias Aludel.Datasets
+  alias Aludel.RedTeam
+
+  test "browses every curated case with its risk and judge guidance", %{conn: conn} do
+    dataset = dataset_fixture()
+
+    {:ok, view, _html} = live(conn, "/datasets/#{dataset.id}/red-team/catalog")
+
+    assert has_element?(view, "#red-team-catalog")
+    assert has_element?(view, "#red-team-case-direct-instruction-override", "critical")
+    assert has_element?(view, "#red-team-case-direct-instruction-override", "prompt injection")
+    assert has_element?(view, "#red-team-case-direct-instruction-override", "refusal")
+    assert has_element?(view, "#red-team-case-fabricated-citation", "lunar dust")
+
+    Enum.each(RedTeam.all(), fn template ->
+      assert has_element?(view, "#red-team-case-#{template.id}[data-red-team-case]")
+    end)
+
+    assert has_element?(view, "a[href='/datasets/#{dataset.id}']", "Back to dataset")
+  end
+
+  test "materializes selected cases with an optional judge", %{conn: conn} do
+    dataset = dataset_fixture()
+    provider = provider_fixture()
+    case_id = "direct-instruction-override"
+    {:ok, view, _html} = live(conn, "/datasets/#{dataset.id}/red-team/catalog")
+
+    view
+    |> form("#red-team-materialization-form",
+      materialization: %{
+        case_ids: [case_id],
+        variable: "request",
+        judge_provider_id: provider.id,
+        judge_threshold: "90"
+      }
+    )
+    |> render_submit()
+
+    assert has_element?(view, "#flash-info", "1 case created")
+    assert has_element?(view, "#materialization-result", "1 created")
+    assert has_element?(view, "#materialization-result", "0 already present")
+
+    [entry] = Datasets.list_entries(dataset)
+    template = RedTeam.fetch!(case_id)
+
+    assert entry.variable_values == %{"request" => template.prompt}
+    assert entry.metadata["red_team"]["case_id"] == case_id
+
+    assert List.last(entry.assertions) == %{
+             "type" => "rubric_judge",
+             "template" => "refusal",
+             "provider_id" => provider.id,
+             "threshold" => 90.0
+           }
+  end
+
+  test "reports idempotent skips without duplicating entries", %{conn: conn} do
+    dataset = dataset_fixture()
+    case_id = "fabricated-citation"
+    {:ok, view, _html} = live(conn, "/datasets/#{dataset.id}/red-team/catalog")
+
+    params = %{
+      case_ids: [case_id],
+      variable: "input",
+      judge_provider_id: "",
+      judge_threshold: "80"
+    }
+
+    view
+    |> form("#red-team-materialization-form", materialization: params)
+    |> render_submit()
+
+    view
+    |> form("#red-team-materialization-form", materialization: params)
+    |> render_submit()
+
+    assert has_element?(view, "#flash-info", "1 case already present")
+    assert has_element?(view, "#materialization-result", "0 created")
+    assert has_element?(view, "#materialization-result", "1 already present")
+    assert length(Datasets.list_entries(dataset)) == 1
+  end
+
+  test "rejects empty, unknown, and invalid materialization options", %{conn: conn} do
+    dataset = dataset_fixture()
+    {:ok, view, _html} = live(conn, "/datasets/#{dataset.id}/red-team/catalog")
+
+    render_hook(view, "materialize", %{
+      "materialization" => %{
+        "case_ids" => [],
+        "variable" => "input",
+        "judge_provider_id" => "",
+        "judge_threshold" => "80"
+      }
+    })
+
+    assert has_element?(view, "#materialization-errors", "Select at least one case")
+
+    render_hook(view, "materialize", %{
+      "materialization" => %{
+        "case_ids" => ["missing-case"],
+        "variable" => "invalid variable",
+        "judge_provider_id" => "missing-provider",
+        "judge_threshold" => "not-a-number"
+      }
+    })
+
+    assert has_element?(view, "#materialization-errors", "Unknown catalog case")
+    assert Datasets.list_entries(dataset) == []
+  end
+end

--- a/test/aludel_web/live/dataset_live/show_test.exs
+++ b/test/aludel_web/live/dataset_live/show_test.exs
@@ -12,6 +12,12 @@ defmodule Aludel.Web.DatasetLive.ShowTest do
 
     assert has_element?(view, "#dataset-entries-empty")
 
+    assert has_element?(
+             view,
+             "a[href='/datasets/#{dataset.id}/red-team/catalog']",
+             "Add red-team cases"
+           )
+
     view
     |> form("#dataset-details-form",
       dataset: %{


### PR DESCRIPTION
## Motivation

Curated red-team cases were available through the library API but could not be inspected or added from the dashboard. This made the security regression workflow harder to discover and required application code for a routine dataset operation.

## What changed

- Add a dataset-level catalog that displays every curated prompt, version, category, severity, technique, risk reference, canary, and recommended judge before selection.
- Materialize exact case selections with a configurable prompt variable and optional judge provider and threshold.
- Preserve the backend's transactional, idempotent behavior: exact reruns are reported as already present and conflicting entries are never overwritten.
- Reject unknown case IDs, unconfigured providers, and invalid thresholds before persistence.
- Link the workflow from each dataset and document UI, API, CLI, and ExUnit availability in the README and HexDocs guides.

## Test Plan

- LiveView coverage verifies complete catalog browsing, exact selected-case materialization, optional judge configuration, idempotent reruns, invalid inputs, and dataset navigation.
- Existing backend materialization tests remain green.
- The complete test, formatting, static-analysis, security, documentation, production compilation, dependency audit, and package dry-run gates pass.

## Next Steps

Generated-case review and approval/import will remain a separate focused dashboard change.
