### PR TITLE
feat(standalone): configure document storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Add validated local, AWS S3, and GCS storage configuration to the standalone release
+
 ### Security
 - Remove the Docker Compose PostgreSQL host port and require an operator-supplied database password
 - Require nonblank HTTP Basic Authentication credentials before the standalone production endpoint starts

--- a/README.md
+++ b/README.md
@@ -542,7 +542,7 @@ Uploaded test case documents go through `Aludel.Storage`. Documents can be attac
 Supported uploads are PDF, PNG, JPEG, JSON, CSV, and plain text. Anthropic accepts PDFs natively; adapters that require images can use the configurable ImageMagick converter.
 
 - Development uses the local filesystem adapter from `config/dev.exs`.
-- Production uses `config/runtime.exs` and requires `ALUDEL_STORAGE_BACKEND`.
+- Standalone production validates `ALUDEL_STORAGE_BACKEND` and its backend-specific settings at startup.
 
 ### Development storage
 
@@ -550,7 +550,14 @@ Development stores uploaded documents on the local filesystem.
 
 ### Production storage
 
-Set `ALUDEL_STORAGE_BACKEND` to `aws` or `gcs`.
+Set `ALUDEL_STORAGE_BACKEND` to `local`, `aws`, or `gcs`.
+
+For a persistent local volume:
+
+```bash
+export ALUDEL_STORAGE_BACKEND=local
+export ALUDEL_STORAGE_PATH=/data/aludel_uploads
+```
 
 For AWS S3:
 
@@ -558,8 +565,14 @@ For AWS S3:
 export ALUDEL_STORAGE_BACKEND=aws
 export AWS_S3_BUCKET=aludel-uploads
 export AWS_REGION=us-east-1
+```
+
+The standalone release uses the AWS runtime identity provider when credentials are not explicitly set. When static or temporary credentials are needed, set the access-key pair together; the session token is optional:
+
+```bash
 export AWS_ACCESS_KEY_ID=...
 export AWS_SECRET_ACCESS_KEY=...
+export AWS_SESSION_TOKEN=...
 ```
 
 For Google Cloud Storage:
@@ -578,6 +591,10 @@ export GCS_USER_PROJECT=your-billing-project-id
 
 The GCS adapter uses `Goth` with standard Google application credentials.
 `GOOGLE_APPLICATION_CREDENTIALS_JSON` also works if you prefer inline JSON.
+
+Startup rejects missing backend settings, unsupported backends, and partial or blank explicit AWS credentials. Embedded applications can configure `Aludel.Storage` directly for these adapters or a custom backend.
+
+Changing the active backend does not move existing objects. Keep the former backend variables configured until its documents have been removed or migrated; the standalone release retains every completely configured backend for reads and cleanup of existing document rows.
 
 ## Evaluation Workflows
 

--- a/guides/embedding.md
+++ b/guides/embedding.md
@@ -202,15 +202,30 @@ config :aludel, Aludel.Storage,
   backends: [{Aludel.Interfaces.Storage.Adapters.Local, root: "tmp/aludel_uploads"}]
 ```
 
-Standalone production selects AWS S3 or Google Cloud Storage through environment variables:
+Standalone production selects local filesystem, AWS S3, or Google Cloud Storage through environment variables. Local storage requires an explicit persistent path:
+
+```bash
+export ALUDEL_STORAGE_BACKEND=local
+export ALUDEL_STORAGE_PATH=/data/aludel_uploads
+```
+
+AWS storage requires the bucket and region:
 
 ```bash
 export ALUDEL_STORAGE_BACKEND=aws
 export AWS_S3_BUCKET=aludel-uploads
 export AWS_REGION=us-east-1
+```
+
+The standalone release uses the AWS runtime identity provider by default. To use explicit static or temporary credentials, set the access-key pair together and optionally include the session token:
+
+```bash
 export AWS_ACCESS_KEY_ID=...
 export AWS_SECRET_ACCESS_KEY=...
+export AWS_SESSION_TOKEN=...
 ```
