### PR TITLE
fix(web): enforce read-only access

### DIFF
--- a/lib/aludel/web/authentication.ex
+++ b/lib/aludel/web/authentication.ex
@@ -1,9 +1,88 @@
 defmodule Aludel.Web.Authentication do
   @moduledoc """
-  LiveView on_mount hook for Aludel dashboard authentication.
+  Loads dashboard session context and enforces LiveView access decisions.
   """
 
   import Phoenix.Component, only: [assign: 3]
+
+  @read_only_events %{
+    Aludel.Web.DashboardLive => MapSet.new(~w(
+        toggle_cost_breakdown
+        toggle_latency_breakdown
+        toggle_activity_chart
+        toggle_cost_view
+        toggle_pass_rates
+      )),
+    Aludel.Web.DatasetLive.GeneratedRedTeam =>
+      MapSet.new(~w(validate_generation validate_import)),
+    Aludel.Web.DatasetLive.Index => MapSet.new(~w(validate)),
+    Aludel.Web.DatasetLive.RedTeamCatalog => MapSet.new(~w(validate_materialization)),
+    Aludel.Web.DatasetLive.Show => MapSet.new(~w(validate_dataset validate_entry filter_entries)),
+    Aludel.Web.PromptLive.Evolution => MapSet.new(~w(
+        toggle_view_mode
+        chart-mounted
+        toggle_breakdown_sidebar
+        toggle_export_dropdown
+        close_export_dropdown
+        select_pareto_suite
+      )),
+    Aludel.Web.PromptLive.Index => MapSet.new(~w(
+        search
+        toggle_tag
+        clear_filters
+        toggle_project
+        select_project
+        clear_project
+        validate_create_project
+        validate_update_project
+        phx-noop
+      )),
+    Aludel.Web.PromptLive.New => MapSet.new(~w(validate)),
+    Aludel.Web.PromptLive.Show => MapSet.new(~w(
+        select_version
+        select_comparison_version
+        show_version_diff
+        hide_version_diff
+      )),
+    Aludel.Web.ProviderLive.New => MapSet.new(~w(validate)),
+    Aludel.Web.RunLive.New => MapSet.new(~w(validate)),
+    Aludel.Web.SuiteLive.Index => MapSet.new(~w(
+        toggle_project
+        validate_create_project
+        validate_update_project
+        phx-noop
+      )),
+    Aludel.Web.SuiteLive.New => MapSet.new(~w(
+        validate
+        add_test_case
+        remove_test_case
+        toggle_assertion_mode
+        add_assertion
+        remove_assertion
+      )),
+    Aludel.Web.SuiteLive.Policy => MapSet.new(~w(validate)),
+    Aludel.Web.SuiteLive.Report => MapSet.new(~w(preview)),
+    Aludel.Web.SuiteLive.Show => MapSet.new(~w(
+        edit_suite_metadata
+        cancel_edit_suite_metadata
+        validate_suite_metadata
+        select_version
+        select_provider
+        validate_run_suite
+        toggle_assertion_mode
+        add_assertion
+        remove_assertion
+        toggle_test_case_import
+        validate_test_case_import
+        cancel_test_case_import_upload
+        preview_test_case_import
+        edit_test_case
+        cancel_edit
+        validate_test_case
+      ))
+  }
+
+  @read_only_message "This dashboard is read-only. Changes and model requests are disabled."
 
   @doc false
   def on_mount(:default, _params, session, socket) do
@@ -22,7 +101,42 @@ defmodule Aludel.Web.Authentication do
       |> assign(:csp_nonces, session["csp_nonces"])
       |> assign(:live_path, session["live_path"])
       |> assign(:live_transport, session["live_transport"])
+      |> attach_access_hook()
 
     {:cont, socket}
