### PR TITLE
refactor(storage): remove compile dependency cycle

### DIFF
--- a/lib/aludel/interfaces/storage.ex
+++ b/lib/aludel/interfaces/storage.ex
@@ -9,6 +9,7 @@ defmodule Aludel.Storage do
   alias Aludel.Interfaces.Storage.Adapters.AWS
   alias Aludel.Interfaces.Storage.Adapters.GCS
   alias Aludel.Interfaces.Storage.Adapters.Local
+  alias Aludel.Storage.Config
 
   @type config :: keyword()
   @type error_reason :: term()
@@ -58,9 +59,7 @@ defmodule Aludel.Storage do
 
   @spec config() :: config()
   def config do
-    :aludel
-    |> Application.get_env(__MODULE__, [])
-    |> resolve_system_values()
+    Config.get()
   end
 
   @spec backend_name(module()) :: String.t()
@@ -128,19 +127,6 @@ defmodule Aludel.Storage do
       _other -> nil
     end)
   end
-
-  defp resolve_system_values(config) when is_list(config) do
-    Enum.map(config, fn
-      {key, {:system, env_var}} -> {key, System.get_env(env_var)}
-      {key, value} -> {key, resolve_system_values(value)}
-    end)
-  end
-
-  defp resolve_system_values(config) when is_map(config) do
-    Map.new(config, fn {key, value} -> {key, resolve_system_values(value)} end)
-  end
-
-  defp resolve_system_values(value), do: value
 
   defp resolve_dynamic_backend(backend) do
     module = String.to_existing_atom(backend)

--- a/lib/aludel/interfaces/storage/adapters/local.ex
+++ b/lib/aludel/interfaces/storage/adapters/local.ex
@@ -5,6 +5,8 @@ defmodule Aludel.Interfaces.Storage.Adapters.Local do
 
   @behaviour Aludel.Interfaces.Storage.Behaviour
 
+  alias Aludel.Storage.Config
+
   @default_root Path.join(System.tmp_dir!(), "aludel-storage")
 
   @impl true
@@ -37,7 +39,9 @@ defmodule Aludel.Interfaces.Storage.Adapters.Local do
   end
 
   @spec path_for(String.t()) :: String.t()
-  def path_for(key), do: path_for(key, Aludel.Storage.config())
+  def path_for(key) do
+    path_for(key, Config.get())
+  end
 
   @spec path_for(String.t(), keyword()) :: String.t()
   def path_for(key, config) do

--- a/lib/aludel/interfaces/storage/config.ex
+++ b/lib/aludel/interfaces/storage/config.ex
@@ -1,0 +1,39 @@
+defmodule Aludel.Storage.Config do
+  @moduledoc """
+  Resolves storage configuration without coupling adapters to the storage facade.
+
+  Values declared as `{:system, variable}` are read from the process environment
+  when configuration is requested. Nested keyword lists and maps are resolved
+  recursively.
+  """
+
+  @type t :: keyword()
+
+  # Keep the configuration key as data so adapters do not compile against the facade.
+  @storage_config_key :"Elixir.Aludel.Storage"
+
+  @doc """
+  Returns the resolved storage configuration for the current application.
+  """
+  @spec get() :: t()
+  def get do
+    :aludel
+    |> Application.get_env(@storage_config_key, [])
+    |> resolve_system_values()
+  end
+
+  defp resolve_system_values(config) when is_list(config) do
+    Enum.map(config, fn
+      {key, {:system, env_var}} -> {key, System.get_env(env_var)}
+      {key, value} -> {key, resolve_system_values(value)}
+    end)
+  end
+
+  defp resolve_system_values(config) when is_map(config) do
+    Map.new(config, fn {key, value} -> {key, resolve_system_values(value)} end)
+  end
+
+  defp resolve_system_values(value) do
+    value
+  end
+end

--- a/test/aludel/interfaces/storage_test.exs
+++ b/test/aludel/interfaces/storage_test.exs
@@ -7,6 +7,7 @@ defmodule Aludel.StorageTest do
   alias Aludel.Interfaces.Storage.Adapters.Local
   alias Aludel.Interfaces.StorageMock
   alias Aludel.Storage
+  alias Aludel.Storage.Config
 
   setup :set_mox_from_context
   setup :verify_on_exit!
@@ -91,6 +92,27 @@ defmodule Aludel.StorageTest do
     end
   end
 
+  test "storage configuration resolves nested system values" do
+    variable = "ALUDEL_STORAGE_TEST_VALUE"
+    original_value = System.get_env(variable)
+    original_config = Application.get_env(:aludel, Aludel.Storage, [])
+
+    System.put_env(variable, "resolved")
+
+    Application.put_env(:aludel, Aludel.Storage,
+      root: {:system, variable},
+      backends: %{Local => [bucket: {:system, variable}]}
+    )
+
+    on_exit(fn ->
+      restore_system_value(variable, original_value)
+      Application.put_env(:aludel, Aludel.Storage, original_config)
+    end)
+
+    assert Config.get() == [root: "resolved", backends: %{Local => [bucket: "resolved"]}]
+    assert Storage.config() == Config.get()
+  end
+
   defp configure_storage(config) do
     original_config = Application.get_env(:aludel, Aludel.Storage, [])
     Application.put_env(:aludel, Aludel.Storage, config)
@@ -98,5 +120,13 @@ defmodule Aludel.StorageTest do
     on_exit(fn ->
       Application.put_env(:aludel, Aludel.Storage, original_config)
     end)
+  end
+
+  defp restore_system_value(variable, nil) do
+    System.delete_env(variable)
+  end
+
+  defp restore_system_value(variable, value) do
+    System.put_env(variable, value)
   end
 end


### PR DESCRIPTION
## Motivation

Move storage configuration resolution into a dedicated module so storage adapters no longer compile against the storage facade. This removes the remaining compile dependency cycle while preserving existing runtime configuration behavior, including nested environment-backed values.

## Test Plan

- Added regression coverage for nested environment-backed storage configuration.
- Storage tests pass: 20 tests, 0 failures.
- Full project checks pass: 887 tests, 0 failures.
- Documentation, static analysis, dependency audit, production compilation, package dry-run, and zero-cycle validation pass.

## Next Steps

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Storage configuration now supports resolving environment variable values, including nested settings.
  * Storage paths and related operations consistently use the resolved configuration.

* **Bug Fixes**
  * Improved handling of storage settings supplied through environment variables, helping ensure configured values are applied correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->