### PR TITLE
fix(release): make publishing recoverable

### DIFF
--- a/.github/workflows/release-hex-package.yml
+++ b/.github/workflows/release-hex-package.yml
@@ -16,7 +16,7 @@ env:
   OTP_VERSION: "28.4.1"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.version }}
+  group: ${{ github.workflow }}
   cancel-in-progress: false
 
 jobs:
@@ -85,7 +85,7 @@ jobs:
           fi
 
           tag_exists=false
-          if git rev-parse "v${RELEASE_VERSION}" >/dev/null 2>&1; then
+          if git show-ref --verify --quiet "refs/tags/v${RELEASE_VERSION}"; then
             tag_exists=true
           fi
 
@@ -94,26 +94,56 @@ jobs:
             release_exists=true
           fi
 
-          if [ "$tag_exists" = "true" ] || [ "$release_exists" = "true" ]; then
-            if [ "$tag_exists" = "true" ] && [ "$release_exists" = "true" ]; then
-              echo "existing_release=true" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
+          hex_status="$(
+            curl --silent --show-error --location --retry 3 --retry-all-errors \
+              --user-agent "aludel-release-workflow/${GITHUB_RUN_ID}" \
+              --output /dev/null --write-out "%{http_code}" \
+              "https://hex.pm/api/packages/aludel/releases/${RELEASE_VERSION}"
+          )"
 
-            echo "::error::release state is partial: tag_exists=${tag_exists}, release_exists=${release_exists}"
+          case "$hex_status" in
+            200) hex_exists=true ;;
+            404) hex_exists=false ;;
+            *)
+              echo "::error::Hex.pm release lookup returned HTTP ${hex_status}"
+              exit 1
+              ;;
+          esac
+
+          if [ "$release_exists" = "true" ] && [ "$tag_exists" != "true" ]; then
+            echo "::error::GitHub release exists without its repository tag"
             exit 1
           fi
 
-          echo "existing_release=false" >> "$GITHUB_OUTPUT"
+          if [ "$hex_exists" = "true" ] && [ "$tag_exists" != "true" ]; then
+            echo "::error::Hex.pm release exists without its repository tag"
+            exit 1
+          fi
+
+          if [ "$tag_exists" = "true" ]; then
+            if ! git merge-base --is-ancestor "v${RELEASE_VERSION}" main; then
+              echo "::error::release tag is not contained in main"
+              exit 1
+            fi
+
+            new_release=false
+          else
+            new_release=true
+          fi
+
+          echo "tag_exists=${tag_exists}" >> "$GITHUB_OUTPUT"
+          echo "release_exists=${release_exists}" >> "$GITHUB_OUTPUT"
+          echo "hex_exists=${hex_exists}" >> "$GITHUB_OUTPUT"
+          echo "new_release=${new_release}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout existing release tag
-        if: ${{ steps.release_state.outputs.existing_release == 'true' }}
+        if: ${{ steps.release_state.outputs.tag_exists == 'true' }}
         env:
           RELEASE_VERSION: ${{ inputs.version }}
         run: git checkout "v${RELEASE_VERSION}"
 
       - name: Prepare release metadata
-        if: ${{ steps.release_state.outputs.existing_release != 'true' }}
+        if: ${{ steps.release_state.outputs.new_release == 'true' }}
         env:
           RELEASE_VERSION: ${{ inputs.version }}
         run: |
@@ -121,7 +151,15 @@ jobs:
 
           elixir scripts/aludel_release_prep.exs "$RELEASE_VERSION" \
             --notes-file /tmp/aludel-release-notes.md
-          mix format
+          mix format mix.exs
+
+      - name: Recover release notes
+        if: ${{ steps.release_state.outputs.tag_exists == 'true' && steps.release_state.outputs.release_exists != 'true' }}
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          elixir scripts/aludel_release_prep.exs "$RELEASE_VERSION" \
+            --notes-only --notes-file /tmp/aludel-release-notes.md
 
       - name: Install dependencies
         run: mix deps.get
@@ -130,7 +168,6 @@ jobs:
         env:
           HEX_API_KEY: ${{ secrets.HEX_SECRET_KEY }}
           RELEASE_VERSION: ${{ inputs.version }}
-          EXISTING_RELEASE: ${{ steps.release_state.outputs.existing_release }}
         run: |
           set -euo pipefail
 
@@ -148,17 +185,17 @@ jobs:
             exit 1
           fi
 
