### PR TITLE
fix(deploy): harden compose database

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,11 @@
-# Database Configuration
-# For Docker Compose: use "db" as hostname (the service name)
-# For local development: use "localhost"
-DATABASE_URL=postgres://postgres:postgres@db:5432/aludel_dash
+# Docker Compose database configuration
+# Generate the password with: openssl rand -hex 32
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=
+POSTGRES_DB=aludel_dash
+
+# Standalone production outside Docker Compose
+# DATABASE_URL=postgres://user:password@localhost:5432/aludel_dash
 POOL_SIZE=10
 
 # Phoenix Configuration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
+      - name: Validate Docker Compose security defaults
+        run: |
+          cp .env.example .env
+          if docker compose config --quiet 2>/dev/null; then
+            echo "Docker Compose accepted a blank database password"
+            exit 1
+          fi
+          POSTGRES_PASSWORD=ci-only-password docker compose config --quiet
+
       - name: Setup Elixir
         uses: ./.github/actions/setup-elixir
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Security
+- Remove the Docker Compose PostgreSQL host port and require an operator-supplied database password
 - Require nonblank HTTP Basic Authentication credentials before the standalone production endpoint starts
 - Compare standalone Basic Authentication credentials with Plug's constant-time verifier
 - Enforce resolver read-only decisions server-side for all dashboard mutation and model-request events

--- a/README.md
+++ b/README.md
@@ -483,6 +483,8 @@ export READ_ONLY=true
 
 Production startup rejects missing, partial, or blank credentials. Local development remains unauthenticated and binds only to loopback. Serve production Basic Authentication over TLS; if a reverse proxy terminates TLS, preserve the `Authorization` header and do not expose the backend port directly.
 