+  end
+
+  @doc false
+  @spec authorize_event(String.t(), map(), Phoenix.LiveView.Socket.t()) ::
+          {:cont, Phoenix.LiveView.Socket.t()} | {:halt, Phoenix.LiveView.Socket.t()}
+  def authorize_event(_event, _params, %{assigns: %{access: :all}} = socket) do
+    {:cont, socket}
+  end
+
+  def authorize_event(event, _params, %{assigns: %{access: :read_only}, view: view} = socket) do
+    allowed_events = Map.get(@read_only_events, view, MapSet.new())
+
+    if MapSet.member?(allowed_events, event) do
+      {:cont, socket}
+    else
+      {:halt, Phoenix.LiveView.put_flash(socket, :error, @read_only_message)}
+    end
+  end
+
+  def authorize_event(_event, _params, socket) do
+    {:halt, Phoenix.LiveView.put_flash(socket, :error, @read_only_message)}
+  end
+
+  defp attach_access_hook(socket) do
+    if Phoenix.LiveView.connected?(socket) do
+      Phoenix.LiveView.attach_hook(
+        socket,
+        :aludel_authorize_access,
+        :handle_event,
+        &authorize_event/3
+      )
+    else
+      socket
+    end
   end
 end

--- a/lib/aludel/web/components/layouts.ex
+++ b/lib/aludel/web/components/layouts.ex
@@ -34,6 +34,7 @@ defmodule Aludel.Web.Layouts do
     doc: "the current [scope](https://hexdocs.pm/phoenix/scopes.html)"
 
   attr :current_path, :string, default: "", doc: "the current path for active link detection"
+  attr :access, :atom, default: :all, values: [:all, :read_only]
 
   slot :inner_block, required: true
 
@@ -66,6 +67,14 @@ defmodule Aludel.Web.Layouts do
 
     <main class="aludel-main">
       <div class="aludel-container">
+        <div
+          :if={@access == :read_only}
+          id="read-only-banner"
+          role="status"
+          class="mb-6 rounded-lg border border-warning/40 bg-warning/10 px-4 py-3 text-sm text-base-content"
+        >
+          Read-only mode is active. Changes and model requests are disabled.
+        </div>
         {render_slot(@inner_block)}
       </div>
     </main>

--- a/lib/aludel/web/live/dashboard_live.html.heex
+++ b/lib/aludel/web/live/dashboard_live.html.heex
@@ -1,4 +1,4 @@
-<Layouts.app flash={@flash} current_path={@current_path}>
+<Layouts.app flash={@flash} current_path={@current_path} access={@access}>
   <div id="dashboard" class="page-container-wide">
     <div class="page-header flex-between">
       <div>

--- a/lib/aludel/web/live/dataset_live/generated_red_team.html.heex
+++ b/lib/aludel/web/live/dataset_live/generated_red_team.html.heex
@@ -1,4 +1,4 @@
-<Layouts.app flash={@flash} current_path={@current_path}>
+<Layouts.app flash={@flash} current_path={@current_path} access={@access}>
   <div id="generated-red-team-workflow" class="page-container-wide" style="max-width: 1180px;">
     <div style="margin-bottom: 28px; padding-bottom: 20px; border-bottom: 1px solid var(--border);">
       <.link

--- a/lib/aludel/web/live/dataset_live/index.html.heex
+++ b/lib/aludel/web/live/dataset_live/index.html.heex
@@ -1,4 +1,4 @@
-<Layouts.app flash={@flash} current_path={@current_path}>
+<Layouts.app flash={@flash} current_path={@current_path} access={@access}>
   <div class="page-container-wide">
     <div style="display: grid; grid-template-columns: minmax(280px, 360px) minmax(0, 1fr); gap: 24px; align-items: start;">
       <section class="aludel-card" aria-labelledby="new-dataset-heading">

--- a/lib/aludel/web/live/dataset_live/red_team_catalog.html.heex
+++ b/lib/aludel/web/live/dataset_live/red_team_catalog.html.heex
@@ -1,4 +1,4 @@
-<Layouts.app flash={@flash} current_path={@current_path}>
+<Layouts.app flash={@flash} current_path={@current_path} access={@access}>
   <div class="page-container-wide" style="max-width: 1180px;">
     <div style="display: flex; justify-content: space-between; align-items: start; gap: 24px; margin-bottom: 28px; padding-bottom: 20px; border-bottom: 1px solid var(--border);">
       <div>

--- a/lib/aludel/web/live/dataset_live/show.html.heex
+++ b/lib/aludel/web/live/dataset_live/show.html.heex
@@ -1,4 +1,4 @@
-<Layouts.app flash={@flash} current_path={@current_path}>
+<Layouts.app flash={@flash} current_path={@current_path} access={@access}>
   <div class="page-container-wide">
     <div style="display: flex; align-items: center; gap: 10px; margin-bottom: 24px;">
       <.link

