### PR TITLE
fix(standalone): require production authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,9 +24,9 @@ OPENROUTER_API_KEY=your_openrouter_api_key_here
 # Environment
 MIX_ENV=dev
 
-# Basic Auth (optional)
-# BASIC_AUTH_USER=admin
-# BASIC_AUTH_PASS=secret
+# Basic Auth (required in production)
+BASIC_AUTH_USER=
+BASIC_AUTH_PASS=
 
 # Read-only mode (optional)
 # READ_ONLY=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,10 @@ jobs:
       - name: Run tests with coverage
         run: mix coveralls.json
 
+      - name: Test standalone application
+        working-directory: standalone
+        run: mix deps.get && mix compile --warnings-as-errors && mix test --no-start
+
       # Only upload coverage when the PR can access repository secrets.
       # Dependabot and fork PRs should not fail CI on the upload step.
       - name: Upload coverage to Codecov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Security
+- Require nonblank HTTP Basic Authentication credentials before the standalone production endpoint starts
+- Compare standalone Basic Authentication credentials with Plug's constant-time verifier
+- Enforce resolver read-only decisions server-side for all dashboard mutation and model-request events
+- Render persisted prompt tags as text instead of reparsing them as HTML
+
 ## [0.6.1] - 2026-09-04
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -473,13 +473,15 @@ mix aludel.seed
 
 Visit `http://localhost:4000`.
 
-The standalone release also supports optional HTTP Basic Authentication and read-only access:
+The standalone release requires HTTP Basic Authentication in production and also supports read-only access:
 
 ```bash
 export BASIC_AUTH_USER=admin
-export BASIC_AUTH_PASS=change-me
+export BASIC_AUTH_PASS="$(openssl rand -base64 32)"
 export READ_ONLY=true
 ```
+
+Production startup rejects missing, partial, or blank credentials. Local development remains unauthenticated and binds only to loopback. Serve production Basic Authentication over TLS; if a reverse proxy terminates TLS, preserve the `Authorization` header and do not expose the backend port directly.
 
 To smoke-test callback mode in the standalone app, configure a local executor module in `standalone/lib/aludel_dash.ex` or another module loaded by the standalone app, then add:
 

--- a/guides/embedding.md
+++ b/guides/embedding.md
@@ -242,15 +242,17 @@ mix ecto.migrate
 mix phx.server
 ```
 
-Optional standalone access controls:
+Standalone production requires Basic Authentication. Generate a strong password and optionally enable read-only access:
 
 ```bash
 export BASIC_AUTH_USER=admin
