### PR TITLE
fix(providers): enforce runtime-only credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Render persisted prompt tags as text instead of reparsing them as HTML
 - Isolate PDF conversion in private workspaces and process groups, with bounded input, output, diagnostics, execution time, and ImageMagick resources
 - Bound regular expression assertion size, matching work, recursion depth, and wall-clock time
+- Reject provider credentials in persisted configuration, remove legacy credential keys, and sanitize runtime and callback boundaries
 
 ## [0.6.1] - 2026-09-04
 

--- a/README.md
+++ b/README.md
@@ -529,6 +529,8 @@ config :aludel, :llm,
   openrouter_api_key: System.get_env("OPENROUTER_API_KEY")
 ```
 
+Provider credentials are runtime-only. Provider configuration accepts generation settings such as `temperature` and `max_tokens`, but rejects credential keys at every nesting level. The database constraint enforces the same rule for direct writes, and the migration removes credential keys from legacy provider configuration.
+
 Ollama runs locally and does not require an API key.
 
 Callback mode does not require Aludel to use those API keys directly, but provider selection still remains part of the current run and suite flows and is passed into the executor for host-app routing when needed.

--- a/guides/embedding.md
+++ b/guides/embedding.md
@@ -130,7 +130,9 @@ config :aludel, :llm,
   openrouter_api_key: System.get_env("OPENROUTER_API_KEY")
 ```
 
-Ollama does not require a key. Provider keys are read at runtime and are not persisted in provider records.
+Ollama does not require a key. Provider keys are read at runtime and are not persisted in provider records. Provider changesets reject credential keys at every nesting level, the database enforces the same policy for direct writes, and execution boundaries defensively remove credential-shaped configuration before injecting runtime keys.
+
+When upgrading from an earlier release, the migration removes credential-shaped keys from existing provider configuration. Rotate any credential that was previously entered there because database backups or historical logs may retain older copies.
 
 ## Run concurrency
 

--- a/guides/features.md
+++ b/guides/features.md
@@ -43,7 +43,7 @@ Provider forms:
 - store JSON generation configuration for temperature and output limits
 - use built-in per-model token pricing or custom input/output rates
 
-Provider credentials come from application configuration or environment variables and are not stored in provider rows. Ollama does not require an API key and resolves to free token pricing by default.
+Provider credentials come from application configuration or environment variables and are not stored in provider rows. Changeset validation, a database constraint, and execution-boundary sanitization enforce this rule while preserving ordinary generation settings. Ollama does not require an API key and resolves to free token pricing by default.
 
 ## Runs
 

--- a/lib/aludel/execution.ex
+++ b/lib/aludel/execution.ex
@@ -9,6 +9,7 @@ defmodule Aludel.Execution do
   alias Aludel.Executor
   alias Aludel.LLM
   alias Aludel.Prompts.PromptVersion
+  alias Aludel.Providers.ConfigPolicy
   alias Aludel.Providers.Provider
   alias Aludel.Storage
   alias Ecto.Association.NotLoaded
@@ -217,7 +218,7 @@ defmodule Aludel.Execution do
         id: provider.id,
         provider: provider.provider,
         model: provider.model,
-        config: provider.config
+        config: ConfigPolicy.sanitize(provider.config || %{})
       },
       metadata: metadata
     }

--- a/lib/aludel/interfaces/llm.ex
+++ b/lib/aludel/interfaces/llm.ex
@@ -36,6 +36,7 @@ defmodule Aludel.LLM do
     XAI
   }
 
+  alias Aludel.Providers.ConfigPolicy
   alias Aludel.Providers.Pricing
   alias Aludel.Providers.Provider
 
@@ -127,7 +128,7 @@ defmodule Aludel.LLM do
   defp get_provider(provider_name), do: Map.fetch!(@providers, provider_name)
 
   defp build_config(provider) do
-    base_config = provider.config || %{}
+    base_config = ConfigPolicy.sanitize(provider.config || %{})
 
     api_key = configured_api_key(provider.provider)
 

