### PR TITLE
fix(web): render prompt tags as text

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,10 @@ jobs:
       - name: Build assets
         run: mix assets.build
 
+      - name: Run frontend tests
+        working-directory: assets
+        run: npm test
+
       - name: Create and migrate database
         run: mix ecto.create && mix ecto.migrate
 

--- a/assets/js/hooks/tag_input.js
+++ b/assets/js/hooks/tag_input.js
@@ -54,22 +54,25 @@ export const TagInput = {
   },
 
   renderTags() {
-    this.container.innerHTML = ''
+    this.container.textContent = ''
 
     this.tags.forEach((tag, index) => {
       const chip = document.createElement('span')
       chip.className = 'tag-chip'
-      chip.innerHTML = `
-        ${tag}
-        <button type="button" class="tag-remove" data-index="${index}">×</button>
-      `
+      chip.appendChild(document.createTextNode(tag))
 
-      const removeBtn = chip.querySelector('.tag-remove')
+      const removeBtn = document.createElement('button')
+      removeBtn.type = 'button'
+      removeBtn.className = 'tag-remove'
+      removeBtn.dataset.index = index
+      removeBtn.textContent = '×'
+
       removeBtn.addEventListener('click', (e) => {
         e.preventDefault()
         this.removeTag(index)
       })
 
+      chip.appendChild(removeBtn)
       this.container.appendChild(chip)
     })
   }

--- a/assets/js/hooks/tag_input.test.mjs
+++ b/assets/js/hooks/tag_input.test.mjs
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict'
+import {readFile} from 'node:fs/promises'
+import test from 'node:test'
+
+const source = await readFile(new URL('./tag_input.js', import.meta.url), 'utf8')
+const moduleUrl = `data:text/javascript;base64,${Buffer.from(source).toString('base64')}`
+const {TagInput} = await import(moduleUrl)
+
+class FakeElement {
+  constructor(tagName) {
+    this.tagName = tagName
+    this.children = []
+    this.dataset = {}
+    this.listeners = new Map()
+    this._textContent = ''
+  }
+
+  get textContent() {
+    return this._textContent
+  }
+
+  set textContent(value) {
+    this._textContent = value
+
+    if (value === '') {
+      this.children = []
+    }
+  }
+
+  appendChild(child) {
+    this.children.push(child)
+    return child
+  }
+
+  addEventListener(name, callback) {
+    this.listeners.set(name, callback)
+  }
+}
+
+test('renders HTML-shaped tags as text while preserving removal', () => {
+  const previousDocument = globalThis.document
+  const payload = '<img src=x onerror=globalThis.compromised=true>'
+  const container = new FakeElement('div')
+
+  globalThis.document = {
+    createElement: (name) => new FakeElement(name),
+    createTextNode: (value) => ({nodeType: 3, textContent: value})
+  }
+
+  const hook = {
+    ...TagInput,
+    container,
+    tags: [payload, 'ordinary'],
+    hiddenInput: {
+      value: '',
+      dispatchEvent() {}
+    }
+  }
+
+  try {
+    hook.renderTags()
+
+    const [chip] = container.children
+    const [tagNode, removeButton] = chip.children
+
+    assert.equal(tagNode.nodeType, 3)
+    assert.equal(tagNode.textContent, payload)
+    assert.equal(removeButton.tagName, 'button')
+    assert.equal(removeButton.textContent, '×')
+
+    removeButton.listeners.get('click')({preventDefault() {}})
+
+    assert.deepEqual(hook.tags, ['ordinary'])
+    assert.equal(hook.hiddenInput.value, 'ordinary')
+    assert.equal(container.children.length, 1)
+    assert.equal(container.children[0].children[0].textContent, 'ordinary')
+  } finally {
+    globalThis.document = previousDocument
+  }
+})

--- a/assets/package.json
+++ b/assets/package.json
@@ -2,6 +2,9 @@
   "name": "aludel",
   "version": "1.0.0",
   "private": true,
+  "scripts": {
+    "test": "node --test js/**/*.test.mjs"
+  },
   "dependencies": {
     "chart.js": "^4.5.1"
   }

--- a/priv/static/app.js
+++ b/priv/static/app.js
@@ -22140,19 +22140,21 @@ removing illegal node: "${("outerHTML" in childNode && childNode.outerHTML || ch
       this.hiddenInput.dispatchEvent(new Event("input", { bubbles: true }));
     },
     renderTags() {
-      this.container.innerHTML = "";
+      this.container.textContent = "";
       this.tags.forEach((tag, index) => {
         const chip = document.createElement("span");
         chip.className = "tag-chip";
-        chip.innerHTML = `
-        ${tag}
-        <button type="button" class="tag-remove" data-index="${index}">\xD7</button>
-      `;
-        const removeBtn = chip.querySelector(".tag-remove");
+        chip.appendChild(document.createTextNode(tag));
+        const removeBtn = document.createElement("button");
+        removeBtn.type = "button";
+        removeBtn.className = "tag-remove";
+        removeBtn.dataset.index = index;
+        removeBtn.textContent = "\xD7";
         removeBtn.addEventListener("click", (e) => {
           e.preventDefault();
           this.removeTag(index);
         });
+        chip.appendChild(removeBtn);
         this.container.appendChild(chip);
       });
     }

--- a/test/aludel/web/assets_test.exs
+++ b/test/aludel/web/assets_test.exs
@@ -27,6 +27,18 @@ defmodule Aludel.Web.AssetsTest do
       assert conn.status == 404
       assert conn.resp_body == "Not Found"
     end
+
+    test "tag input renders persisted tags as text" do
+      source = File.read!("assets/js/hooks/tag_input.js")
+      bundle = File.read!("priv/static/app.js")
+
+      assert source =~ "document.createTextNode(tag)"
+      assert source =~ "removeBtn.textContent = '×'"
+      refute source =~ "chip.innerHTML"
+
+      assert bundle =~ "document.createTextNode(tag)"
+      refute bundle =~ "chip.innerHTML"
+    end
   end
 
   describe "call/2 :font" do


### PR DESCRIPTION
## Motivation

Persisted prompt tags were interpolated into a DOM HTML sink by the tag-input hook. An HTML-shaped tag could therefore be parsed as markup when a prompt edit page loaded.

Render tag values exclusively as text nodes and construct the remove button with DOM APIs. Keep the committed JavaScript bundle synchronized with its source.

## Test Plan

- Added an executable frontend regression covering an HTML-shaped tag, ordinary rendering, removal, and hidden-input synchronization.
- Added a source-to-bundle parity guard for the safe DOM construction.
- Related frontend and prompt LiveView tests pass: 13 tests, 0 failures.
- Full project checks pass: 888 tests, 0 failures.
- Frontend dependency audit reports zero vulnerabilities.

## Next Steps

None.