--- a/lib/aludel/web/live/prompt_live/evolution.html.heex
+++ b/lib/aludel/web/live/prompt_live/evolution.html.heex
@@ -1,4 +1,4 @@
-<Layouts.app flash={@flash} current_path={@current_path}>
+<Layouts.app flash={@flash} current_path={@current_path} access={@access}>
   <div id="prompt-evolution" class="page-container-wide">
     <div style="margin-bottom: 32px; padding-bottom: 20px; border-bottom: 1px solid var(--border);">
       <div style="display: flex; justify-content: space-between; align-items: start; margin-bottom: 12px;">

--- a/lib/aludel/web/live/prompt_live/index.html.heex
+++ b/lib/aludel/web/live/prompt_live/index.html.heex
@@ -1,4 +1,4 @@
-<Layouts.app flash={@flash} current_path={@current_path}>
+<Layouts.app flash={@flash} current_path={@current_path} access={@access}>
   <div class="page-container-wide">
     <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 32px; padding-bottom: 20px; border-bottom: 1px solid var(--border);">
       <div style="display: flex; align-items: center; gap: 12px;">

--- a/lib/aludel/web/live/prompt_live/new.html.heex
+++ b/lib/aludel/web/live/prompt_live/new.html.heex
@@ -1,4 +1,4 @@
-<Layouts.app flash={@flash} current_path={@current_path}>
+<Layouts.app flash={@flash} current_path={@current_path} access={@access}>
   <div style="max-width: 1200px; margin: 0 auto;">
     <%= if @live_action == :new do %>
       <div style="max-width: 800px; margin: 0 auto;">

--- a/lib/aludel/web/live/prompt_live/show.html.heex
+++ b/lib/aludel/web/live/prompt_live/show.html.heex
@@ -1,4 +1,4 @@
-<Layouts.app flash={@flash} current_path={@current_path}>
+<Layouts.app flash={@flash} current_path={@current_path} access={@access}>
   <div style="max-width: 1400px; margin: 0 auto; padding: 0 20px;">
     <div style="margin-bottom: 32px; padding-bottom: 20px; border-bottom: 1px solid var(--border);">
       <div style="display: flex; justify-content: space-between; align-items: start; margin-bottom: 12px;">

--- a/lib/aludel/web/live/provider_live/index.html.heex
+++ b/lib/aludel/web/live/provider_live/index.html.heex
@@ -1,4 +1,4 @@
-<Layouts.app flash={@flash} current_path={@current_path}>
+<Layouts.app flash={@flash} current_path={@current_path} access={@access}>
   <div class="page-container-wide">
     <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 32px; padding-bottom: 20px; border-bottom: 1px solid var(--border);">
       <div style="display: flex; align-items: center; gap: 12px;">

--- a/lib/aludel/web/live/provider_live/new.html.heex
+++ b/lib/aludel/web/live/provider_live/new.html.heex
@@ -1,4 +1,4 @@
-<Layouts.app flash={@flash} current_path={@current_path}>
+<Layouts.app flash={@flash} current_path={@current_path} access={@access}>
   <div style="max-width: 800px; margin: 0 auto;">
     <h1>{if @live_action == :new, do: "New Provider", else: "Edit Provider"}</h1>
 

--- a/lib/aludel/web/live/run_live/new.html.heex
+++ b/lib/aludel/web/live/run_live/new.html.heex
@@ -1,4 +1,4 @@
-<Layouts.app flash={@flash} current_path={@current_path}>
+<Layouts.app flash={@flash} current_path={@current_path} access={@access}>
   <div style="max-width: 1200px; margin: 0 auto;">
     <h1>Configure Run</h1>
     <p style="margin-bottom: 24px; color: var(--text-secondary);">

--- a/lib/aludel/web/live/run_live/show.html.heex
+++ b/lib/aludel/web/live/run_live/show.html.heex
@@ -1,4 +1,4 @@
-<Layouts.app flash={@flash} current_path={@current_path}>
+<Layouts.app flash={@flash} current_path={@current_path} access={@access}>
   <div style="max-width: 1000px; margin: 0 auto;">
     <div style="display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 24px;">
       <div>