-export BASIC_AUTH_PASS=change-me
+export BASIC_AUTH_PASS="$(openssl rand -base64 32)"
 export READ_ONLY=true
 ```
 
-Set both Basic Authentication values to enable the challenge. `READ_ONLY=true` keeps the dashboard visible while disabling mutations.
+Production startup rejects missing, partial, or blank credentials. Local development remains unauthenticated and listens only on loopback. `READ_ONLY=true` keeps the dashboard visible while server-side authorization blocks mutations and model requests.
+
+Basic Authentication credentials require TLS in production. When a reverse proxy terminates TLS, preserve the `Authorization` header and keep the backend port private so clients cannot bypass the proxy.
 
 ## Docker Compose
 

--- a/guides/features.md
+++ b/guides/features.md
@@ -168,7 +168,7 @@ The embedded dashboard supports:
 - self-contained versioned CSS and JavaScript plus packaged fonts, icons, and images
 - light, dark, and system themes
 
-The standalone release adds optional HTTP Basic Authentication and read-only mode. See the [Embedding Guide](embedding.md) for configuration.
+The standalone release requires HTTP Basic Authentication in production and supports server-enforced read-only mode. Local development remains unauthenticated on loopback. See the [Embedding Guide](embedding.md) for configuration and TLS guidance.
 
 ## Demo data
 

--- a/standalone/config/dev.exs
+++ b/standalone/config/dev.exs
@@ -1,5 +1,7 @@
 import Config
 
+config :aludel_dash, :basic_auth, :disabled
+
 config :aludel_dash, AludelDash.Repo,
   username: "postgres",
   password: "postgres",

--- a/standalone/config/runtime.exs
+++ b/standalone/config/runtime.exs
@@ -5,6 +5,21 @@ if System.get_env("PHX_SERVER") do
 end
 
 if config_env() == :prod do
+  basic_auth =
+    case AludelDash.BasicAuth.validate_credentials(
+           System.get_env("BASIC_AUTH_USER"),
+           System.get_env("BASIC_AUTH_PASS")
+         ) do
+      {:ok, credentials} ->
+        credentials
+
+      {:error, :invalid_credentials} ->
+        raise """
+        BASIC_AUTH_USER and BASIC_AUTH_PASS must both be set to nonblank values.
+        BASIC_AUTH_USER cannot contain a colon.
+        """
+    end
+
   database_url =
     System.get_env("DATABASE_URL") ||
       raise """
@@ -30,8 +45,7 @@ if config_env() == :prod do
     secret_key_base: secret_key_base
 
   config :aludel_dash,
-    basic_auth_user: System.get_env("BASIC_AUTH_USER"),
-    basic_auth_pass: System.get_env("BASIC_AUTH_PASS"),
+    basic_auth: basic_auth,
     read_only: System.get_env("READ_ONLY") == "true"
 
   config :aludel, :llm,

--- a/standalone/config/test.exs
+++ b/standalone/config/test.exs
@@ -1,0 +1,5 @@
+import Config
+
+config :aludel_dash, :basic_auth, :disabled
+
+config :aludel_dash, AludelDash.Endpoint, server: false

--- a/standalone/lib/aludel_dash.ex
+++ b/standalone/lib/aludel_dash.ex
@@ -13,33 +13,48 @@ end
 defmodule AludelDash.BasicAuth do
   @moduledoc false
 
-  import Plug.Conn
+  @realm "Aludel Dashboard"
 
-  def init(opts), do: opts
+  @spec init(keyword()) :: keyword()
+  def init(opts) do
+    opts
+  end
 
+  @spec call(Plug.Conn.t(), keyword()) :: Plug.Conn.t()
   def call(conn, _opts) do
-    user = Application.get_env(:aludel_dash, :basic_auth_user)
-    pass = Application.get_env(:aludel_dash, :basic_auth_pass)
+    case Application.fetch_env!(:aludel_dash, :basic_auth) do
+      :disabled ->
+        conn
 
-    if user && pass do
-      authenticate(conn, user, pass)
-    else
-      conn
+      credentials when is_list(credentials) ->
+        Plug.BasicAuth.basic_auth(conn, credentials)
+
+      _invalid ->
+        raise ArgumentError, "invalid standalone Basic Authentication configuration"
     end
   end
 
-  defp authenticate(conn, user, pass) do
-    with ["Basic " <> encoded] <- get_req_header(conn, "authorization"),
-         {:ok, decoded} <- Base.decode64(encoded),
-         ^decoded <- "#{user}:#{pass}" do
-      conn
+  @spec validate_credentials(String.t() | nil, String.t() | nil) ::
+          {:ok, keyword()} | {:error, :invalid_credentials}
+  def validate_credentials(username, password)
+      when is_binary(username) and is_binary(password) do
+    if valid_username?(username) and present?(password) do
+      {:ok, username: username, password: password, realm: @realm}
     else
-      _ ->
-        conn
-        |> put_resp_header("www-authenticate", ~s(Basic realm="Aludel Dashboard"))
-        |> send_resp(401, "Unauthorized")
-        |> halt()
+      {:error, :invalid_credentials}
     end
+  end
+
+  def validate_credentials(_username, _password) do
+    {:error, :invalid_credentials}
+  end
+
+  defp valid_username?(username) do
+    present?(username) and not String.contains?(username, ":")
+  end
+
+  defp present?(value) do
+    String.trim(value) != ""
   end
 end
 

--- a/standalone/test/aludel_dash/basic_auth_test.exs
+++ b/standalone/test/aludel_dash/basic_auth_test.exs
@@ -1,0 +1,122 @@
+defmodule AludelDash.BasicAuthTest do
+  use ExUnit.Case, async: false
+
+  import Plug.Conn
+  import Plug.Test
+
+  alias AludelDash.BasicAuth
+
+  setup do
+    original_config = Application.get_env(:aludel_dash, :basic_auth)
+
+    on_exit(fn ->
+      restore_config(original_config)
+    end)
+  end
+
+  test "valid credentials continue through the plug" do
+    configure_credentials("admin", "correct horse battery staple")
+
+    conn =
+      :get
+      |> conn("/")
+      |> put_req_header(
+        "authorization",
+        Plug.BasicAuth.encode_basic_auth("admin", "correct horse battery staple")
+      )
+      |> BasicAuth.call([])
+
+    refute conn.halted
+  end
+
+  test "passwords containing a colon remain valid" do
+    configure_credentials("admin", "correct:horse")
+
+    conn =
+      :get
+      |> conn("/")
+      |> put_req_header(
+        "authorization",
+        Plug.BasicAuth.encode_basic_auth("admin", "correct:horse")
+      )
+      |> BasicAuth.call([])
+
+    refute conn.halted
+  end
+
+  test "missing and incorrect request credentials receive the challenge" do
+    configure_credentials("admin", "correct horse battery staple")
+
+    for authorization <- [
+          nil,
+          "Basic invalid",
+          Plug.BasicAuth.encode_basic_auth("admin", "wrong")
+        ] do
+      conn = conn(:get, "/")
+
+      conn =
+        case authorization do
+          nil -> conn
+          value -> put_req_header(conn, "authorization", value)
+        end
+
+      conn = BasicAuth.call(conn, [])
+
+      assert conn.halted
+      assert conn.status == 401
+      assert conn.resp_body == "Unauthorized"
+      assert get_resp_header(conn, "www-authenticate") == [~s(Basic realm="Aludel Dashboard")]
+    end
+  end
+
+  test "missing and malformed application configuration fail closed" do
+    Application.delete_env(:aludel_dash, :basic_auth)
+
+    assert_raise ArgumentError, fn ->
+      BasicAuth.call(conn(:get, "/"), [])
+    end
+
+    Application.put_env(:aludel_dash, :basic_auth, nil)
+
+    assert_raise ArgumentError, fn ->
+      BasicAuth.call(conn(:get, "/"), [])
+    end
+  end
+
+  test "explicitly disabled development authentication allows requests" do
+    Application.put_env(:aludel_dash, :basic_auth, :disabled)
+
+    refute BasicAuth.call(conn(:get, "/"), []).halted
+  end
+
+  test "credential validation rejects unsafe production values" do
+    invalid_values = [
+      {nil, nil},
+      {"admin", nil},
+      {nil, "password"},
+      {"", "password"},
+      {"admin", ""},
+      {"   ", "password"},
+      {"admin", "   "},
+      {"admin:operator", "password"}
+    ]
+
+    for {username, password} <- invalid_values do
+      assert {:error, :invalid_credentials} =
+               BasicAuth.validate_credentials(username, password)
+    end
+  end
+
+  defp configure_credentials(username, password) do
+    assert {:ok, credentials} = BasicAuth.validate_credentials(username, password)
+    Application.put_env(:aludel_dash, :basic_auth, credentials)
+  end
+
+  defp restore_config(nil) do
+    Application.delete_env(:aludel_dash, :basic_auth)
+  end
+
+  defp restore_config(config) do
+    Application.put_env(:aludel_dash, :basic_auth, config)
+  end
+end

--- a/standalone/test/test_helper.exs
+++ b/standalone/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
## Motivation

The standalone production release previously skipped authentication when either credential was absent, which could expose the dashboard unintentionally. Production now validates both credentials before the endpoint starts and delegates request verification to Plug’s constant-time Basic Authentication implementation. Development remains unauthenticated on loopback.

The same change documents TLS and reverse-proxy requirements and adds standalone coverage to the root CI workflow.

## Test Plan

- Added six standalone tests covering valid credentials, colon-containing passwords, malformed and incorrect request headers, invalid application configuration, development opt-out, and unsafe production values.
- Verified the standalone application compiles without warnings and all standalone tests pass.
- Verified production release startup rejects missing, partial, and blank credentials and accepts valid credentials.
- Verified the root suite passes with 895 tests.
- Verified documentation builds without warnings, the package dry run succeeds, and the dependency audit reports no known vulnerabilities.

## Next Steps

The production authentication boundary, tests, CI coverage, and operator documentation are contained in this focused change.