### PR TITLE
docs(api): document core integration modules

### DIFF
--- a/.doctor.exs
+++ b/.doctor.exs
@@ -3,7 +3,7 @@
   ignore_paths: [~r/^test\//],
   min_module_doc_coverage: 0,
   min_module_spec_coverage: 0,
-  min_overall_doc_coverage: 70,
+  min_overall_doc_coverage: 78,
   min_overall_moduledoc_coverage: 100,
   min_overall_spec_coverage: 89,
   exception_moduledoc_required: true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Add repeatable quality gates for high-signal code smells, compile cycles, duplicate code, documentation coverage, dependency advisories, and static analysis
 - Normalize provider pricing at its boundary and replace redundant control flow, generated documentation text, and full-list length checks with idiomatic Elixir
+- Document the dataset, storage, and execution APIs and raise the enforced documentation coverage floor
 
 ## [0.6.1] - 2026-09-04
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Most teams evaluating LLM behavior end up with some combination of scripts, spre
 
 The dashboard and automation interfaces use the same persisted prompts, providers, datasets, suites, runs, quality policies, and evaluation evidence. A workflow can be authored in the UI, committed as a suite manifest, gated from the CLI, and inspected again in the dashboard without maintaining a second test-case format.
 
+For direct integration, start with the [`Aludel.Datasets`](https://hexdocs.pm/aludel/Aludel.Datasets.html), [`Aludel.Storage`](https://hexdocs.pm/aludel/Aludel.Storage.html), [`Aludel.Execution`](https://hexdocs.pm/aludel/Aludel.Execution.html), and [`Aludel.Executor`](https://hexdocs.pm/aludel/Aludel.Executor.html) API references.
+
 ## Feature Catalog
 
 | Area | Features |

--- a/guides/features.md
+++ b/guides/features.md
@@ -100,6 +100,8 @@ Datasets are ordered collections of evaluation examples that can be reused by mu
 
 Dataset pages support create, edit, delete, entry management, and JSON containment filters over metadata. Populating a suite copies entries in order, records source provenance, and skips entries already imported from that dataset.
 
+Programmatic dataset workflows use `Aludel.Datasets`; its API covers ordered entry creation, metadata-filtered listing, provenance-preserving suite population, and safe repeat population.
+
 `Aludel.RedTeam` provides seven versioned adversarial cases covering direct and indirect prompt injection, system prompt leakage, sensitive information disclosure, excessive agency, misinformation, and unsafe assistance. The dashboard and library API materialize selected cases into a reusable dataset with deterministic canary assertions, optional rubric judges, and category, severity, provenance, checksum, and deduplication metadata. The dashboard catalog exposes every prompt and risk field before selection. Matching reruns are idempotent; content or judge-configuration drift under the same key fails explicitly. See the [red-team guide](red_team.md).
 
 The dashboard and API can generate product-specific cases through an Aludel provider. Generation validates a strict response schema, bounds calls and output, reports sanitized partial failures and usage, and returns inert checksummed candidates without database writes or execution. Review exposes the complete receipt and leaves every candidate unapproved. A separate import action requires explicit approved candidate IDs, revalidates the review record, and creates the selected entries atomically with rubric judges and provenance.
@@ -117,6 +119,8 @@ Document bytes are kept outside PostgreSQL through `Aludel.Storage`; database ro
 - Google Cloud Storage, including requester-pays buckets
 
 The standalone release selects local, AWS S3, or GCS storage through validated environment settings. AWS can use its runtime identity provider or an explicit access-key pair, and local production requires an explicit persistent path.
+
+Embedded applications use `Aludel.Storage` to create stable keys and read, write, or remove objects through the active or persisted historical backend.
 
 Anthropic can receive PDFs natively. Providers that require images can use the configurable ImageMagick PDF converter.
 
@@ -155,6 +159,8 @@ See the [file-based suite guide](file_suites.html) for manifest examples, the [E
 Native mode renders the prompt and calls the selected provider adapter. Callback mode delegates to a host module implementing `Aludel.Executor`, allowing evaluations to exercise retrieval, tools, routing, retries, or post-processing from the real application.
 
 Both modes use the same run and suite UI. Callback responses require only `output`; tokens, latency, cost, and metadata are optional.
+
+Direct library callers use `Aludel.Execution.execute/1` for the normalized result contract or `Aludel.Execution.execute_with_artifacts/1` when failure artifacts must be retained.
 
 ## Embedding, access, and deployment
 

--- a/lib/aludel/datasets.ex
+++ b/lib/aludel/datasets.ex
@@ -9,6 +9,9 @@ defmodule Aludel.Datasets do
   alias Aludel.Evals.{Suite, TestCase}
   alias Ecto.Changeset
 
+  @doc """
+  Lists datasets alphabetically by name.
+  """
   @spec list_datasets() :: [Dataset.t()]
   def list_datasets do
     Dataset
@@ -16,11 +19,19 @@ defmodule Aludel.Datasets do
     |> repo().all()
   end
 
+  @doc """
+  Fetches a dataset by ID and raises `Ecto.NoResultsError` when it does not exist.
+  """
   @spec get_dataset!(binary()) :: Dataset.t()
   def get_dataset!(id) do
     repo().get!(Dataset, id)
   end
 
+  @doc """
+  Fetches a dataset by ID.
+
+  Returns `nil` for an invalid UUID or a dataset that does not exist.
+  """
   @spec get_dataset(binary()) :: Dataset.t() | nil
   def get_dataset(id) do
     case Ecto.UUID.cast(id) do
@@ -29,6 +40,12 @@ defmodule Aludel.Datasets do
     end
   end
 
+  @doc """
+  Lists a dataset's entries in stable position and insertion order.
+
+  Pass `metadata: %{...}` to retain entries whose JSON metadata contains every
+  supplied key and value.
+  """
   @spec list_entries(Dataset.t(), keyword()) :: [DatasetEntry.t()]
   def list_entries(%Dataset{} = dataset, opts \\ []) do
     DatasetEntry
@@ -38,6 +55,11 @@ defmodule Aludel.Datasets do
     |> repo().all()
   end
 
+  @doc """
+  Fetches a dataset with its entries preloaded in stable order.
+
+  Raises `Ecto.NoResultsError` when the dataset does not exist.
+  """
   @spec get_dataset_with_entries!(binary()) :: Dataset.t()
   def get_dataset_with_entries!(id) do
     entries = from entry in DatasetEntry, order_by: [asc: entry.position, asc: entry.inserted_at]
@@ -47,6 +69,12 @@ defmodule Aludel.Datasets do
     |> repo().preload(entries: entries)
   end
 
+  @doc """
+  Fetches an entry by ID within a dataset.
+
+  Returns `nil` for an invalid UUID, a missing entry, or an entry owned by a
+  different dataset.
+  """
   @spec get_entry(Dataset.t(), binary()) :: DatasetEntry.t() | nil
   def get_entry(%Dataset{} = dataset, id) do
     case Ecto.UUID.cast(id) do
@@ -60,6 +88,9 @@ defmodule Aludel.Datasets do
     end
   end
 
+  @doc """
+  Creates a reusable dataset from the supplied attributes.
+  """
   @spec create_dataset(map()) :: {:ok, Dataset.t()} | {:error, Changeset.t()}
   def create_dataset(attrs) do
     %Dataset{}
@@ -67,6 +98,9 @@ defmodule Aludel.Datasets do
     |> repo().insert()
   end
 
+  @doc """
+  Updates a dataset's name, description, or metadata.
+  """
   @spec update_dataset(Dataset.t(), map()) :: {:ok, Dataset.t()} | {:error, Changeset.t()}
   def update_dataset(%Dataset{} = dataset, attrs) do
     dataset
@@ -74,16 +108,30 @@ defmodule Aludel.Datasets do
     |> repo().update()
   end
 
+  @doc """
+  Deletes a dataset.
+
+  Associated entries are removed according to the repository constraint.
+  """
   @spec delete_dataset(Dataset.t()) :: {:ok, Dataset.t()} | {:error, Changeset.t()}
   def delete_dataset(%Dataset{} = dataset) do
     repo().delete(dataset)
   end
 
+  @doc """
+  Returns a dataset changeset without persisting it.
+  """
   @spec change_dataset(Dataset.t(), map()) :: Changeset.t()
   def change_dataset(%Dataset{} = dataset, attrs \\ %{}) do
     Dataset.changeset(dataset, attrs)
   end
 
+  @doc """
+  Creates an ordered entry in a dataset.
+
+  When no position is supplied, the entry is appended atomically. Concurrent
+  inserts serialize on the dataset row so they cannot claim the same position.
+  """
   @spec create_entry(Dataset.t(), map()) ::
           {:ok, DatasetEntry.t()} | {:error, Changeset.t()}
   def create_entry(%Dataset{} = dataset, attrs) do
@@ -101,6 +149,11 @@ defmodule Aludel.Datasets do
     end)
   end
 
+  @doc """
+  Updates an entry while preserving its dataset ownership.
+
+  Any `dataset_id` attribute is discarded.
+  """
   @spec update_entry(DatasetEntry.t(), map()) ::
           {:ok, DatasetEntry.t()} | {:error, Changeset.t()}
   def update_entry(%DatasetEntry{} = entry, attrs) do
@@ -109,17 +162,29 @@ defmodule Aludel.Datasets do
     |> repo().update()
   end
 
+  @doc """
+  Deletes a dataset entry.
+  """
   @spec delete_entry(DatasetEntry.t()) ::
           {:ok, DatasetEntry.t()} | {:error, Changeset.t()}
   def delete_entry(%DatasetEntry{} = entry) do
     repo().delete(entry)
   end
 
+  @doc """
+  Returns an entry changeset without persisting it.
+  """
   @spec change_entry(DatasetEntry.t(), map()) :: Changeset.t()
   def change_entry(%DatasetEntry{} = entry, attrs \\ %{}) do
     DatasetEntry.changeset(entry, attrs)
   end
 
+  @doc """
+  Copies entries from a dataset into an evaluation suite.
+
+  Entries already linked to the suite through `source_dataset_entry_id` are
+  skipped. The operation is transactional and safe to repeat.
+  """
   @spec populate_suite(Dataset.t(), Suite.t()) ::
           {:ok, [TestCase.t()]} | {:error, term()}
   def populate_suite(%Dataset{} = dataset, %Suite{} = suite) do

--- a/lib/aludel/datasets/dataset.ex
+++ b/lib/aludel/datasets/dataset.ex
@@ -26,6 +26,12 @@ defmodule Aludel.Datasets.Dataset do
     timestamps(type: :utc_datetime)
   end
 
+  @doc """
+  Builds a changeset for a dataset.
+
+  Names are required and limited to 200 characters. Metadata must be JSON
+  encodable so it can be persisted and queried consistently.
+  """
   @spec changeset(t(), map()) :: Changeset.t()
   def changeset(dataset, attrs) do
     dataset

--- a/lib/aludel/datasets/dataset_entry.ex
+++ b/lib/aludel/datasets/dataset_entry.ex
@@ -31,6 +31,13 @@ defmodule Aludel.Datasets.DatasetEntry do
     timestamps(type: :utc_datetime)
   end
 
+  @doc """
+  Builds a changeset for an ordered dataset entry.
+
+  It validates message and assertion shapes, JSON-encodable metadata and
+  variables, nonnegative position, and the requirement for variables or
+  messages to supply evaluation input.
+  """
   @spec changeset(t(), map()) :: Changeset.t()
   def changeset(entry, attrs) do
     entry
@@ -58,6 +65,12 @@ defmodule Aludel.Datasets.DatasetEntry do
     )
   end
 
+  @doc """
+  Classifies an entry as single-turn or multi-turn from its message count.
+
+  Variable-only and one-message entries are single-turn; two or more messages
+  are multi-turn.
+  """
   @spec conversation_kind(t()) :: :single_turn | :multi_turn
   def conversation_kind(%__MODULE__{messages: [_, _ | _]}) do
     :multi_turn

--- a/lib/aludel/execution.ex
+++ b/lib/aludel/execution.ex
@@ -36,6 +36,13 @@ defmodule Aludel.Execution do
           artifacts: map()
         }
 