--- a/lib/aludel/web/live/suite_live/index.html.heex
+++ b/lib/aludel/web/live/suite_live/index.html.heex
@@ -1,4 +1,4 @@
-<Layouts.app flash={@flash} current_path={@current_path}>
+<Layouts.app flash={@flash} current_path={@current_path} access={@access}>
   <div class="page-container-wide">
     <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 32px; padding-bottom: 20px; border-bottom: 1px solid var(--border);">
       <div style="display: flex; align-items: center; gap: 12px;">

--- a/lib/aludel/web/live/suite_live/new.html.heex
+++ b/lib/aludel/web/live/suite_live/new.html.heex
@@ -1,4 +1,4 @@
-<Layouts.app flash={@flash} current_path={@current_path}>
+<Layouts.app flash={@flash} current_path={@current_path} access={@access}>
   <.form for={@form} id="suite-form" phx-change="validate" phx-submit="save">
     <div style="display: grid; grid-template-columns: 400px 1fr; height: calc(100vh - 60px); overflow: hidden;">
       <%!-- Column 1: Suite Details --%>

--- a/lib/aludel/web/live/suite_live/policy.html.heex
+++ b/lib/aludel/web/live/suite_live/policy.html.heex
@@ -1,4 +1,4 @@
-<Layouts.app flash={@flash} current_path={@current_path}>
+<Layouts.app flash={@flash} current_path={@current_path} access={@access}>
   <div class="page-container-wide" style="max-width: 1120px;">
     <div style="display: flex; justify-content: space-between; align-items: start; gap: 24px; margin-bottom: 28px; padding-bottom: 20px; border-bottom: 1px solid var(--border);">
       <div>

--- a/lib/aludel/web/live/suite_live/report.html.heex
+++ b/lib/aludel/web/live/suite_live/report.html.heex
@@ -1,4 +1,4 @@
-<Layouts.app flash={@flash} current_path={@current_path}>
+<Layouts.app flash={@flash} current_path={@current_path} access={@access}>
   <div class="page-container-wide" style="max-width: 1120px;">
     <div style="display: flex; justify-content: space-between; align-items: start; gap: 24px; margin-bottom: 28px; padding-bottom: 20px; border-bottom: 1px solid var(--border);">
       <div>

--- a/lib/aludel/web/live/suite_live/show.html.heex
+++ b/lib/aludel/web/live/suite_live/show.html.heex
@@ -1,4 +1,4 @@
-<Layouts.app flash={@flash} current_path={@current_path}>
+<Layouts.app flash={@flash} current_path={@current_path} access={@access}>
   <div style="display: grid; grid-template-columns: 400px 1fr 1fr; height: calc(100vh - 60px); overflow-x: hidden; overflow-y: hidden;">
     <%!-- Column 1: Prompt & Controls --%>
     <div style="padding: 24px; overflow-y: auto; overflow-x: hidden; border-right: 1px solid var(--border);">

--- a/test/aludel/web/authentication_test.exs
+++ b/test/aludel/web/authentication_test.exs
@@ -50,4 +50,60 @@ defmodule Aludel.Web.AuthenticationTest do
       assert updated_socket.assigns.csp_nonces == %{img: "abc", style: "def", script: "ghi"}
     end
   end
