### PR TITLE
refactor(quality): eliminate code smell findings

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -1,12 +1,8 @@
 # This file contains the configuration for Credo and you are probably reading
 # this after creating it with `mix credo.gen.config`.
-# Existing findings in these categories are handled in a follow-up cleanup before
-# the checks join the enforced set.
 excluded_ex_slop_checks = [
   ExSlop.Check.Warning.DualKeyAccess,
-  ExSlop.Check.Refactor.LengthComparison,
-  ExSlop.Check.Refactor.WithIdentityElse,
-  ExSlop.Check.Readability.NarratorDoc
+  ExSlop.Check.Refactor.LengthComparison
 ]
 
 ex_slop_checks =
@@ -171,7 +167,9 @@ ex_slop_checks =
           {Credo.Check.Warning.UnusedRegexOperation, []},
           {Credo.Check.Warning.UnusedStringOperation, []},
           {Credo.Check.Warning.UnusedTupleOperation, []},
-          {Credo.Check.Warning.WrongTestFileExtension, []}
+          {Credo.Check.Warning.WrongTestFileExtension, []},
+          {ExSlop.Check.Warning.DualKeyAccess, [files: [included: ["lib/"]]]},
+          {ExSlop.Check.Refactor.LengthComparison, [files: [included: ["lib/"]]]}
           | ex_slop_checks
         ],
         disabled: [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Add repeatable quality gates for high-signal code smells, compile cycles, duplicate code, documentation coverage, dependency advisories, and static analysis
+- Normalize provider pricing at its boundary and replace redundant control flow, generated documentation text, and full-list length checks with idiomatic Elixir
 
 ## [0.6.1] - 2026-09-04
 

--- a/lib/aludel/datasets.ex
+++ b/lib/aludel/datasets.ex
@@ -199,8 +199,16 @@ defmodule Aludel.Datasets do
     end
   end
 
-  defp entry_position(attrs, default) do
-    Map.get(attrs, :position) || Map.get(attrs, "position") || default
+  defp entry_position(%{position: position}, _default) when position not in [nil, false] do
+    position
+  end
+
+  defp entry_position(%{"position" => position}, _default) when position not in [nil, false] do
+    position
+  end
+
+  defp entry_position(_attrs, default) do
+    default
   end
 
   defp repo do

--- a/lib/aludel/datasets/dataset_entry.ex
+++ b/lib/aludel/datasets/dataset_entry.ex
@@ -59,7 +59,7 @@ defmodule Aludel.Datasets.DatasetEntry do
   end
 
   @spec conversation_kind(t()) :: :single_turn | :multi_turn
-  def conversation_kind(%__MODULE__{messages: messages}) when length(messages) > 1 do
+  def conversation_kind(%__MODULE__{messages: [_, _ | _]}) do
     :multi_turn
   end
 

--- a/lib/aludel/evals/test_case_importer.ex
+++ b/lib/aludel/evals/test_case_importer.ex
@@ -127,9 +127,6 @@ defmodule Aludel.Evals.TestCaseImporter do
            variable_values: %{"input" => input},
            assertions: [assertion_payload]
          }}
-      else
-        {:error, message} ->
-          {:error, message}
       end
     end
   end

--- a/lib/aludel/interfaces/storage/adapters/gcs/google_api_client.ex
+++ b/lib/aludel/interfaces/storage/adapters/gcs/google_api_client.ex
@@ -51,8 +51,6 @@ defmodule Aludel.Interfaces.Storage.Adapters.GCS.GoogleApiClient do
          {:ok, _response} <-
            Objects.storage_objects_delete(connection, bucket, key, request_options(config)) do
       :ok
-    else
-      {:error, reason} -> {:error, reason}
     end
   end
 

--- a/lib/aludel/providers.ex
+++ b/lib/aludel/providers.ex
@@ -226,8 +226,7 @@ defmodule Aludel.Providers do
 
     {input, output} =
       if has_custom do
-        i = pricing["input"] || pricing[:input] || ""
-        o = pricing["output"] || pricing[:output] || ""
+        %{input: i, output: o} = Pricing.normalize(pricing)
         {to_string(i), to_string(o)}
       else
         {"", ""}

--- a/lib/aludel/providers/pricing.ex
+++ b/lib/aludel/providers/pricing.ex
@@ -57,6 +57,21 @@ defmodule Aludel.Providers.Pricing do
   end
 
   @doc """
+  Normalizes string-keyed or atom-keyed pricing into the internal atom-keyed shape.
+
+  String keys take precedence because persisted JSON maps use strings. Missing or
+  false string values fall back to their atom-keyed counterparts for compatibility
+  with programmatically constructed providers.
+  """
+  @spec normalize(map()) :: %{input: term(), output: term()}
+  def normalize(pricing) when is_map(pricing) do
+    %{
+      input: pricing_value(pricing, :input),
+      output: pricing_value(pricing, :output)
+    }
+  end
+
+  @doc """
   Formats pricing for human-readable display.
 
   ## Examples
@@ -86,6 +101,13 @@ defmodule Aludel.Providers.Pricing do
     case :persistent_term.get(@persistent_term_key, nil) do
       nil -> build_and_cache_index()
       index -> index
+    end
+  end
+
+  defp pricing_value(pricing, key) do
+    case Map.fetch(pricing, Atom.to_string(key)) do
+      {:ok, value} when value not in [nil, false] -> value
+      _other -> Map.get(pricing, key)
     end
   end
 

--- a/lib/aludel/providers/provider.ex
+++ b/lib/aludel/providers/provider.ex
@@ -7,6 +7,7 @@ defmodule Aludel.Providers.Provider do
   import Ecto.Changeset
 
   alias Aludel.Providers.ConfigPolicy
+  alias Aludel.Providers.Pricing
   alias Ecto.Changeset
 
   @type t :: %__MODULE__{}
@@ -72,8 +73,7 @@ defmodule Aludel.Providers.Provider do
           [pricing: "must be a map"]
 
         true ->
-          input = pricing["input"] || pricing[:input]
-          output = pricing["output"] || pricing[:output]
+          %{input: input, output: output} = Pricing.normalize(pricing)
 
           cond do
             not is_number(input) -> [pricing: "must contain a numeric input rate"]

--- a/lib/aludel/web/components/layouts.ex
+++ b/lib/aludel/web/components/layouts.ex
@@ -1,7 +1,6 @@
 defmodule Aludel.Web.Layouts do
   @moduledoc """
