### PR TITLE
fix(evals): prevent stale suite retry writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Move curated Unreleased entries into the versioned changelog section during release preparation
 - Make Hex release reruns recover interrupted GitHub releases and documentation publication safely
+- Prevent overlapping suite-result retries from silently replacing a newer retry
 
 ### Changed
 - Add repeatable quality gates for high-signal code smells, compile cycles, duplicate code, documentation coverage, dependency advisories, and static analysis

--- a/lib/aludel/evals.ex
+++ b/lib/aludel/evals.ex
@@ -408,13 +408,16 @@ defmodule Aludel.Evals do
 
   The existing embedded result is replaced in-place and the suite run
   aggregates are recalculated from the updated result set. Sampled results
-  repeat their complete persisted sampling configuration.
+  repeat their complete persisted sampling configuration. The run is refreshed
+  before execution, and overlapping retries reject the stale write instead of
+  replacing a newer result.
   """
   @spec retry_suite_run_test_case(SuiteRun.t(), binary()) ::
           {:ok, SuiteRun.t()} | {:error, term()}
   def retry_suite_run_test_case(%SuiteRun{} = suite_run, test_case_id)
       when is_binary(test_case_id) do
-    with {:ok, existing_result} <- fetch_suite_run_result(suite_run, test_case_id),
+    with {:ok, suite_run} <- fetch_suite_run(suite_run.id),
+         {:ok, existing_result} <- fetch_suite_run_result(suite_run, test_case_id),
          {:ok, sampling} <- Sampling.from_result(existing_result),
          {:ok, test_case} <- fetch_suite_test_case(suite_run.suite_id, test_case_id),
          {:ok, version} <- fetch_prompt_version(suite_run.prompt_version_id),
@@ -434,9 +437,13 @@ defmodule Aludel.Evals do
         |> Map.put(:results, updated_results)
         |> Map.merge(quality_policy_attrs(policy, updated_results, summary))
       )
+      |> Changeset.optimistic_lock(:lock_version)
       |> repo().update()
     end
   rescue
+    _error in Ecto.StaleEntryError ->
+      {:error, :stale_suite_run}
+
     error ->
       {:error, {:retry_failed, Exception.message(error)}}
   catch
@@ -723,6 +730,13 @@ defmodule Aludel.Evals do
     do: "Invalid callback response: #{inspect(detail)}"
 
   defp error_message(reason), do: inspect(reason)
+
+  defp fetch_suite_run(suite_run_id) do
+    case repo().get(SuiteRun, suite_run_id) do
+      nil -> {:error, :suite_run_not_found}
+      suite_run -> {:ok, suite_run}
+    end
+  end
 
   defp fetch_suite_run_result(%SuiteRun{results: results}, test_case_id) do
     case Enum.find(results, &(&1["test_case_id"] == test_case_id)) do

--- a/lib/aludel/evals/suite_run.ex
+++ b/lib/aludel/evals/suite_run.ex
@@ -49,6 +49,7 @@ defmodule Aludel.Evals.SuiteRun do
     field :total_latency_ms, :integer
     field :latency_sample_count, :integer, default: 0
     field :quality_policy_result, :map
+    field :lock_version, :integer, default: 1
 
     belongs_to(:suite, Suite)
     belongs_to(:suite_policy, SuitePolicy)

--- a/lib/aludel/web/live/suite_live/show.ex
+++ b/lib/aludel/web/live/suite_live/show.ex
@@ -1323,6 +1323,9 @@ defmodule Aludel.Web.SuiteLive.Show do
   defp retry_result_error_message(:provider_not_found),
     do: "Failed to retry test case: provider not found"
 
+  defp retry_result_error_message(:stale_suite_run),
+    do: "Suite run changed while retrying. Refresh and try again"
+
   defp retry_result_error_message({:retry_failed, detail}),
     do: "Failed to retry test case: #{format_execution_error_detail(detail)}"
 

--- a/priv/repo/migrations/20260905043000_add_lock_version_to_suite_runs.exs
+++ b/priv/repo/migrations/20260905043000_add_lock_version_to_suite_runs.exs
@@ -1,0 +1,9 @@
+defmodule Aludel.Repo.Migrations.AddLockVersionToSuiteRuns do
+  use Ecto.Migration
+
+  def change do
+    alter table(:suite_runs) do
+      add :lock_version, :integer, null: false, default: 1
+    end
+  end
+end

--- a/test/aludel/evals_test.exs
+++ b/test/aludel/evals_test.exs
@@ -445,7 +445,7 @@ defmodule Aludel.EvalsTest do
           ]
         })
 
-      expect(HttpClientMock, :request, fn _model, prompt, _opts ->
+      expect(HttpClientMock, :request, 2, fn _model, prompt, _opts ->
         assert prompt == "Hello Alice"
 
         {:ok, build_mock_response("Hello Alice", 5, 10)}
@@ -478,6 +478,64 @@ defmodule Aludel.EvalsTest do
                result["test_case_id"] == retried_test_case.id and
                  result["retry_count"] == 1 and result["output"] == "Hello Alice"
              end)
+
+      assert {:ok, retried_again} =
+               Evals.retry_suite_run_test_case(suite_run, retried_test_case.id)
+
+      retried_again_result =
+        Enum.find(retried_again.results, fn result ->
+          result["test_case_id"] == retried_test_case.id
+        end)
+
+      assert retried_again_result["retry_count"] == 2
+    end
+
+    test "retry_suite_run_test_case/2 rejects a concurrent stale write" do
+      prompt = prompt_fixture()
+      {:ok, version} = Aludel.Prompts.create_prompt_version(prompt, "Hello {{name}}")
+      suite = suite_fixture(%{prompt_id: prompt.id})
+      provider = provider_fixture()
+
+      test_case =
+        test_case_fixture(%{
+          suite_id: suite.id,
+          variable_values: %{"name" => "Alice"},
+          assertions: [%{"type" => "contains", "value" => "Hello"}]
+        })
+
+      suite_run =
+        suite_run_fixture(%{
+          suite_id: suite.id,
+          prompt_version_id: version.id,
+          provider_id: provider.id,
+          failed: 1,
+          results: [
+            %{
+              "test_case_id" => test_case.id,
+              "passed" => false,
+              "output" => "failed",
+              "assertion_results" => []
+            }
+          ]
+        })
+
+      expect(HttpClientMock, :request, fn _model, _prompt, _opts ->
+        repo = Aludel.Repo.get()
+        current_suite_run = Evals.get_suite_run!(suite_run.id)
+
+        {:ok, _concurrent_update} =
+          current_suite_run
+          |> SuiteRun.changeset(%{failed: 2})
+          |> Ecto.Changeset.optimistic_lock(:lock_version)
+          |> repo.update()
+
+        {:ok, build_mock_response("Hello Alice", 5, 10)}
+      end)
+
+      assert {:error, :stale_suite_run} =
+               Evals.retry_suite_run_test_case(suite_run, test_case.id)
+
+      assert Evals.get_suite_run!(suite_run.id).failed == 2
     end
   end
 

--- a/test/support/migrations/20260905043000_add_lock_version_to_suite_runs.exs
+++ b/test/support/migrations/20260905043000_add_lock_version_to_suite_runs.exs
@@ -1,0 +1,9 @@
+defmodule Aludel.Repo.Migrations.AddLockVersionToSuiteRuns do
+  use Ecto.Migration
+
+  def change do
+    alter table(:suite_runs) do
+      add :lock_version, :integer, null: false, default: 1
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- refresh suite-run state before retrying so stale UI snapshots use the latest persisted result
- use optimistic locking to reject overlapping retry writes instead of silently replacing a newer result
- return a stable conflict error and tell dashboard users to refresh before retrying again

## Retry write contract

~~~mermaid
sequenceDiagram
  participant A as Retry A
  participant B as Retry B
  participant DB as Suite run
  A->>DB: Read lock version 1
  B->>DB: Read lock version 1
  A->>A: Execute model request
  B->>B: Execute model request
  A->>DB: Update where lock version is 1
  DB-->>A: Persist version 2
  B->>DB: Update where lock version is 1
  DB-->>B: Reject stale write
~~~

## Validation

- regression coverage proves stale callers reload current state
- regression coverage proves a concurrent update is preserved and the retry returns a stale-write error
- all quality, security, static-analysis, migration, and test gates pass with 940 tests