+
+  describe "authorize_event/3" do
+    test "blocks mutations for read-only access" do
+      provider_socket = socket(Aludel.Web.ProviderLive.Index, :read_only)
+      run_socket = socket(Aludel.Web.RunLive.New, :read_only)
+
+      assert {:halt, updated_socket} =
+               Authentication.authorize_event("delete", %{}, provider_socket)
+
+      assert updated_socket.assigns.flash["error"] =~ "read-only"
+      assert {:halt, _socket} = Authentication.authorize_event("save", %{}, run_socket)
+    end
+
+    test "allows inspection events for read-only access" do
+      socket = socket(Aludel.Web.PromptLive.Index, :read_only)
+
+      assert {:cont, ^socket} = Authentication.authorize_event("search", %{}, socket)
+    end
+
+    test "classifies events by view as well as name" do
+      new_suite_socket = socket(Aludel.Web.SuiteLive.New, :read_only)
+      existing_suite_socket = socket(Aludel.Web.SuiteLive.Show, :read_only)
+
+      assert {:cont, ^new_suite_socket} =
+               Authentication.authorize_event("add_test_case", %{}, new_suite_socket)
+
+      assert {:halt, _socket} =
+               Authentication.authorize_event("add_test_case", %{}, existing_suite_socket)
+    end
+
+    test "allows all events for full access" do
+      socket = socket(Aludel.Web.ProviderLive.Index, :all)
+
+      assert {:cont, ^socket} = Authentication.authorize_event("delete", %{}, socket)
+      assert {:cont, ^socket} = Authentication.authorize_event("future_event", %{}, socket)
+    end
+
+    test "denies unknown events and invalid access values" do
+      read_only_socket = socket(Aludel.Web.DashboardLive, :read_only)
+      invalid_socket = socket(Aludel.Web.DashboardLive, :unexpected)
+
+      assert {:halt, _socket} =
+               Authentication.authorize_event("future_event", %{}, read_only_socket)
+
+      assert {:halt, _socket} =
+               Authentication.authorize_event("toggle_cost_view", %{}, invalid_socket)
+    end
+  end
+
+  defp socket(view, access) do
+    %Phoenix.LiveView.Socket{
+      view: view,
+      assigns: %{__changed__: %{}, access: access, flash: %{}},
+      private: %{live_temp: %{}}
+    }
+  end
 end

--- a/test/aludel/web/read_only_access_test.exs
+++ b/test/aludel/web/read_only_access_test.exs
@@ -1,0 +1,25 @@
+defmodule Aludel.Web.ReadOnlyAccessTest do
+  use Aludel.Web.ConnCase, async: false
+
+  import Aludel.ProvidersFixtures
+
+  alias Aludel.Providers
+
+  test "blocks direct mutation events", %{conn: conn} do
+    provider = provider_fixture(%{name: "Protected Provider"})
+    {:ok, view, html} = live(conn, "/read-only/providers")
+
+    assert html =~ "Read-only mode is active"
+    assert render_click(view, "delete", %{"id" => provider.id}) =~ "read-only"
+    assert Providers.get_provider!(provider.id).id == provider.id
+  end
+
+  test "keeps inspection events available", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/read-only/")
+
+    html = render_click(view, "toggle_cost_view", %{})
+
+    assert html =~ "Read-only mode is active"
+    refute html =~ "This dashboard is read-only. Changes and model requests are disabled."
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -27,6 +27,25 @@ Application.put_env(:aludel, Aludel.Web.Endpoint,
 )
 
 # Define test router
+defmodule Aludel.Web.Test.ReadOnlyResolver do
+  @behaviour Aludel.Web.Resolver
+
+  @impl true
+  def resolve_user(_conn) do
+    %{id: "read-only-user"}
+  end
+
+  @impl true
+  def resolve_access(_user) do
+    :read_only
+  end
+
+  @impl true
+  def resolve_refresh(_user) do
+    5
+  end
+end
+
 defmodule Aludel.Web.Test.Router do
   use Phoenix.Router
 
@@ -40,6 +59,15 @@ defmodule Aludel.Web.Test.Router do
   scope "/" do
     pipe_through :browser
     aludel_dashboard("/")
+  end
+
+  scope "/read-only" do
+    pipe_through :browser
+
+    aludel_dashboard("/",
+      as: :read_only_aludel,
+      resolver: Aludel.Web.Test.ReadOnlyResolver
+    )
   end
 end
 


### PR DESCRIPTION
## Motivation

Resolver access decisions were present in the signed LiveView session but were not enforced by event handlers. A read-only user could submit direct mutation events and trigger data changes or model requests.

Attach a shared, fail-closed LiveView event hook that classifies inspection events by view and blocks every other event for read-only sessions. Add a consistent read-only banner across dashboard pages while retaining inspection and export workflows.

## Test Plan

- Added boundary tests for blocked mutations, blocked model requests, allowed inspection events, view-specific event classification, invalid access values, and unrestricted full access.
- Added an integration test proving a direct provider-deletion event leaves the record intact.
- Added an integration test proving an inspection event remains available in read-only mode.
- Full project checks pass: 895 tests, 0 failures.
- Documentation, static analysis, production compilation, and zero-cycle validation pass.

## Next Steps

None.