### PR TITLE
docs: improve project discovery metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Normalize provider pricing at its boundary and replace redundant control flow, generated documentation text, and full-list length checks with idiomatic Elixir
 - Document the dataset, storage, and execution APIs and raise the enforced documentation coverage floor
 - Document evaluation, prompt optimization, and analytics APIs and add missing public typespecs
+- Improve Hex and GitHub discovery metadata for LLM evaluation, prompt testing, and model comparison
 
 ## [0.6.1] - 2026-09-04
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="left">
-  <h1>Aludel - LLM Eval Workbench</h1>
+  <h1>Aludel - LLM Evaluation and Prompt Testing for Elixir</h1>
 
   <p>
     <a href="https://hex.pm/packages/aludel"><img src="https://img.shields.io/hexpm/v/aludel.svg" alt="Hex.pm"/></a>
@@ -9,7 +9,7 @@
   </p>
 </div>
 
-Aludel gives teams a clean way to evaluate prompt and model behavior without inventing their own tooling first.
+Aludel is a Phoenix-native LLM evaluation workbench for Elixir applications. It combines prompt testing, model comparison, regression suites, red-team datasets, quality gates, and LLM observability in an embeddable dashboard and standalone release.
 
 - Compare the same prompt across OpenAI, Anthropic, Gemini, Ollama, xAI, Groq, and OpenRouter.
 - Inspect output, latency, token usage, and cost side by side.

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,8 @@ defmodule Aludel.MixProject do
         plt_file: {:no_warn, "priv/plts/dialyzer.plt"}
       ],
       package: package(),
-      description: "Aludel - LLM Eval Workbench for Phoenix applications",
+      description:
+        "Phoenix-native LLM evaluation, prompt testing, model comparison, red teaming, and observability for Elixir applications",
       source_url: "https://github.com/ccarvalho-eng/aludel",
       homepage_url: "https://github.com/ccarvalho-eng/aludel",
       docs: [
@@ -87,7 +88,9 @@ defmodule Aludel.MixProject do
       files:
         ~w(lib priv/repo priv/static guides .formatter.exs mix.exs README* CHANGELOG* LICENSE*),
       links: %{
-        "GitHub" => "https://github.com/ccarvalho-eng/aludel"
+        "Documentation" => "https://hexdocs.pm/aludel",
+        "GitHub" => "https://github.com/ccarvalho-eng/aludel",
+        "Wiki" => "https://github.com/ccarvalho-eng/aludel/wiki"
       }
     ]
   end


### PR DESCRIPTION
## Summary

- describe Aludel with clear LLM evaluation, prompt testing, model comparison, red-team, and observability language
- improve the README title and opening description for GitHub and search results
- add direct Hex package links to documentation, source, and the feature wiki

## Validation

- Hex package dry run includes the revised description and links
- documentation builds successfully
- all quality, security, static-analysis, and test gates pass