-  This module holds layouts and related functionality
-  used by your application.
+  Shared layouts for the embedded and standalone Aludel interfaces.
   """
   use Aludel.Web, :html
 

--- a/test/aludel/providers/pricing_test.exs
+++ b/test/aludel/providers/pricing_test.exs
@@ -75,6 +75,28 @@ defmodule Aludel.Providers.PricingTest do
     end
   end
 
+  describe "normalize/1" do
+    test "normalizes atom and string keys" do
+      assert Pricing.normalize(%{input: 1.0, output: 2.0}) == %{input: 1.0, output: 2.0}
+
+      assert Pricing.normalize(%{"input" => 3.0, "output" => 4.0}) == %{
+               input: 3.0,
+               output: 4.0
+             }
+    end
+
+    test "prefers persisted string keys and falls back from empty values" do
+      pricing = %{
+        "input" => 3.0,
+        "output" => nil,
+        input: 1.0,
+        output: 2.0
+      }
+
+      assert Pricing.normalize(pricing) == %{input: 3.0, output: 2.0}
+    end
+  end
+
   describe "format_pricing/1" do
     test "formats normal pricing" do
       assert Pricing.format_pricing(%{input: 3.0, output: 15.0}) ==

--- a/test/aludel/providers_test.exs
+++ b/test/aludel/providers_test.exs
@@ -371,8 +371,8 @@ defmodule Aludel.ProvidersTest do
     test "returns a pricing map with input and output rates for known models" do
       result = Providers.default_pricing(:openai, "gpt-4o")
       assert is_map(result)
-      assert is_number(result[:input] || result["input"])
-      assert is_number(result[:output] || result["output"])
+      assert is_number(result.input)
+      assert is_number(result.output)
     end
 
     test "accepts provider as a binary string" do

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -1,18 +1,10 @@
 defmodule Aludel.Web.ConnCase do
   @moduledoc """
-  This module defines the test case to be used by
-  tests that require setting up a connection.
+  Connection-backed ExUnit case for controller and LiveView behavior.
 
-  Such tests rely on `Phoenix.ConnTest` and also
-  import other functionality to make it easier
-  to build common data structures and query the data layer.
-
-  Finally, if the test case interacts with the database,
-  we enable the SQL sandbox, so changes done to the database
-  are reverted at the end of every test. If you are using
-  PostgreSQL, you can even run database tests asynchronously
-  by setting `use Aludel.Web.ConnCase, async: true`, although
-  this option is not recommended for other databases.
+  Tests receive `Plug.Conn`, `Phoenix.ConnTest`, and `Phoenix.LiveViewTest`
+  helpers with the default Aludel endpoint. Each test also uses the isolated SQL
+  sandbox setup from `Aludel.DataCase` and receives a fresh connection.
   """
 
   use ExUnit.CaseTemplate

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -1,17 +1,13 @@
 defmodule Aludel.DataCase do
   @moduledoc """
-  This module defines the setup for tests requiring
-  access to the application's data layer.
+  Database-backed ExUnit case with shared data-layer helpers.
 
-  You may define functions here to be used as helpers in
-  your tests.
+  Tests receive Ecto query and changeset imports, project fixtures, and model
+  stubs. Each test owns an SQL sandbox connection and installs the default HTTP
+  client stub, isolating persisted data and external model requests.
 
-  Finally, if the test case interacts with the database,
-  we enable the SQL sandbox, so changes done to the database
-  are reverted at the end of every test. If you are using
-  PostgreSQL, you can even run database tests asynchronously
-  by setting `use Aludel.DataCase, async: true`, although
-  this option is not recommended for other databases.
+  PostgreSQL-backed tests can use `use Aludel.DataCase, async: true`. Other
+  database adapters may require synchronous execution.
   """
 
   use ExUnit.CaseTemplate


### PR DESCRIPTION
## Motivation

The new quality baseline identified four actionable production-code patterns that were temporarily excluded: ambiguous string and atom key access, full-list length comparison, redundant error passthroughs, and scaffold-style documentation.

## Changes

- Normalize provider pricing maps into a documented atom-keyed shape while preserving persisted string-key precedence
- Use structural matching for conversation cardinality and explicit function heads for optional dataset positions
- Remove redundant error passthrough branches from import and storage flows
- Replace generic scaffold documentation with Aludel-specific module contracts
- Enable all deferred checks for production code while avoiding noise from idiomatic test assertions

## Test Plan

- 79 focused pricing, provider, dataset, import, and storage tests pass
- The complete precommit suite passes with 939 tests
- All 98 strict Credo checks, Doctor, ExDNA, Sobelow, dependency audit, compile-cycle detection, and Dialyzer pass
- HexDocs builds successfully and the staged diff is clean

## Next Steps

The next focused change will improve public API documentation and typespec coverage and raise the enforced Doctor baseline.