+
+GCS storage requires a bucket and Google application credentials:
 
 ```bash
 export ALUDEL_STORAGE_BACKEND=gcs
@@ -219,7 +234,9 @@ export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
 export GCS_USER_PROJECT=optional-requester-pays-project
 ```
 
-Inline `GOOGLE_APPLICATION_CREDENTIALS_JSON` is also supported. Applications can implement `Aludel.Interfaces.Storage.Behaviour` when documents must use another storage system.
+Inline `GOOGLE_APPLICATION_CREDENTIALS_JSON` is also supported. Standalone startup rejects missing backend settings, unsupported backends, relative local paths, and partial explicit AWS credentials. Changing the active backend does not move existing objects, so retain the former backend variables until its documents have been removed or migrated. Every completely configured backend remains available for reads and cleanup of existing document rows.
+
+Applications can implement `Aludel.Interfaces.Storage.Behaviour` when documents must use another storage system.
 
 ## PDF conversion
 

--- a/guides/features.md
+++ b/guides/features.md
@@ -116,6 +116,8 @@ Document bytes are kept outside PostgreSQL through `Aludel.Storage`; database ro
 - AWS S3
 - Google Cloud Storage, including requester-pays buckets
 
+The standalone release selects local, AWS S3, or GCS storage through validated environment settings. AWS can use its runtime identity provider or an explicit access-key pair, and local production requires an explicit persistent path.
+
 Anthropic can receive PDFs natively. Providers that require images can use the configurable ImageMagick PDF converter.
 
 ## Prompt evolution and optimization

--- a/standalone/config/dev.exs
+++ b/standalone/config/dev.exs
@@ -27,3 +27,10 @@ config :aludel, :llm,
   xai_api_key: System.get_env("XAI_API_KEY"),
   groq_api_key: System.get_env("GROQ_API_KEY"),
   openrouter_api_key: System.get_env("OPENROUTER_API_KEY")
+
+config :aludel, Aludel.Storage,
+  adapter: Aludel.Interfaces.Storage.Adapters.Local,
+  backends: [
+    {Aludel.Interfaces.Storage.Adapters.Local,
+     [root: System.get_env("ALUDEL_STORAGE_PATH") || "tmp/aludel_uploads"]}
+  ]

--- a/standalone/config/runtime.exs
+++ b/standalone/config/runtime.exs
@@ -41,6 +41,33 @@ if config_env() == :prod do
 
   config :aludel_dash, AludelDash.Repo, repo_config
 