-          if [ "$EXISTING_RELEASE" != "true" ]; then
-            MIX_ENV=test mix ecto.create
-            MIX_ENV=test mix ecto.migrate
-            mix precommit
-          fi
+          MIX_ENV=test mix ecto.create
+          MIX_ENV=test mix ecto.migrate
+          mix precommit
+          mix deps.audit
+          mix hex.audit
 
           mix hex.publish --dry-run --yes
           mix hex.build --unpack --output /tmp/aludel-hex-package
 
       - name: Commit release metadata
-        if: ${{ steps.release_state.outputs.existing_release != 'true' }}
+        if: ${{ steps.release_state.outputs.new_release == 'true' }}
         env:
           RELEASE_VERSION: ${{ inputs.version }}
         run: |
@@ -178,7 +215,7 @@ jobs:
             -m "Update Aludel package metadata and changelog for ${RELEASE_VERSION}."
 
       - name: Tag and push release
-        if: ${{ steps.release_state.outputs.existing_release != 'true' }}
+        if: ${{ steps.release_state.outputs.new_release == 'true' }}
         env:
           RELEASE_VERSION: ${{ inputs.version }}
         run: |
@@ -188,7 +225,7 @@ jobs:
           git push --atomic origin HEAD:main "v${RELEASE_VERSION}"
 
       - name: Create GitHub release