+  @doc """
+  Executes one provider request through the configured execution mode.
+
+  Native mode renders the prompt and calls the configured provider. Callback
+  mode sends a sanitized input map to the host application's executor. Expected
+  failures return `{:error, reason}`.
+  """
   @spec execute(request()) :: {:ok, result()} | {:error, term()}
   def execute(
         %{
@@ -52,6 +59,14 @@ defmodule Aludel.Execution do
     end
   end
 
+  @doc """
+  Executes a provider request while retaining diagnostic artifacts on failure.
+
+  Documents are loaded concurrently before dispatch. Validation, storage,
+  configuration, provider, and callback failures return
+  `{:error, reason, artifacts}` so callers can persist the attempted input and
+  failure context.
+  """
   @spec execute_with_artifacts(request()) ::
           {:ok, result()} | {:error, term(), map()}
   def execute_with_artifacts(

--- a/lib/aludel/executor.ex
+++ b/lib/aludel/executor.ex
@@ -43,11 +43,23 @@ defmodule Aludel.Executor do
 
   @callback run(input()) :: {:ok, result()} | {:error, term()}
 
+  @doc """
+  Returns the raw configured execution mode, defaulting to `:native`.
+
+  Use `configured_execution_mode/0` when validating configuration at a runtime
+  boundary.
+  """
   @spec execution_mode() :: term()
   def execution_mode do
     Application.get_env(:aludel, :execution_mode, :native)
   end
 
+  @doc """
+  Validates and normalizes the configured execution mode.
+
+  An unset value selects native execution. Any value other than `:native` or
+  `:callback` returns an `:invalid_execution_mode` error.
+  """
   @spec configured_execution_mode() ::
           {:ok, :native | :callback} | {:error, {:invalid_execution_mode, term()}}
   def configured_execution_mode do
@@ -59,6 +71,9 @@ defmodule Aludel.Executor do
     end
   end
 
+  @doc """
+  Returns the execution mode label used by the web interface.
+  """
   @spec execution_mode_label() :: String.t()
   def execution_mode_label do
     case configured_execution_mode() do
@@ -68,6 +83,12 @@ defmodule Aludel.Executor do
     end
   end
 
+  @doc """
+  Resolves the configured callback executor module.
+
+  The module must be loaded and export `run/1`. Missing and invalid
+  configuration return tagged errors instead of raising.
+  """
   @spec configured_executor() :: {:ok, module()} | {:error, :executor_not_configured | term()}
   def configured_executor do
     case Application.get_env(:aludel, :executor) do

--- a/lib/aludel/interfaces/storage.ex
+++ b/lib/aludel/interfaces/storage.ex
@@ -32,6 +32,12 @@ defmodule Aludel.Storage do
     adapter().put(key, data, content_type, config())
   end
 
+  @doc """
+  Reads a storage key through its owning backend.
+
+  Use `:storage_backend` to select a named historical backend and `:config` to
+  overlay adapter configuration for this operation.
+  """
   @spec get(String.t(), keyword()) :: {:ok, binary()} | {:error, error_reason()}
   def get(key, opts \\ []) do
     with {:ok, storage_adapter} <- adapter_for(opts) do
@@ -39,6 +45,11 @@ defmodule Aludel.Storage do
     end
   end
 
+  @doc """
+  Deletes a storage key through its owning backend.
+
+  Accepts the same `:storage_backend` and `:config` options as `get/2`.
+  """
   @spec delete(String.t(), keyword()) :: :ok | {:error, error_reason()}
   def delete(key, opts \\ []) do
     with {:ok, storage_adapter} <- adapter_for(opts) do
@@ -46,6 +57,13 @@ defmodule Aludel.Storage do
     end
   end
 
+  @doc """
+  Reads the contents associated with a test case document.
+
+  The document's persisted backend name is honored, allowing records created
+  before a backend switch to remain readable. Documents without storage
+  metadata return `{:error, :missing_document_data}`.
+  """
   @spec read(TestCaseDocument.t()) :: {:ok, binary()} | {:error, error_reason()}
   def read(%TestCaseDocument{storage_key: key, storage_backend: backend})
       when is_binary(key) and is_binary(backend) do
@@ -54,24 +72,47 @@ defmodule Aludel.Storage do
 
   def read(%TestCaseDocument{}), do: {:error, :missing_document_data}
 
+  @doc """
+  Returns the currently configured storage adapter.
+
+  The local filesystem adapter is used when no adapter is configured.
+  """
   @spec adapter() :: module()
   def adapter, do: Keyword.get(config(), :adapter, @default_adapter)
 
+  @doc """
+  Returns the resolved application storage configuration.
+  """
   @spec config() :: config()
   def config do
     Config.get()
   end
 
+  @doc """
+  Returns the stable persisted name for a storage adapter.
+  """
   @spec backend_name(module()) :: String.t()
   def backend_name(storage_adapter \\ adapter()) do
     Map.get(@backend_names, storage_adapter, Atom.to_string(storage_adapter))
   end
 
+  @doc """
+  Builds a namespaced storage key for an uploaded document.
+
+  Directory components are removed from the filename and unsupported
+  characters are replaced with underscores.
+  """
   @spec storage_key(Ecto.UUID.t(), String.t()) :: String.t()
   def storage_key(document_id, filename) do
     Path.join(["test_case_documents", document_id, sanitize_filename(filename)])
   end
 
+  @doc """
+  Resolves a persisted backend name to a storage adapter module.
+
+  `nil` selects the active adapter. Unknown names return
+  `{:error, :unknown_storage_backend}` without creating atoms.
+  """
   @spec resolve_backend(String.t() | nil) :: {:ok, module()} | {:error, :unknown_storage_backend}
   def resolve_backend(nil), do: {:ok, adapter()}
 

--- a/lib/aludel/interfaces/storage/adapters/local.ex
+++ b/lib/aludel/interfaces/storage/adapters/local.ex
@@ -38,11 +38,22 @@ defmodule Aludel.Interfaces.Storage.Adapters.Local do
     end
   end
 
+  @doc """
+  Resolves a storage key beneath the configured local root.
+
+  Raises `ArgumentError` if the expanded key would escape the root directory.
+  """
   @spec path_for(String.t()) :: String.t()
   def path_for(key) do
     path_for(key, Config.get())
   end
 
+  @doc """
+  Resolves a storage key using an explicit adapter configuration.
+
+  The `:root` option defaults to a temporary Aludel directory. Production
+  installations should configure a persistent absolute root.
+  """
   @spec path_for(String.t(), keyword()) :: String.t()
   def path_for(key, config) do
     root =


### PR DESCRIPTION
## Motivation

The dataset, storage, and execution modules are primary integration surfaces, but callers had to read their implementations to understand ordering, filtering, backend selection, retry-safe population, and error contracts.

## Changes

- Document every public dataset context and schema function, including metadata filtering, stable ordering, ownership, locking, and repeat-safe suite population
- Document active and historical storage backend operations, safe key construction, and local root containment
- Document native and callback execution results, artifact-preserving failures, and executor configuration validation
- Add direct API-reference links to the README and programmatic entry points to the feature guide
- Raise the enforced documentation coverage floor from 70 percent to 78 percent

## Test Plan

- HexDocs builds without warnings or broken references
- Doctor reports 78.3 percent function documentation, 100 percent moduledocs, and 89.5 percent typespecs
- The complete precommit suite passes with 939 tests
- All quality, security, dependency, duplication, compile-cycle, and static-analysis gates pass
- The staged diff is clean

## Next Steps

A follow-up documentation PR will cover the public evaluation, prompt-analysis, and statistics APIs and tighten the coverage floor again.