--- a/lib/aludel/interfaces/llm/README.md
+++ b/lib/aludel/interfaces/llm/README.md
@@ -84,6 +84,8 @@ Register in `lib/aludel/interfaces/llm.ex`:
 Provider credentials are loaded from application configuration. The supported environment
 variables are `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `XAI_API_KEY`,
 `GROQ_API_KEY`, and `OPENROUTER_API_KEY`. Ollama does not require an API key.
+Provider records reject credential-shaped configuration keys recursively, and the execution
+boundary sanitizes provider configuration before adding the runtime key.
 
 ## Swapping HTTP Client
 

--- a/lib/aludel/interfaces/llm/behaviour.ex
+++ b/lib/aludel/interfaces/llm/behaviour.ex
@@ -26,7 +26,7 @@ defmodule Aludel.Interfaces.LLM.Behaviour do
   ## Parameters
     - model: Model identifier (e.g., "gpt-4o", "claude-3-5-sonnet")
     - prompt: Text prompt or normalized conversation messages to send to the model
-    - config: Provider configuration (API keys, temperature, etc.)
+    - config: Request-scoped configuration assembled from runtime credentials and safe provider settings
     - opts: Additional options (e.g., documents for vision models)
 
   ## Returns

--- a/lib/aludel/interfaces/llm/config.ex
+++ b/lib/aludel/interfaces/llm/config.ex
@@ -14,7 +14,7 @@ defmodule Aludel.Interfaces.LLM.Config do
   end
 
   @doc """
-  Extracts and validates API key from provider config.
+  Extracts and validates the API key injected into request-scoped configuration.
 
   Returns `{:ok, key}` if valid, `{:error, :missing_api_key}` otherwise.
   """

--- a/lib/aludel/providers/config_policy.ex
+++ b/lib/aludel/providers/config_policy.ex
@@ -1,0 +1,114 @@
+defmodule Aludel.Providers.ConfigPolicy do
+  @moduledoc false
+
+  @error_message "must not contain credentials; configure them at runtime"
+
+  @credential_fragments ~w(
+    apikey
+    apisecret
+    authorization
+    credential
+    passwd
+    password
+    privatekey
+    secret
+  )
+
+  @credential_suffixes ~w(
+    accesskey
+    accesskeyid
+    accountkey
+    cookie
+    encryptionkey
+    sessionkey
+    signingkey
+    subscriptionkey
+    token
+  )
+
+  @credential_keys ~w(auth bearer key)
+
+  @spec error_message() :: String.t()
+  def error_message do
+    @error_message
+  end
+
+  @spec validate(term()) :: :ok | {:error, :credentials_not_allowed}
+  def validate(config) do
+    if contains_credentials?(config) do
+      {:error, :credentials_not_allowed}
+    else
+      :ok
+    end
+  end
+
+  @spec sanitize(term()) :: term()
+  def sanitize(config) when is_map(config) do
+    Enum.reduce(config, %{}, fn {key, value}, sanitized ->
+      if credential_key?(key) do
+        sanitized
+      else
+        Map.put(sanitized, key, sanitize(value))
+      end
+    end)
+  end
+
+  def sanitize(config) when is_list(config) do
+    config
+    |> Enum.reduce([], fn
+      {key, value}, sanitized when is_binary(key) or is_atom(key) ->
+        if credential_key?(key) do
+          sanitized
+        else
+          [{key, sanitize(value)} | sanitized]
+        end
+
+      value, sanitized ->
+        [sanitize(value) | sanitized]
+    end)
+    |> Enum.reverse()
+  end
+
+  def sanitize(config) do
+    config
+  end
+
+  defp contains_credentials?(config) when is_map(config) do
+    Enum.any?(config, fn {key, value} ->
+      credential_key?(key) or contains_credentials?(value)
+    end)
+  end
+
+  defp contains_credentials?(config) when is_list(config) do
+    Enum.any?(config, fn
+      {key, value} when is_binary(key) or is_atom(key) ->
+        credential_key?(key) or contains_credentials?(value)
+
+      value ->
+        contains_credentials?(value)
+    end)
+  end
+
+  defp contains_credentials?(_config) do
+    false
+  end
+
+  defp credential_key?(key) when is_binary(key) or is_atom(key) do
+    key
+    |> to_string()
+    |> String.trim()
+    |> String.downcase()
+    |> String.replace(~r/[^a-z0-9]/u, "")
+    |> credential_key_name?()
+  end
+
+  defp credential_key?(_key) do
+    false
+  end
+
+  defp credential_key_name?(key) do
+    key in @credential_keys or
+      Enum.any?(@credential_fragments, &String.contains?(key, &1)) or
+      Enum.any?(@credential_suffixes, &String.ends_with?(key, &1))
+  end
+end

--- a/lib/aludel/providers/provider.ex
+++ b/lib/aludel/providers/provider.ex
@@ -6,6 +6,7 @@ defmodule Aludel.Providers.Provider do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias Aludel.Providers.ConfigPolicy
   alias Ecto.Changeset
 
   @type t :: %__MODULE__{}
@@ -24,7 +25,7 @@ defmodule Aludel.Providers.Provider do
       values: [:openai, :anthropic, :ollama, :google, :xai, :groq, :openrouter]
 
     field :model, :string
-    field :config, :map
+    field :config, :map, redact: true
     field :pricing, :map
     field :model_selection, :string, virtual: true
     field :model_custom, :string, virtual: true
@@ -44,7 +45,21 @@ defmodule Aludel.Providers.Provider do
     |> cast(attrs, @required_fields ++ @optional_fields ++ @virtual_fields)
     |> normalize_model()
     |> validate_required(@required_fields)
+    |> validate_config()
     |> validate_pricing()
+    |> check_constraint(:config,
+      name: :providers_config_no_credentials,
+      message: ConfigPolicy.error_message()
+    )
+  end
+
+  defp validate_config(changeset) do
+    validate_change(changeset, :config, fn :config, config ->
+      case ConfigPolicy.validate(config) do
+        :ok -> []
+        {:error, :credentials_not_allowed} -> [config: ConfigPolicy.error_message()]
+      end
+    end)
   end
 
   defp validate_pricing(changeset) do

--- a/lib/aludel/web/live/provider_live/new.ex
+++ b/lib/aludel/web/live/provider_live/new.ex
@@ -6,6 +6,7 @@ defmodule Aludel.Web.ProviderLive.New do
   use Aludel.Web, :live_view
 
   alias Aludel.Providers
+  alias Aludel.Providers.ConfigPolicy
   alias Aludel.Providers.Provider
 
   @impl Phoenix.LiveView
@@ -27,6 +28,7 @@ defmodule Aludel.Web.ProviderLive.New do
 
   @impl Phoenix.LiveView
   def handle_event("validate", %{"provider" => provider_params}, socket) do
+    config_json = Map.get(provider_params, "config", "")
     provider_type = provider_params["provider"]
     model_groups = Providers.fetch_model_groups(provider_type)
 
@@ -46,7 +48,9 @@ defmodule Aludel.Web.ProviderLive.New do
     changeset =
       socket.assigns.provider
       |> Providers.change_provider(
-        Map.merge(provider_params, %{
+        provider_params
+        |> parse_config()
+        |> Map.merge(%{
           "custom_pricing_enabled" => custom_pricing_enabled,
           "pricing_input" => pricing_input,
           "pricing_output" => pricing_output
@@ -61,7 +65,7 @@ defmodule Aludel.Web.ProviderLive.New do
      |> assign(:model_groups, model_groups)
      |> assign(:model_options, model_options(model_groups))
      |> assign(:form, to_form(changeset))
-     |> assign(:config_json, Map.get(provider_params, "config", ""))
+     |> assign(:config_json, safe_config_json(config_json, changeset))
      |> assign(:default_pricing, default_pricing)
      |> assign(:custom_pricing_enabled, custom_pricing_enabled)
      |> assign(:pricing_input, pricing_input)
@@ -128,7 +132,7 @@ defmodule Aludel.Web.ProviderLive.New do
     |> assign(:provider, provider)
     |> assign(:model_groups, model_groups)
     |> assign(:model_options, model_options(model_groups))
-    |> assign(:config_json, encode_config(provider.config))
+    |> assign(:config_json, provider.config |> ConfigPolicy.sanitize() |> encode_config())
     |> assign(:form, to_form(changeset))
     |> assign(:default_pricing, default_pricing)
     |> assign(:custom_pricing_enabled, has_custom_pricing)
@@ -153,7 +157,7 @@ defmodule Aludel.Web.ProviderLive.New do
         {:noreply,
          socket
          |> assign(:form, to_form(changeset))
-         |> assign(:config_json, config_json)}
+         |> assign(:config_json, safe_config_json(config_json, changeset))}
     end
   end
 
@@ -174,7 +178,7 @@ defmodule Aludel.Web.ProviderLive.New do
         {:noreply,
          socket
          |> assign(:form, to_form(changeset))
-         |> assign(:config_json, config_json)}
+         |> assign(:config_json, safe_config_json(config_json, changeset))}
     end
   end
 
@@ -197,6 +201,64 @@ defmodule Aludel.Web.ProviderLive.New do
   defp encode_config(nil), do: ""
   defp encode_config(config) when map_size(config) == 0, do: ""
   defp encode_config(config), do: Jason.encode!(config, pretty: true)
+
+  defp safe_config_json(config_json, changeset) do
+    if credential_config_error?(changeset) or credential_key_in_json?(config_json) do
+      sanitize_config_json(config_json)
+    else
+      config_json
+    end
+  end
+
+  defp credential_config_error?(changeset) do
+    Enum.any?(changeset.errors, fn
+      {:config, {message, _opts}} -> message == ConfigPolicy.error_message()
+      _other -> false
+    end)
+  end
+
+  defp sanitize_config_json(config_json) when is_binary(config_json) do
+    case Jason.decode(config_json) do
+      {:ok, config} when is_map(config) ->
+        config
+        |> ConfigPolicy.sanitize()
+        |> encode_config()
+
+      _invalid_or_non_map ->
+        ""
+    end
+  end
+
+  defp sanitize_config_json(_config_json) do
+    ""
+  end
+
+  defp credential_key_in_json?(config_json) when is_binary(config_json) do
+    case Jason.decode(config_json) do
+      {:ok, config} ->
+        ConfigPolicy.validate(config) != :ok
+
+      {:error, _reason} ->
+        credential_key_in_malformed_json?(config_json)
+    end
+  end
+
+  defp credential_key_in_json?(_config_json) do
+    false
+  end
+
+  defp credential_key_in_malformed_json?(config_json) do
+    ~r/"((?:\\.|[^"\\])*)"\s*:/u
+    |> Regex.scan(config_json, capture: :all_but_first)
+    |> Enum.any?(&encoded_credential_key?/1)
+  end
+
+  defp encoded_credential_key?([encoded_key]) do
+    case Jason.decode(~s("#{encoded_key}")) do
+      {:ok, key} -> ConfigPolicy.validate(%{key => nil}) != :ok
+      {:error, _reason} -> false
+    end
+  end
 
   defp normalize_model_params(params) do
     case params["model_selection"] do

--- a/lib/aludel/web/live/provider_live/new.html.heex
+++ b/lib/aludel/web/live/provider_live/new.html.heex
@@ -190,9 +190,16 @@
                 class="w-full textarea font-mono text-[13px]"
               >{@config_json}</textarea>
             </label>
+            <p
+              :if={@form[:config].errors != []}
+              id="provider_config-error"
+              class="mt-2 text-sm text-error"
+            >
+              {Enum.map_join(@form[:config].errors, ", ", &translate_error/1)}
+            </p>
           </div>
           <div style="font-size: 12px; color: var(--text-secondary); margin-top: 4px;">
-            Optional: Model parameters as JSON (temperature, max_tokens, etc.). API keys are set via environment variables.
+            Optional: Model parameters as JSON (temperature, max_tokens, etc.). Credentials are runtime-only and rejected from this field.
           </div>
         </div>
 

--- a/priv/repo/migrations/20260905020000_prevent_provider_credential_persistence.exs
+++ b/priv/repo/migrations/20260905020000_prevent_provider_credential_persistence.exs
@@ -1,0 +1,123 @@
+defmodule Aludel.Repo.Migrations.PreventProviderCredentialPersistence do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    CREATE FUNCTION aludel_provider_config_credential_key(key_name text)
+    RETURNS boolean
+    LANGUAGE sql
+    IMMUTABLE
+    PARALLEL SAFE
+    AS $function$
+      SELECT
+        canonical = ANY (ARRAY['auth', 'bearer', 'key']::text[]) OR
+        canonical ~ '(apikey|apisecret|authorization|credential|passwd|password|privatekey|secret)' OR
+        canonical ~ '(accesskey|accesskeyid|accountkey|cookie|encryptionkey|sessionkey|signingkey|subscriptionkey|token)$'
+      FROM (
+        SELECT regexp_replace(lower(btrim(key_name)), '[^a-z0-9]', '', 'g') AS canonical
+      ) AS normalized
+    $function$;
+    """)
+
+    execute("""
+    CREATE FUNCTION aludel_provider_config_contains_credentials(config_value jsonb)
+    RETURNS boolean
+    LANGUAGE plpgsql
+    IMMUTABLE
+    PARALLEL SAFE
+    AS $function$
+    DECLARE
+      item record;
+    BEGIN
+      IF config_value IS NULL THEN
+        RETURN false;
+      END IF;
+
+      IF jsonb_typeof(config_value) = 'object' THEN
+        FOR item IN SELECT key, value FROM jsonb_each(config_value)
+        LOOP
+          IF aludel_provider_config_credential_key(item.key) OR
+             aludel_provider_config_contains_credentials(item.value) THEN
+            RETURN true;
+          END IF;
+        END LOOP;
+      ELSIF jsonb_typeof(config_value) = 'array' THEN
+        FOR item IN SELECT value FROM jsonb_array_elements(config_value)
+        LOOP
+          IF aludel_provider_config_contains_credentials(item.value) THEN
+            RETURN true;
+          END IF;
+        END LOOP;
+      END IF;
+
+      RETURN false;
+    END;
+    $function$;
+    """)
+
+    execute("""
+    CREATE FUNCTION aludel_scrub_provider_config_credentials(config_value jsonb)
+    RETURNS jsonb
+    LANGUAGE plpgsql
+    IMMUTABLE
+    PARALLEL SAFE
+    AS $function$
+    DECLARE
+      sanitized jsonb;
+    BEGIN
+      IF config_value IS NULL THEN
+        RETURN NULL;
+      END IF;
+
+      IF jsonb_typeof(config_value) = 'object' THEN
+        SELECT COALESCE(
+          jsonb_object_agg(
+            entry.key,
+            aludel_scrub_provider_config_credentials(entry.value)
+          ),
+          '{}'::jsonb
+        )
+        INTO sanitized
+        FROM jsonb_each(config_value) AS entry
+        WHERE NOT aludel_provider_config_credential_key(entry.key);
+
+        RETURN sanitized;
+      ELSIF jsonb_typeof(config_value) = 'array' THEN
+        SELECT COALESCE(
+          jsonb_agg(
+            aludel_scrub_provider_config_credentials(entry.value)
+            ORDER BY entry.position
+          ),
+          '[]'::jsonb
+        )
+        INTO sanitized
+        FROM jsonb_array_elements(config_value) WITH ORDINALITY AS entry(value, position);
+
+        RETURN sanitized;
+      END IF;
+
+      RETURN config_value;
+    END;
+    $function$;
+    """)
+
+    execute("""
+    UPDATE providers
+    SET config = aludel_scrub_provider_config_credentials(config)
+    WHERE aludel_provider_config_contains_credentials(config)
+    """)
+
+    execute("DROP FUNCTION aludel_scrub_provider_config_credentials(jsonb)")
+
+    create constraint(:providers, :providers_config_no_credentials,
+             check: "NOT aludel_provider_config_contains_credentials(config)"
+           )
+  end
+
+  def down do
+    drop constraint(:providers, :providers_config_no_credentials)
+
+    execute("DROP FUNCTION aludel_provider_config_contains_credentials(jsonb)")
+    execute("DROP FUNCTION aludel_provider_config_credential_key(text)")
+  end
+end

--- a/test/aludel/execution_test.exs
+++ b/test/aludel/execution_test.exs
@@ -61,8 +61,11 @@ defmodule Aludel.ExecutionTest do
       provider_fixture(%{
         provider: :openai,
         model: "gpt-4o-mini",
-        config: %{"api_key" => "must-not-be-persisted"}
+        config: %{"temperature" => 0.2}
       })
+
+    dirty_provider =
+      %{provider | config: Map.put(provider.config, "api_key", "must-not-be-persisted")}
 
     expect(HttpClientMock, :request, fn _model, "Return JSON for Alice", _opts ->
       {:ok, %{content: ~s({"name":"Alice"}), input_tokens: 5, output_tokens: 7}}
@@ -73,7 +76,7 @@ defmodule Aludel.ExecutionTest do
                kind: :run,
                prompt_version: version,
                variables: %{"name" => "Alice"},
-               provider: provider,
+               provider: dirty_provider,
                documents: [],
                metadata: %{run_id: Ecto.UUID.generate()}
              })
@@ -161,6 +164,40 @@ defmodule Aludel.ExecutionTest do
                prompt_version: version,
                variables: %{"name" => "Alice"},
                provider: provider,
+               documents: [],
+               metadata: %{run_id: Ecto.UUID.generate()}
+             })
+  end
+
+  test "removes credentials before invoking callback executors" do
+    Application.put_env(:aludel, :execution_mode, :callback)
+    Application.put_env(:aludel, :executor, Aludel.ExecutorMock)
+
+    prompt = prompt_fixture()
+    {:ok, version} = Aludel.Prompts.create_prompt_version(prompt, "Hello {{name}}")
+    provider = provider_fixture(%{config: %{"temperature" => 0.2}})
+
+    dirty_provider = %{
+      provider
+      | config: %{
+          "api_secret" => "sensitive-value",
+          "temperature" => 0.2,
+          "headers" => [%{"Proxy-Authorization" => "sensitive-value"}]
+        }
+    }
+
+    expect(Aludel.ExecutorMock, :run, fn input ->
+      assert input.provider.config == %{"headers" => [%{}], "temperature" => 0.2}
+      refute inspect(input) =~ "sensitive-value"
+      {:ok, %{output: "Hello Alice"}}
+    end)
+
+    assert {:ok, _result} =
+             Execution.execute(%{
+               kind: :run,
+               prompt_version: version,
+               variables: %{"name" => "Alice"},
+               provider: dirty_provider,
                documents: [],
                metadata: %{run_id: Ecto.UUID.generate()}
              })

--- a/test/aludel/llm_test.exs
+++ b/test/aludel/llm_test.exs
@@ -45,6 +45,27 @@ defmodule Aludel.LLMTest do
       end
     end
 
+    test "does not use API keys from an in-memory provider config" do
+      original_config = Application.get_env(:aludel, :llm)
+      Application.put_env(:aludel, :llm, openai_api_key: nil)
+
+      try do
+        provider =
+          provider_fixture(%{
+            provider: :openai,
+            model: "gpt-4o",
+            config: %{"temperature" => 0.2}
+          })
+
+        dirty_provider =
+          %{provider | config: %{"api_key" => "sensitive-value", "temperature" => 0.2}}
+
+        assert {:error, :missing_api_key} = LLM.call(dirty_provider, "test", [])
+      after
+        Application.put_env(:aludel, :llm, original_config)
+      end
+    end
+
     test "returns structured response with all required fields" do
       mock_response = build_mock_response("Hello! How can I help?", 5, 10)
 
@@ -647,7 +668,7 @@ defmodule Aludel.LLMTest do
         provider_fixture(%{
           provider: :openai,
           model: "gpt-4o",
-          config: %{"api_key" => "sk-test-key"}
+          config: %{"temperature" => 0.7}
         })
 
       assert {:ok, result} =

--- a/test/aludel/providers/config_policy_test.exs
+++ b/test/aludel/providers/config_policy_test.exs
@@ -1,0 +1,56 @@
+defmodule Aludel.Providers.ConfigPolicyTest do
+  use ExUnit.Case, async: true
+
+  alias Aludel.Providers.ConfigPolicy
+
+  test "detects normalized credential keys recursively" do
+    configs = [
+      %{"API KEY" => "value"},
+      %{"openai-api-key" => "value"},
+      %{"headers" => [%{"Authorization" => "value"}]},
+      %{"nested" => %{:client_secret => nil}},
+      %{"api_secret" => "value"},
+      %{"proxy_authorization" => "value"},
+      %{"secret_key" => "value"},
+      %{"aws_session_token" => "value"},
+      [safe: true, api_secret: "value"]
+    ]
+
+    for config <- configs do
+      assert {:error, :credentials_not_allowed} = ConfigPolicy.validate(config)
+    end
+  end
+
+  test "sanitizes credential keys while preserving safe structure" do
+    config = %{
+      "api_key" => "top-level-value",
+      "max_tokens" => 1_000,
+      "nested" => [
+        %{"Authorization" => "nested-value", "top_p" => 0.9},
+        "unchanged"
+      ]
+    }
+
+    assert ConfigPolicy.sanitize(config) == %{
+             "max_tokens" => 1_000,
+             "nested" => [%{"top_p" => 0.9}, "unchanged"]
+           }
+  end
+
+  test "sanitizes credential entries from keyword lists" do
+    config = [temperature: 0.2, headers: [proxy_authorization: "value"]]
+
+    assert ConfigPolicy.sanitize(config) == [temperature: 0.2, headers: []]
+  end
+
+  test "allows safe token-related keys" do
+    config = %{
+      "max_tokens" => 1_000,
+      "tokenizer" => "provider-default",
+      "token_usage" => true
+    }
+
+    assert :ok = ConfigPolicy.validate(config)
+    assert ConfigPolicy.sanitize(config) == config
+  end
+end

--- a/test/aludel/providers_test.exs
+++ b/test/aludel/providers_test.exs
@@ -2,6 +2,8 @@ defmodule Aludel.ProvidersTest do
   use Aludel.DataCase, async: true
 
   alias Aludel.Providers
+  alias Aludel.Providers.Provider
+  alias Ecto.Adapters.SQL
 
   describe "providers" do
     test "list_providers/0 returns all providers" do
@@ -132,6 +134,110 @@ defmodule Aludel.ProvidersTest do
                "max_tokens" => 2000,
                "top_p" => 1.0
              }
+    end
+
+    test "rejects credential keys anywhere in provider configuration" do
+      unsafe_configs = [
+        %{"api_key" => "sensitive-value"},
+        %{api_key: "sensitive-value"},
+        %{"OpenAI-API-Key" => "sensitive-value"},
+        %{"headers" => [%{"Authorization" => "sensitive-value"}]},
+        %{"client_secret" => nil},
+        %{"api_secret" => "sensitive-value"},
+        %{"proxy_authorization" => "sensitive-value"},
+        %{"secret_key" => "sensitive-value"},
+        %{"aws_session_token" => "sensitive-value"}
+      ]
+
+      for config <- unsafe_configs do
+        assert {:error, changeset} =
+                 Providers.create_provider(%{
+                   name: "Unsafe Provider",
+                   provider: :openai,
+                   model: "gpt-4o",
+                   config: config
+                 })
+
+        assert errors_on(changeset).config == [
+                 "must not contain credentials; configure them at runtime"
+               ]
+
+        refute inspect(changeset) =~ "sensitive-value"
+      end
+    end
+
+    test "allows safe token-related provider configuration keys" do
+      config = %{
+        "max_tokens" => 1_000,
+        "tokenizer" => "provider-default",
+        "top_p" => 0.9
+      }
+
+      assert {:ok, provider} =
+               Providers.create_provider(%{
+                 name: "Safe Provider",
+                 provider: :openai,
+                 model: "gpt-4o",
+                 config: config
+               })
+
+      assert provider.config == config
+    end
+
+    test "rejects credential updates without changing the stored provider" do
+      provider = provider_fixture(%{config: %{"temperature" => 0.2}})
+
+      assert {:error, changeset} =
+               Providers.update_provider(provider, %{
+                 config: %{
+                   "temperature" => 0.9,
+                   "credentials" => %{"token" => "sensitive-value"}
+                 }
+               })
+
+      assert errors_on(changeset).config == [
+               "must not contain credentials; configure them at runtime"
+             ]
+
+      assert Providers.get_provider!(provider.id).config == %{"temperature" => 0.2}
+    end
+
+    test "redacts provider configuration from inspection" do
+      provider = %Provider{config: %{"api_key" => "sensitive-value"}}
+
+      inspected = inspect(provider)
+
+      refute inspected =~ "sensitive-value"
+      refute inspected =~ "api_key"
+    end
+
+    test "database constraint rejects direct credential persistence" do
+      assert_raise Ecto.ConstraintError, fn ->
+        Aludel.Repo.get().insert!(%Provider{
+          name: "Bypassed Provider",
+          provider: :openai,
+          model: "gpt-4o",
+          config: %{"nested" => %{"access_token" => "sensitive-value"}}
+        })
+      end
+    end
+
+    test "database credential classifier covers common key variants" do
+      keys = [
+        "api_secret",
+        "proxy_authorization",
+        "secret_key",
+        "aws_session_token"
+      ]
+
+      result =
+        SQL.query!(
+          Aludel.Repo.get(),
+          "SELECT aludel_provider_config_credential_key(key_name) FROM unnest($1::text[]) AS key_name",
+          [keys]
+        )
+
+      assert Enum.all?(result.rows, fn [blocked?] -> blocked? end)
     end
 
     test "update_provider/2 with valid data updates the provider" do

--- a/test/aludel_web/live/provider_live/new_test.exs
+++ b/test/aludel_web/live/provider_live/new_test.exs
@@ -188,6 +188,83 @@ defmodule Aludel.Web.ProviderLive.NewTest do
       assert provider.config == %{"temperature" => 0.2, "max_tokens" => 512}
     end
 
+    test "rejects credential configuration without rendering its value", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/providers/new")
+
+      view
+      |> form("#provider-form", provider: %{provider: "openai", model_selection: "custom"})
+      |> render_change()
+
+      html =
+        view
+        |> form("#provider-form",
+          provider: %{
+            name: "Unsafe Provider",
+            provider: "openai",
+            model_selection: "custom",
+            model_custom: "gpt-4.1",
+            config: ~s({"temperature":0.2,"api_key":"sensitive-value"})
+          }
+        )
+        |> render_submit()
+
+      assert html =~ "must not contain credentials; configure them at runtime"
+      assert html =~ "temperature"
+      refute html =~ "sensitive-value"
+      refute html =~ "api_key"
+      assert Providers.list_providers() == []
+    end
+
+    test "does not reflect credential values from malformed configuration", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/providers/new")
+
+      view
+      |> form("#provider-form", provider: %{provider: "openai", model_selection: "custom"})
+      |> render_change()
+
+      html =
+        view
+        |> form("#provider-form",
+          provider: %{
+            name: "Unsafe Provider",
+            provider: "openai",
+            model_selection: "custom",
+            model_custom: "gpt-4.1",
+            config: ~s({"api_secret":"sensitive-value")
+          }
+        )
+        |> render_submit()
+
+      refute html =~ "sensitive-value"
+      refute html =~ "api_secret"
+      assert Providers.list_providers() == []
+    end
+
+    test "does not reflect credential values from non-object configuration", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/providers/new")
+
+      view
+      |> form("#provider-form", provider: %{provider: "openai", model_selection: "custom"})
+      |> render_change()
+
+      html =
+        view
+        |> form("#provider-form",
+          provider: %{
+            name: "Unsafe Provider",
+            provider: "openai",
+            model_selection: "custom",
+            model_custom: "gpt-4.1",
+            config: ~s([{"aws_session_token":"sensitive-value"}])
+          }
+        )
+        |> render_submit()
+
+      refute html =~ "sensitive-value"
+      refute html =~ "aws_session_token"
+      assert Providers.list_providers() == []
+    end
+
     test "shows Google Gemini in provider type dropdown", %{conn: conn} do
       {:ok, _view, html} = live(conn, "/providers/new")
 

--- a/test/support/migrations/20260905020000_prevent_provider_credential_persistence.exs
+++ b/test/support/migrations/20260905020000_prevent_provider_credential_persistence.exs
@@ -1,0 +1,123 @@
+defmodule Aludel.Test.Repo.Migrations.PreventProviderCredentialPersistence do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    CREATE FUNCTION aludel_provider_config_credential_key(key_name text)
+    RETURNS boolean
+    LANGUAGE sql
+    IMMUTABLE
+    PARALLEL SAFE
+    AS $function$
+      SELECT
+        canonical = ANY (ARRAY['auth', 'bearer', 'key']::text[]) OR
+        canonical ~ '(apikey|apisecret|authorization|credential|passwd|password|privatekey|secret)' OR
+        canonical ~ '(accesskey|accesskeyid|accountkey|cookie|encryptionkey|sessionkey|signingkey|subscriptionkey|token)$'
+      FROM (
+        SELECT regexp_replace(lower(btrim(key_name)), '[^a-z0-9]', '', 'g') AS canonical
+      ) AS normalized
+    $function$;
+    """)
+
+    execute("""
+    CREATE FUNCTION aludel_provider_config_contains_credentials(config_value jsonb)
+    RETURNS boolean
+    LANGUAGE plpgsql
+    IMMUTABLE
+    PARALLEL SAFE
+    AS $function$
+    DECLARE
+      item record;
+    BEGIN
+      IF config_value IS NULL THEN
+        RETURN false;
+      END IF;
+
+      IF jsonb_typeof(config_value) = 'object' THEN
+        FOR item IN SELECT key, value FROM jsonb_each(config_value)
+        LOOP
+          IF aludel_provider_config_credential_key(item.key) OR
+             aludel_provider_config_contains_credentials(item.value) THEN
+            RETURN true;
+          END IF;
+        END LOOP;
+      ELSIF jsonb_typeof(config_value) = 'array' THEN
+        FOR item IN SELECT value FROM jsonb_array_elements(config_value)
+        LOOP
+          IF aludel_provider_config_contains_credentials(item.value) THEN
+            RETURN true;
+          END IF;
+        END LOOP;
+      END IF;
+
+      RETURN false;
+    END;
+    $function$;
+    """)
+
+    execute("""
+    CREATE FUNCTION aludel_scrub_provider_config_credentials(config_value jsonb)
+    RETURNS jsonb
+    LANGUAGE plpgsql
+    IMMUTABLE
+    PARALLEL SAFE
+    AS $function$
+    DECLARE
+      sanitized jsonb;
+    BEGIN
+      IF config_value IS NULL THEN
+        RETURN NULL;
+      END IF;
+
+      IF jsonb_typeof(config_value) = 'object' THEN
+        SELECT COALESCE(
+          jsonb_object_agg(
+            entry.key,
+            aludel_scrub_provider_config_credentials(entry.value)
+          ),
+          '{}'::jsonb
+        )
+        INTO sanitized
+        FROM jsonb_each(config_value) AS entry
+        WHERE NOT aludel_provider_config_credential_key(entry.key);
+
+        RETURN sanitized;
+      ELSIF jsonb_typeof(config_value) = 'array' THEN
+        SELECT COALESCE(
+          jsonb_agg(
+            aludel_scrub_provider_config_credentials(entry.value)
+            ORDER BY entry.position
+          ),
+          '[]'::jsonb
+        )
+        INTO sanitized
+        FROM jsonb_array_elements(config_value) WITH ORDINALITY AS entry(value, position);
+
+        RETURN sanitized;
+      END IF;
+
+      RETURN config_value;
+    END;
+    $function$;
+    """)
+
+    execute("""
+    UPDATE providers
+    SET config = aludel_scrub_provider_config_credentials(config)
+    WHERE aludel_provider_config_contains_credentials(config)
+    """)
+
+    execute("DROP FUNCTION aludel_scrub_provider_config_credentials(jsonb)")
+
+    create constraint(:providers, :providers_config_no_credentials,
+             check: "NOT aludel_provider_config_contains_credentials(config)"
+           )
+  end
+
+  def down do
+    drop constraint(:providers, :providers_config_no_credentials)
+
+    execute("DROP FUNCTION aludel_provider_config_contains_credentials(jsonb)")
+    execute("DROP FUNCTION aludel_provider_config_credential_key(text)")
+  end
+end


### PR DESCRIPTION
## Motivation

Provider configuration could retain credential-shaped values that belong in runtime configuration. This change enforces a runtime-only credential boundary across supported writes, direct database writes, native execution, callback execution, inspection, and the provider form. The migration recursively removes legacy credential fields while preserving safe nested settings.

## Test Plan

- Added recursive classifier and sanitizer coverage for normalized, nested, list, and common credential-key variants.
- Added create, update, direct database enforcement, runtime execution, callback, redaction, and LiveView non-reflection regressions.
- Verified legacy migration cleanup preserves safe settings and list ordering.
- Verified the full unit, static analysis, security scan, type analysis, dependency audit, documentation, and standalone application suites.

## Next Steps

Publish the matching provider configuration examples to the project wiki after merge.