-        if: ${{ steps.release_state.outputs.existing_release != 'true' }}
+        if: ${{ steps.release_state.outputs.release_exists != 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_VERSION: ${{ inputs.version }}
@@ -199,9 +236,10 @@ jobs:
             --title "v${RELEASE_VERSION}" \
             --notes-file /tmp/aludel-release-notes.md
 
-      - name: Publish package
+      - name: Publish package or recover documentation
         env:
           HEX_API_KEY: ${{ secrets.HEX_SECRET_KEY }}
+          HEX_RELEASE_EXISTS: ${{ steps.release_state.outputs.hex_exists }}
         run: |
           set -euo pipefail
 
@@ -210,4 +248,8 @@ jobs:
             exit 1
           fi
 
-          mix hex.publish --yes
+          if [ "$HEX_RELEASE_EXISTS" = "true" ]; then
+            mix hex.publish docs --yes
+          else
+            mix hex.publish --yes
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bound regular expression assertion size, matching work, recursion depth, and wall-clock time
 - Reject provider credentials in persisted configuration, remove legacy credential keys, and sanitize runtime and callback boundaries
 
+### Fixed
+- Move curated Unreleased entries into the versioned changelog section during release preparation
+- Make Hex release reruns recover interrupted GitHub releases and documentation publication safely
+
 ## [0.6.1] - 2026-09-04
 
 ### Security

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,12 @@ mix phx.server
 - Ensure all tests pass before submitting: `mix test`
 - Maintain or improve code coverage
 
+## Maintainer Releases
+
+Keep user-facing release notes under `Unreleased` in `CHANGELOG.md`, then run the **Release Hex Package** workflow with the next SemVer version without a leading `v`. The workflow serializes releases, moves those curated notes into the new version, verifies the package, creates the version commit and annotated tag, publishes the GitHub release, and publishes the Hex package and documentation.
+
+Rerun the same version after an interruption. A tag-only state recreates the GitHub release from the versioned changelog, a GitHub release without a Hex package resumes package publication, and an existing Hex package republishes its documentation. The workflow refuses GitHub or Hex release state that has no matching repository tag.
+
 ## Questions or Ideas?
 
 - **💬 [Discussions](https://github.com/ccarvalho-eng/aludel/discussions)** — Ask questions, share ideas, or discuss use cases

--- a/scripts/aludel_release_prep.exs
+++ b/scripts/aludel_release_prep.exs
@@ -5,7 +5,7 @@ defmodule Aludel.ReleasePrepScript do
   def main(args) do
     {opts, args, invalid} =
       OptionParser.parse(args,
-        strict: [date: :string, from_tag: :string, notes_file: :string],
+        strict: [date: :string, from_tag: :string, notes_file: :string, notes_only: :boolean],
         aliases: [d: :date]
       )
 
@@ -16,14 +16,22 @@ defmodule Aludel.ReleasePrepScript do
     version = single_version!(args)
     validate_version!(version)
 
+    if opts[:notes_only] do
+      write_existing_notes!(version, opts[:notes_file])
+    else
+      prepare_release!(version, opts)
+    end
+  end
+
+  defp prepare_release!(version, opts) do
     date = Keyword.get(opts, :date, Date.to_iso8601(Date.utc_today()))
     from_tag = Keyword.get(opts, :from_tag) || previous_version_tag!(version)
-    commits = commits_since!(from_tag)
+    commits_since!(from_tag)
+    notes = unreleased_notes!()
 
     update_mix_version!(version)
     update_install_snippets!(version)
 
-    notes = changelog_notes(commits)
     update_changelog!(version, date, notes)
     write_notes_file(opts[:notes_file], notes)
 
@@ -31,6 +39,13 @@ defmodule Aludel.ReleasePrepScript do
     Prepared Aludel #{version} release metadata.
     Changelog source: #{from_tag}..HEAD
     """)
+  end
+
+  defp write_existing_notes!(version, notes_file) do
+    notes = versioned_notes!(version)
+    write_notes_file(notes_file, notes)
+
+    IO.puts("Prepared release notes for Aludel #{version}.")
   end
 
   defp single_version!([version]) do
@@ -116,17 +131,36 @@ defmodule Aludel.ReleasePrepScript do
     end)
   end
 
-  defp changelog_notes(commits) do
-    commit_lines =
-      Enum.map_join(commits, "\n", fn
-        {"", subject} -> "- #{subject}"
-        {sha, subject} -> "- `#{sha}` #{subject}"
-      end)
+  defp unreleased_notes! do
+    body = File.read!("CHANGELOG.md")
 
-    """
-    ### Changed
-    #{commit_lines}
-    """
+    case Regex.run(~r/^## Unreleased[^\n]*\n(?<notes>.*?)(?=^## \[)/ms, body, capture: ["notes"]) do
+      [notes] -> normalize_notes!(notes, "Unreleased section has no entries")
+      nil -> fail!("Could not find an Unreleased section before the latest release")
+    end
+  end
+
+  defp versioned_notes!(version) do
+    body = File.read!("CHANGELOG.md")
+    escaped_version = Regex.escape(version)
+
+    pattern =
+      Regex.compile!(
+        "^## \\[#{escaped_version}\\][^\\n]*\\n(?<notes>.*?)(?=^## \\[|\\z)",
+        "ms"
+      )
+
+    case Regex.run(pattern, body, capture: ["notes"]) do
+      [notes] -> normalize_notes!(notes, "Release #{version} has no changelog entries")
+      nil -> fail!("Could not find CHANGELOG.md release #{version}")
+    end
+  end
+
+  defp normalize_notes!(notes, error_message) do
+    case String.trim(notes) do
+      "" -> fail!(error_message)
+      normalized -> normalized <> "\n"
+    end
   end
 
   defp update_changelog!(version, date, notes) do
@@ -136,13 +170,20 @@ defmodule Aludel.ReleasePrepScript do
       end
 
       section = """
+      ## Unreleased
+
       ## [#{version}] - #{date}
 
       #{String.trim_trailing(notes)}
 
       """
 
-      replace_once!(body, ~r/\n## \[/, "\n#{section}## [", "CHANGELOG.md release insertion point")
+      replace_once!(
+        body,
+        ~r/^## Unreleased[^\n]*\n.*?(?=^## \[)/ms,
+        section,
+        "CHANGELOG.md Unreleased section"
+      )
     end)
   end
 
@@ -165,7 +206,7 @@ defmodule Aludel.ReleasePrepScript do
 
   defp replace_once!(body, pattern, replacement, label) do
     if Regex.match?(pattern, body) do
-      Regex.replace(pattern, body, replacement, global: false)
+      Regex.replace(pattern, body, fn _match -> replacement end, global: false)
     else
       fail!("Could not find #{label}")
     end

--- a/test/scripts/aludel_release_prep_test.exs
+++ b/test/scripts/aludel_release_prep_test.exs
@@ -3,7 +3,7 @@ defmodule Aludel.ReleasePrepScriptTest do
 
   @script Path.expand("../../scripts/aludel_release_prep.exs", __DIR__)
 
-  test "prepares package metadata and release notes from commits since the previous tag" do
+  test "moves curated unreleased notes into the versioned release" do
     repo = temporary_repo!()
     notes_file = Path.join(repo, "release-notes.md")
 
@@ -31,8 +31,82 @@ defmodule Aludel.ReleasePrepScriptTest do
 
     changelog = File.read!(Path.join(repo, "CHANGELOG.md"))
     assert changelog =~ "## [0.4.2] - 2026-08-15"
-    assert changelog =~ "- `#{commit}` feat: add release automation"
-    assert File.read!(notes_file) =~ "- `#{commit}` feat: add release automation"
+    assert changelog =~ "## Unreleased\n\n## [0.4.2]"
+    assert changelog =~ "### Added\n- Add reliable release automation"
+    assert changelog =~ "### Security\n- Validate release state before publication"
+
+    notes = File.read!(notes_file)
+    assert notes =~ "### Added\n- Add reliable release automation"
+    assert notes =~ "### Security\n- Validate release state before publication"
+    refute notes =~ commit
+    refute notes =~ "feat: add release automation"
+  end
+
+  test "extracts notes from an existing version for interrupted release recovery" do
+    repo = temporary_repo!()
+    notes_file = Path.join(repo, "release-notes.md")
+
+    File.write!(
+      Path.join(repo, "CHANGELOG.md"),
+      """
+      # Changelog
+
+      ## Unreleased
+
+      ## [0.4.2] - 2026-08-15
+
+      ### Added
+      - Add reliable release automation
+
+      ## [0.4.1] - 2026-06-15
+
+      ### Changed
+      - Previous release
+      """
+    )
+
+    {output, status} =
+      System.cmd(
+        "elixir",
+        [@script, "0.4.2", "--notes-only", "--notes-file", notes_file],
+        cd: repo,
+        stderr_to_stdout: true
+      )
+
+    assert status == 0, output
+    assert File.read!(notes_file) == "### Added\n- Add reliable release automation\n"
+  end
+
+  test "rejects a release with no curated unreleased entries" do
+    repo = temporary_repo!()
+
+    write_release_files!(repo)
+    changelog_path = Path.join(repo, "CHANGELOG.md")
+
+    changelog_path
+    |> File.read!()
+    |> String.replace(
+      "## Unreleased\n\n### Added\n- Add reliable release automation\n\n### Security\n- Validate release state before publication\n",
+      "## Unreleased\n"
+    )
+    |> then(&File.write!(changelog_path, &1))
+
+    run_git!(repo, ["add", "."])
+    run_git!(repo, ["commit", "-m", "chore: release 0.4.1"])
+    run_git!(repo, ["tag", "v0.4.1"])
+
+    File.write!(Path.join(repo, "feature.txt"), "new feature\n")
+    run_git!(repo, ["add", "feature.txt"])
+    run_git!(repo, ["commit", "-m", "feat: add release automation"])
+
+    {output, status} =
+      System.cmd("elixir", [@script, "0.4.2", "--date", "2026-08-15"],
+        cd: repo,
+        stderr_to_stdout: true
+      )
+
+    assert status == 1
+    assert output =~ "Unreleased section has no entries"
   end
 
   test "rejects a version with a leading v" do
@@ -73,6 +147,14 @@ defmodule Aludel.ReleasePrepScriptTest do
       Path.join(repo, "CHANGELOG.md"),
       """
       # Changelog
+
+      ## Unreleased
+
+      ### Added
+      - Add reliable release automation
+
+      ### Security
+      - Validate release state before publication
 
       ## [0.4.1] - 2026-06-15
 


### PR DESCRIPTION
## Motivation

Interrupted releases could leave a tag, GitHub release, Hex package, or documentation publication incomplete, and rerunning the workflow could not safely converge every valid partial state. Release notes were also generated from commit subjects instead of the curated Unreleased changelog.

## Changes

- Serialize all package releases and validate repository, GitHub, and Hex state before publishing
- Resume tag-only and partially published releases without replacing an existing package
- Move curated Unreleased notes into each version and recover GitHub release notes from versioned changelog entries
- Run project, dependency, package, and documentation verification on every release attempt
- Document the maintainer release and recovery contract

## Test Plan

- Release preparation regressions cover curated note promotion, interrupted-run note recovery, empty-note rejection, and version validation
- The complete project precommit suite, static analysis, dependency audits, documentation build, and Hex package dry run pass
- The workflow YAML parses successfully and the staged diff has no whitespace errors

## Next Steps

No follow-up is required for this focused release reliability change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added maintainer guidance for preparing and publishing releases.
  * Clarified that curated notes from the changelog are used for release announcements.

* **Bug Fixes**
  * Improved recovery for interrupted releases, including cases where tags, GitHub releases, packages, or documentation were published separately.
  * Prevented releases from proceeding when repository state is inconsistent.

* **Release Process**
  * Added a notes-only mode for recovering existing release notes without modifying project files.
  * Improved validation and verification across release publication steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->