+Docker Compose deployments also require a generated `POSTGRES_PASSWORD`. The database stays private to the Compose network and the web release receives separate connection fields, so passwords containing URI-reserved characters work without encoding. Existing Compose volumes need a one-time password rotation before upgrade; see the [embedding and deployment guide](https://hexdocs.pm/aludel/embedding.html#upgrading-an-existing-compose-database).
+
 To smoke-test callback mode in the standalone app, configure a local executor module in `standalone/lib/aludel_dash.ex` or another module loaded by the standalone app, then add:
 
 ```elixir

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,15 +2,13 @@ services:
   db:
     image: postgres:17
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: aludel_dash
-    ports:
-      - "5432:5432"
+      POSTGRES_USER: "${POSTGRES_USER:-postgres}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}"
+      POSTGRES_DB: "${POSTGRES_DB:-aludel_dash}"
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -U \"$${POSTGRES_USER}\" -d \"$${POSTGRES_DB}\""]
       interval: 2s
       timeout: 5s
       retries: 10
@@ -25,6 +23,11 @@ services:
       sh -c '/app/bin/aludel_dash eval "Ecto.Migrator.with_repo(AludelDash.Repo, &Ecto.Migrator.run(&1, :up, all: true))" && /app/bin/aludel_dash start'
     env_file:
       - .env
+    environment:
+      DATABASE_HOST: db
+      DATABASE_USERNAME: "${POSTGRES_USER:-postgres}"
+      DATABASE_PASSWORD: "${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}"
+      DATABASE_NAME: "${POSTGRES_DB:-aludel_dash}"
     depends_on:
       db:
         condition: service_healthy

--- a/guides/embedding.md
+++ b/guides/embedding.md
@@ -256,13 +256,25 @@ Basic Authentication credentials require TLS in production. When a reverse proxy
 
 ## Docker Compose
 
-From the repository root, configure `.env` from `.env.example`, then start the database and release:
+From the repository root, copy `.env.example` to `.env`. Generate a strong database password with `openssl rand -hex 32`, paste it into `POSTGRES_PASSWORD`, configure the remaining required values, then start the database and release:
 
 ```bash
 docker compose up -d
 ```
 
-The web container waits for PostgreSQL, runs all migrations, and starts the standalone dashboard on the configured port.
+Compose rejects a missing or blank database password before startup. PostgreSQL is reachable only by services on the Compose network; it does not publish a host port. The web container receives separate database fields, waits for PostgreSQL, runs all migrations, and starts the standalone dashboard on the configured port.
+
+For standalone production outside Compose, configure `DATABASE_URL` instead. Existing URL-based deployments remain supported.
+
+### Upgrading an existing Compose database
+
+PostgreSQL applies `POSTGRES_PASSWORD` only when it creates a new data volume. Before switching an existing Aludel Compose deployment to this version, rotate the existing `postgres` role password while the old stack is running:
+
+```bash
+docker compose exec db psql -U postgres -d aludel_dash
+```
+
+At the `psql` prompt, run `\password postgres`, enter a newly generated password twice, then run `\q`. Set that same value as `POSTGRES_PASSWORD` in the new `.env` before starting the updated stack. This interactive flow keeps the password out of shell history. Do not delete the `pgdata` volume during the upgrade because it contains the existing Aludel data.
 
 ## Demo catalog
 

--- a/standalone/config/runtime.exs
+++ b/standalone/config/runtime.exs
@@ -20,15 +20,26 @@ if config_env() == :prod do
         """
     end
 
-  database_url =
-    System.get_env("DATABASE_URL") ||
-      raise """
-      environment variable DATABASE_URL is missing.
-      """
+  database_config =
+    case AludelDash.DatabaseConfig.resolve(System.get_env()) do
+      {:ok, config} ->
+        config
 
-  config :aludel_dash, AludelDash.Repo,
-    url: database_url,
-    pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10")
+      {:error, :invalid_database_config} ->
+        raise """
+        Configure DATABASE_URL or all of DATABASE_HOST, DATABASE_USERNAME,
+        DATABASE_PASSWORD, and DATABASE_NAME with nonblank values.
+        """
+    end
+
+  repo_config =
+    Keyword.put(
+      database_config,
+      :pool_size,
+      String.to_integer(System.get_env("POOL_SIZE") || "10")
+    )
+
+  config :aludel_dash, AludelDash.Repo, repo_config
 
   secret_key_base =
     System.get_env("SECRET_KEY_BASE") ||

--- a/standalone/lib/aludel_dash.ex
+++ b/standalone/lib/aludel_dash.ex
@@ -58,6 +58,65 @@ defmodule AludelDash.BasicAuth do
   end
 end
 
+defmodule AludelDash.DatabaseConfig do
+  @moduledoc false
+
+  @component_variables [
+    "DATABASE_HOST",
+    "DATABASE_USERNAME",
+    "DATABASE_PASSWORD",
+    "DATABASE_NAME"
+  ]
+
+  @type result :: {:ok, keyword(String.t())} | {:error, :invalid_database_config}
+
+  @spec resolve(%{optional(String.t()) => term()}) :: result()
+  def resolve(environment) when is_map(environment) do
+    if component_configuration?(environment) do
+      resolve_components(environment)
+    else
+      resolve_url(environment)
+    end
+  end
+
+  def resolve(_environment) do
+    {:error, :invalid_database_config}
+  end
+
+  defp component_configuration?(environment) do
+    Enum.any?(@component_variables, &Map.has_key?(environment, &1))
+  end
+
+  defp resolve_components(environment) do
+    with {:ok, hostname} <- fetch_present(environment, "DATABASE_HOST"),
+         {:ok, username} <- fetch_present(environment, "DATABASE_USERNAME"),
+         {:ok, password} <- fetch_present(environment, "DATABASE_PASSWORD"),
+         {:ok, database} <- fetch_present(environment, "DATABASE_NAME") do
+      {:ok, hostname: hostname, username: username, password: password, database: database}
+    end
+  end
+
+  defp resolve_url(environment) do
+    with {:ok, url} <- fetch_present(environment, "DATABASE_URL") do
+      {:ok, url: url}
+    end
+  end
+
+  defp fetch_present(environment, variable) do
+    case Map.get(environment, variable) do
+      value when is_binary(value) ->
+        if String.trim(value) == "" do
+          {:error, :invalid_database_config}
+        else
+          {:ok, value}
+        end
+
+      _missing_or_invalid ->
+        {:error, :invalid_database_config}
+    end
+  end
+end
+
 defmodule AludelDash.Resolver do
   @behaviour Aludel.Web.Resolver
 

--- a/standalone/test/aludel_dash/database_config_test.exs
+++ b/standalone/test/aludel_dash/database_config_test.exs
@@ -1,0 +1,73 @@
+defmodule AludelDash.DatabaseConfigTest do
+  use ExUnit.Case, async: true
+
+  alias AludelDash.DatabaseConfig
+
+  test "resolves the existing database URL configuration" do
+    assert {:ok, [url: "postgres://user:password@localhost/database"]} =
+             DatabaseConfig.resolve(%{
+               "DATABASE_URL" => "postgres://user:password@localhost/database"
+             })
+  end
+
+  test "resolves complete component configuration" do
+    assert {:ok, config} =
+             DatabaseConfig.resolve(%{
+               "DATABASE_HOST" => "db",
+               "DATABASE_USERNAME" => "aludel",
+               "DATABASE_PASSWORD" => "strong-password",
+               "DATABASE_NAME" => "aludel_dash"
+             })
+
+    assert config == [
+             hostname: "db",
+             username: "aludel",
+             password: "strong-password",
+             database: "aludel_dash"
+           ]
+  end
+
+  test "component configuration takes precedence and preserves reserved characters" do
+    password = ":/@%?#[]!$&'()*+,;="
+
+    assert {:ok, config} =
+             DatabaseConfig.resolve(%{
+               "DATABASE_URL" => "postgres://old:default@localhost/old",
+               "DATABASE_HOST" => "db",
+               "DATABASE_USERNAME" => "aludel",
+               "DATABASE_PASSWORD" => password,
+               "DATABASE_NAME" => "aludel_dash"
+             })
+
+    assert config[:password] == password
+    refute Keyword.has_key?(config, :url)
+  end
+
+  test "partial or blank component configuration fails closed" do
+    complete = %{
+      "DATABASE_HOST" => "db",
+      "DATABASE_USERNAME" => "aludel",
+      "DATABASE_PASSWORD" => "strong-password",
+      "DATABASE_NAME" => "aludel_dash"
+    }
+
+    for variable <- Map.keys(complete) do
+      assert {:error, :invalid_database_config} =
+               complete
+               |> Map.delete(variable)
+               |> DatabaseConfig.resolve()
+
+      assert {:error, :invalid_database_config} =
+               complete
+               |> Map.put(variable, "   ")
+               |> DatabaseConfig.resolve()
+    end
+  end
+
+  test "missing or blank URL configuration fails closed" do
+    assert {:error, :invalid_database_config} = DatabaseConfig.resolve(%{})
+
+    assert {:error, :invalid_database_config} =
+             DatabaseConfig.resolve(%{"DATABASE_URL" => "   "})
+  end
+end

--- a/test/config/docker_compose_test.exs
+++ b/test/config/docker_compose_test.exs
@@ -1,0 +1,40 @@
+defmodule Aludel.DockerComposeTest do
+  use ExUnit.Case, async: true
+
+  @compose_file Path.expand("../../docker-compose.yaml", __DIR__)
+
+  setup_all do
+    compose = @compose_file |> File.read!() |> YamlElixir.read_from_string!()
+    {:ok, compose: compose}
+  end
+
+  test "database is private and requires an operator-supplied password", %{compose: compose} do
+    database = get_in(compose, ["services", "db"])
+
+    refute Map.has_key?(database, "ports")
+
+    assert database["environment"] == %{
+             "POSTGRES_USER" => "${POSTGRES_USER:-postgres}",
+             "POSTGRES_PASSWORD" => "${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}",
+             "POSTGRES_DB" => "${POSTGRES_DB:-aludel_dash}"
+           }
+  end
+
+  test "web receives matching database components", %{compose: compose} do
+    web_environment = get_in(compose, ["services", "web", "environment"])
+
+    assert web_environment == %{
+             "DATABASE_HOST" => "db",
+             "DATABASE_USERNAME" => "${POSTGRES_USER:-postgres}",
+             "DATABASE_PASSWORD" => "${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}",
+             "DATABASE_NAME" => "${POSTGRES_DB:-aludel_dash}"
+           }
+  end
+
+  test "healthcheck expands database identity inside the container", %{compose: compose} do
+    assert get_in(compose, ["services", "db", "healthcheck", "test"]) == [
+             "CMD-SHELL",
+             ~s(pg_isready -U "$${POSTGRES_USER}" -d "$${POSTGRES_DB}")
+           ]
+  end
+end


### PR DESCRIPTION
## Motivation

The Docker Compose deployment previously published PostgreSQL on the host and initialized it with a hardcoded password. This change keeps the database private to the Compose network and requires an operator-supplied nonblank password before Compose can render the deployment.

The web release receives separate database fields instead of an interpolated URL, preserving reserved characters in generated passwords. Component configuration takes precedence over stale URL values, while existing non-Compose `DATABASE_URL` deployments remain supported. Existing Compose deployments retain the current role default and have a documented, non-destructive password-rotation path.

## Test Plan

- Added standalone tests for URL compatibility, complete component configuration, component precedence, reserved-character passwords, and fail-closed partial or blank values.
- Added structural Compose tests for the private database boundary, matching service credentials, and container-side healthcheck expansion.
- Added CI validation that rejects a blank database password and successfully renders Compose with a supplied password.
- Verified the production release accepts both URL and component configuration and rejects partial or missing configuration before startup.
- Verified all 898 root tests and all 11 standalone tests pass.
- Verified warnings-as-errors compilation, formatting, Credo, Sobelow, Dialyzer, documentation, dependency audit, and Hex package dry run succeed.

## Next Steps

A full fresh-container boot remains covered by normal deployment smoke testing; this PR focuses on the credential and network boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Docker Compose deployments now require an operator-supplied PostgreSQL password.
  - The database is no longer exposed through a host port, remaining accessible only to Compose services.

- **Configuration**
  - Compose supports separate database host, user, password, and name settings.
  - Standalone deployments continue to support `DATABASE_URL` configuration.

- **Documentation**
  - Added setup guidance for generating passwords and upgrading existing Compose databases safely.

- **Tests**
  - Added validation for secure Compose defaults and supported database configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->