+  storage_config =
+    case AludelDash.StorageConfig.resolve(System.get_env()) do
+      {:ok, config} ->
+        config
+
+      {:error, {:missing, variable}} ->
+        raise "#{variable} must be set to a nonblank value."
+
+      {:error, {:invalid, variable}} ->
+        raise "#{variable} is invalid. Use an absolute path for local storage."
+
+      {:error, {:unsupported_backend, _backend}} ->
+        raise "ALUDEL_STORAGE_BACKEND must be one of: local, aws, gcs."
+
+      {:error, :invalid_aws_credentials} ->
+        raise """
+        AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must both be nonblank when either is set.
+        AWS_SESSION_TOKEN is optional and requires the explicit key pair.
+        Omit all three variables to use the AWS runtime identity provider.
+        """
+
+      {:error, :invalid_environment} ->
+        raise "Unable to read standalone storage configuration."
+    end
+
+  config :aludel, Aludel.Storage, storage_config
+
   secret_key_base =
     System.get_env("SECRET_KEY_BASE") ||
       raise """

--- a/standalone/config/test.exs
+++ b/standalone/config/test.exs
@@ -3,3 +3,7 @@ import Config
 config :aludel_dash, :basic_auth, :disabled
 
 config :aludel_dash, AludelDash.Endpoint, server: false
+
+config :aludel, Aludel.Storage,
+  adapter: Aludel.Interfaces.Storage.Adapters.Local,
+  backends: [{Aludel.Interfaces.Storage.Adapters.Local, [root: "tmp/aludel_test_uploads"]}]

--- a/standalone/lib/aludel_dash.ex
+++ b/standalone/lib/aludel_dash.ex
@@ -117,6 +117,202 @@ defmodule AludelDash.DatabaseConfig do
   end
 end
 
+defmodule AludelDash.StorageConfig do
+  @moduledoc false
+
+  alias Aludel.Interfaces.Storage.Adapters.AWS
+  alias Aludel.Interfaces.Storage.Adapters.GCS
+  alias Aludel.Interfaces.Storage.Adapters.Local
+
+  @aws_credential_variables [
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN"
+  ]
+  @backend_order [Local, AWS, GCS]
+  @backend_modules %{
+    "local" => Local,
+    "aws" => AWS,
+    "gcs" => GCS
+  }
+
+  @type error_reason ::
+          {:invalid, String.t()}
+          | {:missing, String.t()}
+          | {:unsupported_backend, String.t()}
+          | :invalid_aws_credentials
+          | :invalid_environment
+  @type result :: {:ok, keyword()} | {:error, error_reason()}
+
+  @spec resolve(%{optional(String.t()) => term()}) :: result()
+  def resolve(environment) when is_map(environment) do
+    with {:ok, backend} <- fetch_present(environment, "ALUDEL_STORAGE_BACKEND"),
+         {:ok, adapter} <- resolve_adapter(backend),
+         {:ok, backends} <- resolve_backends(adapter, environment) do
+      {:ok, [adapter: adapter, backends: backends]}
+    end
+  end
+
+  def resolve(_environment) do
+    {:error, :invalid_environment}
+  end
+
+  defp resolve_adapter(backend) do
+    case Map.fetch(@backend_modules, backend) do
+      {:ok, adapter} -> {:ok, adapter}
+      :error -> {:error, {:unsupported_backend, backend}}
+    end
+  end
+
+  defp resolve_backends(active_adapter, environment) do
+    @backend_order
+    |> Enum.reduce_while({:ok, []}, fn adapter, {:ok, backends} ->
+      case maybe_add_backend(adapter, active_adapter, environment, backends) do
+        {:ok, updated_backends} -> {:cont, {:ok, updated_backends}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, backends} -> {:ok, Enum.reverse(backends)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp maybe_add_backend(adapter, active_adapter, environment, backends) do
+    if adapter == active_adapter or backend_configured?(adapter, environment) do
+      with {:ok, config} <- resolve_backend_config(adapter, environment) do
+        {:ok, [{adapter, config} | backends]}
+      end
+    else
+      {:ok, backends}
+    end
+  end
+
+  defp resolve_backend_config(Local, environment) do
+    with {:ok, root} <- fetch_present(environment, "ALUDEL_STORAGE_PATH"),
+         :ok <- validate_local_root(root) do
+      {:ok, [root: root]}
+    end
+  end
+
+  defp resolve_backend_config(AWS, environment) do
+    with {:ok, bucket} <- fetch_present(environment, "AWS_S3_BUCKET"),
+         {:ok, region} <- fetch_present(environment, "AWS_REGION"),
+         {:ok, credential_config} <- resolve_aws_credentials(environment) do
+      {:ok, [bucket: bucket, region: region] ++ credential_config}
+    end
+  end
+
+  defp resolve_backend_config(GCS, environment) do
+    with {:ok, bucket} <- fetch_present(environment, "GCS_BUCKET") do
+      config =
+        [bucket: bucket, goth: Aludel.Goth]
+        |> maybe_put_user_project(environment)
+
+      {:ok, config}
+    end
+  end
+
+  defp backend_configured?(Local, environment) do
+    Map.has_key?(environment, "ALUDEL_STORAGE_PATH")
+  end
+
+  defp backend_configured?(AWS, environment) do
+    Map.has_key?(environment, "AWS_S3_BUCKET") or Map.has_key?(environment, "AWS_REGION")
+  end
+
+  defp backend_configured?(GCS, environment) do
+    Map.has_key?(environment, "GCS_BUCKET")
+  end
+
+  defp validate_local_root(root) do
+    if Path.type(root) == :absolute do
+      :ok
+    else
+      {:error, {:invalid, "ALUDEL_STORAGE_PATH"}}
+    end
+  end
+
+  defp resolve_aws_credentials(environment) do
+    credential_states =
+      Enum.map(@aws_credential_variables, &credential_state(environment, &1))
+
+    case credential_states do
+      [:missing, :missing, :missing] ->
+        {:ok, runtime_identity_config()}
+
+      [:present, :present, :missing] ->
+        {:ok, explicit_credential_config()}
+
+      [:present, :present, :present] ->
+        {:ok, explicit_credential_config() ++ [security_token: {:system, "AWS_SESSION_TOKEN"}]}
+
+      _invalid_or_partial ->
+        {:error, :invalid_aws_credentials}
+    end
+  end
+
+  defp runtime_identity_config do
+    [
+      access_key_id: [:pod_identity, :instance_role],
+      secret_access_key: [:pod_identity, :instance_role],
+      security_token: [:pod_identity, :instance_role]
+    ]
+  end
+
+  defp explicit_credential_config do
+    [
+      access_key_id: {:system, "AWS_ACCESS_KEY_ID"},
+      secret_access_key: {:system, "AWS_SECRET_ACCESS_KEY"}
+    ]
+  end
+
+  defp credential_state(environment, variable) do
+    case Map.get(environment, variable) do
+      nil ->
+        :missing
+
+      value when is_binary(value) ->
+        if String.trim(value) == "" do
+          :invalid
+        else
+          :present
+        end
+
+      _invalid ->
+        :invalid
+    end
+  end
+
+  defp maybe_put_user_project(config, environment) do
+    case Map.get(environment, "GCS_USER_PROJECT") do
+      value when is_binary(value) ->
+        if String.trim(value) == "" do
+          config
+        else
+          config ++ [user_project: value]
+        end
+
+      _missing_or_invalid ->
+        config
+    end
+  end
+
+  defp fetch_present(environment, variable) do
+    case Map.get(environment, variable) do
+      value when is_binary(value) ->
+        if String.trim(value) == "" do
+          {:error, {:missing, variable}}
+        else
+          {:ok, value}
+        end
+
+      _missing_or_invalid ->
+        {:error, {:missing, variable}}
+    end
+  end
+end
+
 defmodule AludelDash.Resolver do
   @behaviour Aludel.Web.Resolver
 

--- a/standalone/test/aludel_dash/storage_config_test.exs
+++ b/standalone/test/aludel_dash/storage_config_test.exs
@@ -1,0 +1,196 @@
+defmodule AludelDash.StorageConfigTest do
+  use ExUnit.Case, async: true
+
+  alias Aludel.Interfaces.Storage.Adapters.AWS
+  alias Aludel.Interfaces.Storage.Adapters.GCS
+  alias Aludel.Interfaces.Storage.Adapters.Local
+  alias AludelDash.StorageConfig
+
+  test "resolves local storage with an explicit persistent path" do
+    assert {:ok, config} =
+             StorageConfig.resolve(%{
+               "ALUDEL_STORAGE_BACKEND" => "local",
+               "ALUDEL_STORAGE_PATH" => "/data/aludel"
+             })
+
+    assert config == [
+             adapter: Local,
+             backends: [{Local, [root: "/data/aludel"]}]
+           ]
+  end
+
+  test "resolves AWS storage without copying credentials into application config" do
+    environment = %{
+      "ALUDEL_STORAGE_BACKEND" => "aws",
+      "AWS_S3_BUCKET" => "aludel-uploads",
+      "AWS_REGION" => "us-east-1",
+      "AWS_ACCESS_KEY_ID" => "access-value",
+      "AWS_SECRET_ACCESS_KEY" => "secret-value",
+      "AWS_SESSION_TOKEN" => "session-value"
+    }
+
+    assert {:ok, config} = StorageConfig.resolve(environment)
+
+    assert config == [
+             adapter: AWS,
+             backends: [
+               {AWS,
+                [
+                  bucket: "aludel-uploads",
+                  region: "us-east-1",
+                  access_key_id: {:system, "AWS_ACCESS_KEY_ID"},
+                  secret_access_key: {:system, "AWS_SECRET_ACCESS_KEY"},
+                  security_token: {:system, "AWS_SESSION_TOKEN"}
+                ]}
+             ]
+           ]
+
+    refute inspect(config) =~ "access-value"
+    refute inspect(config) =~ "secret-value"
+    refute inspect(config) =~ "session-value"
+  end
+
+  test "allows AWS runtime identity credentials" do
+    assert {:ok, config} =
+             StorageConfig.resolve(%{
+               "ALUDEL_STORAGE_BACKEND" => "aws",
+               "AWS_S3_BUCKET" => "aludel-uploads",
+               "AWS_REGION" => "eu-west-1"
+             })
+
+    assert config == [
+             adapter: AWS,
+             backends: [
+               {AWS,
+                [
+                  bucket: "aludel-uploads",
+                  region: "eu-west-1",
+                  access_key_id: [:pod_identity, :instance_role],
+                  secret_access_key: [:pod_identity, :instance_role],
+                  security_token: [:pod_identity, :instance_role]
+                ]}
+             ]
+           ]
+  end
+
+  test "allows an explicit AWS key pair without a session token" do
+    assert {:ok, config} =
+             StorageConfig.resolve(%{
+               "ALUDEL_STORAGE_BACKEND" => "aws",
+               "AWS_S3_BUCKET" => "aludel-uploads",
+               "AWS_REGION" => "us-east-1",
+               "AWS_ACCESS_KEY_ID" => "access-value",
+               "AWS_SECRET_ACCESS_KEY" => "secret-value"
+             })
+
+    [{AWS, backend_config}] = config[:backends]
+
+    assert backend_config[:access_key_id] == {:system, "AWS_ACCESS_KEY_ID"}
+    assert backend_config[:secret_access_key] == {:system, "AWS_SECRET_ACCESS_KEY"}
+    refute Keyword.has_key?(backend_config, :security_token)
+  end
+
+  test "rejects partial or blank explicit AWS credentials" do
+    base = %{
+      "ALUDEL_STORAGE_BACKEND" => "aws",
+      "AWS_S3_BUCKET" => "aludel-uploads",
+      "AWS_REGION" => "us-east-1"
+    }
+
+    invalid_credentials = [
+      %{"AWS_ACCESS_KEY_ID" => "access-value"},
+      %{"AWS_SECRET_ACCESS_KEY" => "secret-value"},
+      %{"AWS_SESSION_TOKEN" => "session-value"},
+      %{"AWS_ACCESS_KEY_ID" => " ", "AWS_SECRET_ACCESS_KEY" => "secret-value"},
+      %{"AWS_ACCESS_KEY_ID" => "access-value", "AWS_SECRET_ACCESS_KEY" => " "}
+    ]
+
+    for credentials <- invalid_credentials do
+      assert {:error, :invalid_aws_credentials} =
+               base
+               |> Map.merge(credentials)
+               |> StorageConfig.resolve()
+    end
+  end
+
+  test "resolves GCS storage with optional requester-pays project" do
+    assert {:ok, config} =
+             StorageConfig.resolve(%{
+               "ALUDEL_STORAGE_BACKEND" => "gcs",
+               "GCS_BUCKET" => "aludel-uploads",
+               "GCS_USER_PROJECT" => "billing-project"
+             })
+
+    assert config == [
+             adapter: GCS,
+             backends: [
+               {GCS,
+                [bucket: "aludel-uploads", goth: Aludel.Goth, user_project: "billing-project"]}
+             ]
+           ]
+  end
+
+  test "omits a blank requester-pays project" do
+    assert {:ok, config} =
+             StorageConfig.resolve(%{
+               "ALUDEL_STORAGE_BACKEND" => "gcs",
+               "GCS_BUCKET" => "aludel-uploads",
+               "GCS_USER_PROJECT" => " "
+             })
+
+    assert config == [
+             adapter: GCS,
+             backends: [{GCS, [bucket: "aludel-uploads", goth: Aludel.Goth]}]
+           ]
+  end
+
+  test "retains complete inactive backend configurations for existing documents" do
+    assert {:ok, config} =
+             StorageConfig.resolve(%{
+               "ALUDEL_STORAGE_BACKEND" => "gcs",
+               "ALUDEL_STORAGE_PATH" => "/data/aludel",
+               "AWS_S3_BUCKET" => "aludel-archive",
+               "AWS_REGION" => "us-east-1",
+               "GCS_BUCKET" => "aludel-current"
+             })
+
+    assert config[:adapter] == GCS
+    assert Keyword.keys(config[:backends]) == [Local, AWS, GCS]
+  end
+
+  test "rejects relative local paths and partial inactive backends" do
+    assert {:error, {:invalid, "ALUDEL_STORAGE_PATH"}} =
+             StorageConfig.resolve(%{
+               "ALUDEL_STORAGE_BACKEND" => "local",
+               "ALUDEL_STORAGE_PATH" => "tmp/uploads"
+             })
+
+    assert {:error, {:missing, "AWS_REGION"}} =
+             StorageConfig.resolve(%{
+               "ALUDEL_STORAGE_BACKEND" => "local",
+               "ALUDEL_STORAGE_PATH" => "/data/aludel",
+               "AWS_S3_BUCKET" => "partial-archive"
+             })
+  end
+
+  test "rejects missing required backend variables" do
+    cases = [
+      {%{}, "ALUDEL_STORAGE_BACKEND"},
+      {%{"ALUDEL_STORAGE_BACKEND" => "local"}, "ALUDEL_STORAGE_PATH"},
+      {%{"ALUDEL_STORAGE_BACKEND" => "aws", "AWS_REGION" => "us-east-1"}, "AWS_S3_BUCKET"},
+      {%{"ALUDEL_STORAGE_BACKEND" => "aws", "AWS_S3_BUCKET" => "bucket"}, "AWS_REGION"},
+      {%{"ALUDEL_STORAGE_BACKEND" => "gcs"}, "GCS_BUCKET"}
+    ]
+
+    for {environment, variable} <- cases do
+      assert {:error, {:missing, ^variable}} = StorageConfig.resolve(environment)
+    end
+  end
+
+  test "rejects unsupported backends and invalid input" do
+    assert {:error, {:unsupported_backend, "azure"}} =
+             StorageConfig.resolve(%{"ALUDEL_STORAGE_BACKEND" => "azure"})
+
+    assert {:error, :invalid_environment} = StorageConfig.resolve([])
+  end
+end


### PR DESCRIPTION
## Motivation

The standalone release documented production document storage but did not apply backend configuration at runtime. This change adds validated local, AWS S3, and GCS configuration before the endpoint starts.

The resolver supports persistent local paths, AWS runtime identities or explicit credential pairs, GCS requester-pays projects, and complete inactive backend configurations so documents written before a backend switch remain readable and removable.

## Test Plan

- Added standalone resolver coverage for each backend, required values, invalid values, AWS credential modes, requester-pays settings, and historical backend retention.
- Verified production release configuration for local, AWS runtime identity, and GCS modes.
- Verified unsupported configuration fails closed during release startup.
- Verified standalone and shared-library compile, unit, static analysis, security, dependency, and documentation checks.

## Next Steps

Publish the matching storage configuration and backend-switch guidance to the project wiki after merge.